### PR TITLE
fix(grpc): ensure CA certificates available for grpc TLS

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -13,6 +13,8 @@ LABEL description="Honeydipper - an event-driven orchestration framework" \
       org.label-schema.vcs-url=https://github.com/honeydipper/honeydipper \
       org.label-schema.schema-version="1.0"
 
+RUN apk add --no-cache ca-certificates
+
 WORKDIR /opt/honeydipper/drivers/builtin
 COPY --from=build /go/bin/* ./
 

--- a/drivers/cmd/gcloud-kms/main.go
+++ b/drivers/cmd/gcloud-kms/main.go
@@ -53,11 +53,13 @@ func decrypt(msg *dipper.Message) {
 	}
 	client, err := kms.NewKeyManagementClient(ctx)
 	if err != nil {
-		panic(errors.New("failed to create kms client"))
+		dipper.Logger.Warning("failed to create kms client")
+		panic(err)
 	}
 	resp, err := client.Decrypt(ctx, req)
 	if err != nil {
-		panic(errors.New("failed to decrypt"))
+		dipper.Logger.Warning("failed to decrypt")
+		panic(err)
 	}
 
 	msg.Reply <- dipper.Message{


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->

Ensure the images we built has `ca-certificates` to avoid grpc x509 unknown CA issue.

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->

Fixes #72