### PR TITLE
fix: Install git in Docker image

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -13,7 +13,7 @@ LABEL description="Honeydipper - an event-driven orchestration framework" \
       org.label-schema.vcs-url=https://github.com/honeydipper/honeydipper \
       org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates git
 
 WORKDIR /opt/honeydipper/drivers/builtin
 COPY --from=build /go/bin/* ./


### PR DESCRIPTION
#### Description
Add git to final Docker build

```
Successfully built 4807236d3292
[...]
% docker run --entrypoint /bin/sh -it 4807236d3292 
/opt/honeydipper/drivers/builtin # git --version
git version 2.20.1
```

#### This PR fixes the following issues
Fixes #84
