### PR TITLE
docs(jekyll): wrapping some loose double curly braces

### DIFF
--- a/docs/interpolation.md
+++ b/docs/interpolation.md
@@ -118,7 +118,7 @@ workflow definitions(data, content), workflow conidtion, and function parameters
 Unlike in typical templating languages, where templates were executed before yaml rendering, Honeydipper renders all configuration yaml at
 boot time or when reloading, and only executes the template when the particular content is needed. This allows Honeydipper to provide
 runtime data to the template when it is executed. However, that also means that templates can only be stored in strings. You can't wrap yaml
-tags in templates, unless you store the yaml as text like in the example for `:yaml:` prefix interpolation. Also, you can't use `{{` at the
+tags in templates, unless you store the yaml as text like in the example for `:yaml:` prefix interpolation. Also, you can't use <!-- {% raw %} -->`{{`<!-- {% endraw %} --> at the
 begining of a string without quoting, because the yaml renderer may treat it as the start of a data structure.
 
 ### go template


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->

Github pages throwing errors complaining about this loose brace. Wrapping this with raw block should fix it.

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
N/A