### PR TITLE
docs(jekyll): bypass jekyll expanding double curly braces

### DIFF
--- a/docs/interpolation.md
+++ b/docs/interpolation.md
@@ -68,6 +68,7 @@ template, we can dynamically generate complex yaml structure that we can't write
 Can be used in workflow definitions(data, content), workflow condition, function parameters.
 
 For example:
+<!-- {% raw %} -->
 ```yaml
 workflows:
   foreach_parallel:
@@ -86,6 +87,7 @@ workflows:
                 current: "{{ . }}"
             {{- end }}
 ```
+<!-- {% endraw %} -->
 
 ### *:path:* Referencing context data with given path
 
@@ -96,6 +98,7 @@ string representation.
 Can be used in workflow definitions(data, content), workflow condition, function parameters.
 
 For example:
+<!-- {% raw %} -->
 ```yaml
 workflows:
   next_if_success:
@@ -103,6 +106,7 @@ workflows:
     condition: '{{ eq .labels.status "success" }}'
     content: :path:wfdata.work
 ```
+<!-- {% endraw %} -->
 
 ## Inline go template
 
@@ -131,6 +135,7 @@ Like the `:path:` prefix interpolation, the `fromPath` function takes a paramete
 similar to the `index` built in function, but uses a more condensed path expression.
 
 For example:
+<!-- {% raw %} -->
 ```yaml
 systems:
   opsgenie:
@@ -157,6 +162,7 @@ rules:
       parameters:
         alertIdPath: event.json.alert.Id
 ```
+<!-- {% endraw %} -->
 
 ## Escaping function parameter interpolation
 Honeydipper executes the inline go templates and run `:path:`, `:yaml:` interpolations at two places:
@@ -166,7 +172,8 @@ Honeydipper executes the inline go templates and run `:path:`, `:yaml:` interpol
 When a workflow starts, Honeydipper workflow engine needs all information to determine how the workflow should be executed, so the `data`, `content` and `condition` fields are interpolated. It will not interpolate/execute the function parameters, because the contextual data for the function call has not been finalized yet, and it may very well be overridden by the children workflows. So, we want to leave the function parameters to the `operator` service to interpolate when all the data is available and finalized. Sometimes, we want to define some abstract workflows, such as `repeat` `foreach`, where the actual workflow content including the parameters is passed as workflow data, we will need to escape the parameters interpolation, if used, so workflow engine won't interpolate them too early.
 
 For example:
-```
+<!-- {% raw %} -->
+```yaml
 rules:
   - when:
       source:
@@ -190,6 +197,7 @@ rules:
               # see below how to escape the interpolation
               channel: '{{ "{{ .wfdata.current }}" }}'
 ```
+<!-- {% endraw %} -->
 
 ## Workflow contextual data
 Depending on where the interpolation is executed, 1) workflow engine, 2) operator (function parameters), the available contextual data is slightly different.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -107,7 +107,7 @@ rules:
 When the `type` is 'if', an additional `condition` field is required. The `content` should be a list of at most two child workflows. If the value of `condition` field is "truy", such as 1, "true", "True" etc., the first child workflow will be executed, otherwise, the second child workflow will be executed if present. To use interpolation in the `condition` field see the [Interpoation Guide](./interpolation.md) for detail.
 
 For example:
-
+<!-- {% raw %} -->
 ```yaml
 rules:
   - when:
@@ -124,12 +124,14 @@ rules:
               system: server_room_ac
               function: turn_on
 ```
+<!-- {% endraw %} -->
 
 ### Pipe workflow
 When the `type` is set to 'pipe', the `content` will be interpreted as a list of child workflows. The child workflows will be executed one by one in the order listed. The return information of the previous child workflow will be available to the next children through interpolation. See [Interpoation Guide](./interpolation.md) for detail.
 
 For example:
 
+<!-- {% raw %} -->
 ```yaml
 rules:
   - when:
@@ -149,6 +151,7 @@ rules:
           content:
             - content: run_deploy
 ```         
+<!-- {% endraw %} -->
 
 ### Parallel workflow
 Similiar to `pipe` workflow, the `content` of `parallel` workflow is also a list of child workflows. The child workflows will be executed in parallel.
@@ -170,6 +173,7 @@ workflows:
 
 For example:
 
+<!-- {% raw %} -->
 ```yaml
 workflows:
   slashcommands:
@@ -183,12 +187,14 @@ workflows:
       "*":
         content: show_unknown_command_err
 ```
+<!-- {% endraw %} -->
 
 ### Suspend workflow
 A workflow can be suspended to wait for manual approval or manual intervention. It is useful in conjunction with slack (or other chat system) interactive components, web dashboards, etc. to inject manual interaction into the automation. The `content` should be a globally unique string serving as an identifer for the workflow.  The workflow will continue when a message with "resume_session" subject carries the identifier in `key` field of the payload.
 
 For example
 
+<!-- {% raw %} -->
 ```yaml
 workflows:
   confirm_then_apply:
@@ -207,6 +213,7 @@ workflows:
         content:
           - content: tf_apply
 ```
+<!-- {% endraw %} -->
 
 ## Workflow helper
 With the combination of the various type of workflows, it is possible to create a lot of complex workflows. To keep our rules and workflows simple and DRY, we have created a few helper workflows that can be used in some common cases. They are implemented using the same building blocks introduced in the above chapters. Feel free to check them out in the `workflow_helper.yaml`. They also serve as a showcase on how we can use the building blocks.
@@ -216,7 +223,8 @@ Repeat the same `work` for the specified number of times, the `work` should be a
 
 For example:
 
-```
+<!-- {% raw %} -->
+```yaml
 rules:
   - when:
       source:
@@ -240,13 +248,15 @@ rules:
                     text: hooray! {{ "{{ .wfdata.times }}" }}
                   channel: '#corp'
 ```
+<!-- {% endraw %} -->
 
 ### For each (pipe)
 Repeat the same workflow in `work` for each of the item listed in the `items`. While the loop is running, the remaining items can be accessed through `wfdata` using interpolation. Again, the interpolation in `work` should be escaped.  See [Interpoation Guide](./interpolation.md)  for detail.
 
 For example:
 
-```
+<!-- {% raw %} -->
+```yaml
 workflows:
   tell_my_favorite:
     content: foreach
@@ -265,13 +275,15 @@ workflows:
             content:
               text: I like {{ "{{ first .wfdata.items }}" }}
 ```
+<!-- {% endraw %} -->
 
 ### For each (parallel)
 Same as the `pipe` version of the `foreach`, `foreach_parallel` will repeat the `work` for each item listed.  The difference is that the parallel version will run the child workflow with all the items in parallel.  There is no guanrantee of order, there is no "remaing items".  The current item can still be accessed through `.wfdata.current`.
 
 For example:
 
-```
+<!-- {% raw %} -->
+```yaml
 workflows:
   notify_all:
     content: foreach
@@ -291,6 +303,7 @@ workflows:
               text: Notifying something
             channel: '{{ "{{ .wfdata.current }}" }}'
 ```
+<!-- {% endraw %} -->
 
 ### Wanted
 More helpers wanted


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->

The markdown formatted documents are not showing properly when using github pages.  This is because the jekyll templating engine used by github pages tries to expand the double curly braces in the sample code snippets.  We will use the jekyll `raw` block (wrapped inside html comments) to wrap around the code snippets to bypass the expansion.

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->

N/A
