### PR TITLE
chore: Update Dockerfile and move to multi-stage build

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,10 +1,19 @@
-FROM golang:alpine
+FROM golang:1.11-alpine AS build
 
 WORKDIR /go/src/github.com/honeydipper/honeydipper
 
 RUN apk add --no-cache git gcc libc-dev
-COPY . .
+COPY ./ ./
 RUN go get -u github.com/golang/dep/cmd/dep && dep ensure
-RUN go install ./...
+RUN go install ./... && rm /go/bin/dep
 
-ENTRYPOINT ["honeydipper"]
+FROM alpine:3.9
+
+LABEL description="Honeydipper - an event-driven orchestration framework" \
+      org.label-schema.vcs-url=https://github.com/honeydipper/honeydipper \
+      org.label-schema.schema-version="1.0"
+
+WORKDIR /opt/honeydipper/drivers/builtin
+COPY --from=build /go/bin/* ./
+
+ENTRYPOINT ["./honeydipper"]


### PR DESCRIPTION
#### Description
* Multi-stage build will result in a much smaller runtime container.
* Update labels.

```
lana~% docker run 36544890d454                                            
22:15:57.498 daemon.initEnv ▶ CRIT 001 REPO environment variable is required to bootstrap honeydipper
22:15:57.498 daemon.initEnv ▶ CRIT 001 REPO environment variable is required to bootstrap honeydipper
lana~% docker run 36544890d454 -h
./honeydipper [ -h ] service1 service2 ...
    Supported services include engie, receiver.
  Note: REPO environment variable is required to specify the bootstrap config.
lana~% docker run --entrypoint /bin/ls 36544890d454 
datadog-emitter
dummy
gcloud-dataflow
gcloud-gke
gcloud-kms
honeydipper
kubernetes
redispubsub
redisqueue
web
webhook
```

#### This PR fixes the following issues
- Fixes #56