### PR TITLE
fix(drivers): Return error on >= 4xx response and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 vendor/**
 
 # test log
-test.log
+**/test.log
 
 # bak files
 **/*.bak

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -188,6 +188,22 @@
   revision = "787624de3eb7bd915c329cba748687a3b22666a6"
 
 [[projects]]
+  digest = "1:fb332c4b0e1944eb132e2075ea0447873a1081ecdabb140ff9696327ac8b947b"
+  name = "github.com/h2non/gock"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ba88c4862a27596539531ce469478a91bc5a0511"
+  version = "v1.0.14"
+
+[[projects]]
+  digest = "1:574f4e0c57e045c9d109d23c60c586b2198eaead53daa97ed5f65c616e22a9b0"
+  name = "github.com/h2non/parth"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b4df798d65426f8c8ab5ca5f9987aec5575d26c9"
+  version = "v2.0.1"
+
+[[projects]]
   digest = "1:f9a5e090336881be43cfc1cf468330c1bdd60abdc9dd194e0b1ab69f4b94dd7c"
   name = "github.com/huandu/xstrings"
   packages = ["."]
@@ -790,6 +806,7 @@
     "github.com/ghodss/yaml",
     "github.com/go-errors/errors",
     "github.com/go-redis/redis",
+    "github.com/h2non/gock",
     "github.com/imdario/mergo",
     "github.com/mitchellh/mapstructure",
     "github.com/op/go-logging",

--- a/drivers/cmd/web/main.go
+++ b/drivers/cmd/web/main.go
@@ -153,10 +153,19 @@ func sendRequest(m *dipper.Message) {
 		defer resp.Body.Close()
 	}
 
-	m.Reply <- dipper.Message{
-		Payload: extractHTTPResponseData(resp),
+	response := extractHTTPResponseData(resp)
+	statusCode, _ := strconv.Atoi(response["status_code"].(string))
+	ret := dipper.Message{
+		Payload: response,
 		IsRaw:   false,
 	}
+	if statusCode >= 400 {
+		ret.Labels = map[string]string{
+			"error": fmt.Sprintf("Error: got status code: %d", statusCode),
+		}
+	}
+
+	m.Reply <- ret
 }
 
 func extractHTTPResponseData(r *http.Response) map[string]interface{} {

--- a/drivers/cmd/web/main_test.go
+++ b/drivers/cmd/web/main_test.go
@@ -1,0 +1,84 @@
+// Copyright 2019 Honey Science Corporation
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/h2non/gock"
+	"github.com/honeydipper/honeydipper/pkg/dipper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	if dipper.Logger == nil {
+		logFile, err := os.Create("test.log")
+		if err != nil {
+			panic(err)
+		}
+		defer logFile.Close()
+		dipper.GetLogger("test", "INFO", logFile, logFile)
+	}
+	driver = &dipper.Driver{Service: "test"}
+	m.Run()
+}
+
+func TestSendRequest(t *testing.T) {
+
+	defer gock.Off()
+
+	gock.New("http://example.com").
+		Get("/test").
+		Reply(200).
+		JSON(map[string]string{"foo": "bar"})
+
+	request := &dipper.Message{
+		Channel: "event",
+		Subject: "command",
+		Payload: map[string]interface{}{
+			"URL": "http://example.com/test",
+		},
+		Reply: make(chan dipper.Message, 1),
+	}
+	sendRequest(request)
+	response := <-request.Reply
+	assert.Equal(t, "200", response.Payload.(map[string]interface{})["status_code"])
+	assert.NotContains(t, response.Labels, "error")
+}
+
+func TestSendRequestInvalid(t *testing.T) {
+
+	defer gock.Off()
+
+	// Test that we get an error with various >= 400 status codes
+	parameters := []int{
+		400, 403, 500, 503,
+	}
+
+	for _, i := range parameters {
+		gock.New("http://example.com").
+			Get("/test").
+			Reply(i).
+			BodyString("This is broken")
+
+		request := &dipper.Message{
+			Channel: "event",
+			Subject: "command",
+			Payload: map[string]interface{}{
+				"URL": "http://example.com/test",
+			},
+			Reply: make(chan dipper.Message, 1),
+		}
+		sendRequest(request)
+		response := <-request.Reply
+		assert.Equal(t, strconv.Itoa(i), response.Payload.(map[string]interface{})["status_code"])
+		assert.Contains(t, response.Labels, "error")
+		assert.NotNil(t, response.Labels["error"])
+	}
+}


### PR DESCRIPTION
#### Description
* Add basic test cases for (outgoing) web driver
* Return an error label if response code is >= 4XX

#### This PR fixes the following issues
Fixes #69 
