### PR TITLE
fix(service): issue #34 daemon crashing when operator call undefined driver

### DIFF
--- a/internal/service/operator.go
+++ b/internal/service/operator.go
@@ -68,6 +68,9 @@ func operatorRoute(msg *dipper.Message) (ret []RoutedMessage) {
 		dipper.Logger.Debugf("[operator] collapsed function %s %s %+v", driver, rawaction, params)
 
 		worker := operator.getDriverRuntime("driver:" + driver)
+		if worker == nil {
+			panic(fmt.Errorf("driver %s not defined", driver))
+		}
 		finalParams := params
 		if params != nil {
 			// interpolate twice for giving an chance for using sysData in wfdata

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -394,6 +394,7 @@ func (s *Service) serviceLoop() {
 			}
 		} else if chosen < len(orderedRuntimes) {
 			func() {
+				defer dipper.SafeExitOnError("[%s] service loop continue", s.name)
 				runtime := orderedRuntimes[chosen]
 				msg := value.Interface().(dipper.Message)
 				if runtime.Feature != FeatureEmitter {


### PR DESCRIPTION
Fixes #34

Added a check in operator service to detect undefined driver, however, it is the right thing to just bubble that error out at that place.  Placed a defer/recover in `serviceLoop` to make sure the all local process errors are recovered and won't cause loop and daemon to die.