### PR TITLE
fix(web): json Payload use interface to support top level array

### DIFF
--- a/drivers/cmd/web/main.go
+++ b/drivers/cmd/web/main.go
@@ -191,7 +191,7 @@ func extractHTTPResponseData(r *http.Response) map[string]interface{} {
 
 	contentType := r.Header.Get("Content-type")
 	if len(contentType) > 0 && strings.HasPrefix(contentType, "application/json") {
-		bodyObj := map[string]interface{}{}
+		var bodyObj interface{}
 		err := json.Unmarshal(bodyBytes, &bodyObj)
 		if err != nil {
 			log.Panicf("[%s] invalid json in response body", driver.Service)


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
json Payload uses interface to support top level array

#### This PR fixes the following issues
Fixes #92
