### PR TITLE
fix(workflow): only event message payload in data

### DIFF
--- a/internal/service/engine.go
+++ b/internal/service/engine.go
@@ -171,7 +171,7 @@ func executeWorkflow(sessionID string, wf *config.Workflow, msg *dipper.Message)
 	}
 
 	data := msg.Payload
-	if msg.Subject != dipper.EventbusReturn {
+	if msg.Subject == dipper.EventbusMessage {
 		data, _ = dipper.GetMapData(msg.Payload, "data")
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->

When fetching data from messages for interpolation purpose, event message has data and some meta info, so the data is in a field `Payload.data`. For other type of messages, the whole `Payload` field is the data. The `data` type workflow returns a pseudo message without `Channel` and `Subject`, the workflow engine treated it as an event message so only using data under `Payload.data` field. With this fix, the `data` type workflow can use the whole `Payload` to return data.

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->

N/A