### PR TITLE
bug(web): response was not closed causing memory leak

### DIFF
--- a/drivers/cmd/web/main.go
+++ b/drivers/cmd/web/main.go
@@ -149,8 +149,11 @@ func sendRequest(m *dipper.Message) {
 
 	client := http.Client{}
 	resp, err := client.Do(req)
-	if err != nil {
+	if resp != nil {
 		defer resp.Body.Close()
+	}
+	if err != nil {
+		panic(err)
 	}
 
 	response := extractHTTPResponseData(resp)


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->

Logic error in the web driver where the body is not closed unless there is a error. This PR should fix this.

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->

N/A