### PR TITLE
fix(daemon): Don’t panic when Payload is nil

### DIFF
--- a/internal/service/engine.go
+++ b/internal/service/engine.go
@@ -175,6 +175,10 @@ func executeWorkflow(sessionID string, wf *config.Workflow, msg *dipper.Message)
 		data, _ = dipper.GetMapData(msg.Payload, "data")
 	}
 
+	if data == nil {
+		data = map[string]interface{}{}
+	}
+
 	envData := map[string]interface{}{
 		"data":   data,
 		"labels": msg.Labels,

--- a/internal/service/engine_test.go
+++ b/internal/service/engine_test.go
@@ -1,0 +1,57 @@
+// Copyright 2019 Honey Science Corporation
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build !integration
+
+package service
+
+import (
+	"testing"
+
+	"github.com/honeydipper/honeydipper/internal/config"
+	"github.com/honeydipper/honeydipper/pkg/dipper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecuteWorkflow(t *testing.T) {
+	sessionID := "123"
+	wf := config.Workflow{
+		Type: "if",
+		Content: []config.Workflow{
+			{
+				Type: "",
+				Content: "noop",
+			},
+		},
+		Condition: "false",
+	}
+	msg := &dipper.Message{
+		Channel: "eventbus",
+		Subject: "return",
+		Labels: map[string]string{
+			"status": "success",
+		},
+		Payload: nil,
+	}
+	parent := &WorkflowSession {
+		work: []*config.Workflow {
+			{
+				Type: "pipe",
+				Content: []config.Workflow{
+					{
+						Type: "function",
+					},
+					wf,
+				},
+			},
+		},
+	}
+	sessions[sessionID] = parent
+	testFunc := func() {
+		executeWorkflow(sessionID, &wf, msg)
+	}
+	assert.NotPanics(t, testFunc, "Should not panic when Payload is nil")
+}

--- a/internal/service/main_test.go
+++ b/internal/service/main_test.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Honey Science Corporation
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+package service
+
+import (
+	"os"
+	"testing"
+
+	"github.com/honeydipper/honeydipper/pkg/dipper"
+)
+
+func TestMain(m *testing.M) {
+	if dipper.Logger == nil {
+		f, _ := os.OpenFile(os.DevNull, os.O_APPEND, 0777)
+		defer f.Close()
+		dipper.GetLogger("test service", "DEBUG", f, f)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/service/operator.go
+++ b/internal/service/operator.go
@@ -52,6 +52,9 @@ func operatorRoute(msg *dipper.Message) (ret []RoutedMessage) {
 		dipper.Logger.Debugf("[operator] function call payload %+v", msg.Payload)
 		function := config.Function{}
 		data, _ := dipper.GetMapData(msg.Payload, "data")
+		if data == nil {
+			data = map[string]interface{}{}
+		}
 		event, _ := dipper.GetMapData(msg.Payload, "event")
 		wfdata, _ := dipper.GetMapData(msg.Payload, "wfdata")
 		funcDef, ok := dipper.GetMapData(msg.Payload, "function")


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
Bug: its possible for workflow to search for data in nil Payload
Fix: before building new packet, build an empty Payload, so data search that occurs in an empty Payload has graceful error/failure


#### This PR fixes the following issues
Fixes #70 
