### PR TITLE
feat(driver) #85: extract host and remoteAddr from eventData

### DIFF
--- a/drivers/cmd/webhook/main.go
+++ b/drivers/cmd/webhook/main.go
@@ -152,7 +152,7 @@ func extractEventData(w http.ResponseWriter, r *http.Request) map[string]interfa
 		"method":     r.Method,
 		"form":       r.Form,
 		"headers":    r.Header,
-		"host":	      r.Host,
+		"host":       r.Host,
 		"remoteAddr": r.RemoteAddr,
 	}
 

--- a/drivers/cmd/webhook/main.go
+++ b/drivers/cmd/webhook/main.go
@@ -148,10 +148,12 @@ func extractEventData(w http.ResponseWriter, r *http.Request) map[string]interfa
 	dipper.PanicError(r.ParseForm())
 
 	eventData := map[string]interface{}{
-		"url":     r.URL.Path,
-		"method":  r.Method,
-		"form":    r.Form,
-		"headers": r.Header,
+		"url":        r.URL.Path,
+		"method":     r.Method,
+		"form":       r.Form,
+		"headers":    r.Header,
+		"host":	      r.Host,
+		"remoteAddr": r.RemoteAddr,
 	}
 
 	log.Debugf("[%s] webhook event data: %+v", driver.Service, eventData)

--- a/drivers/cmd/webhook/main_test.go
+++ b/drivers/cmd/webhook/main_test.go
@@ -1,0 +1,58 @@
+// Copyright 2019 Honey Science Corporation
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+	"net/http"
+
+	"github.com/honeydipper/honeydipper/pkg/dipper"
+	"github.com/honeydipper/honeydipper/internal/daemon"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	if dipper.Logger == nil {
+		logFile, err := os.Create("test.log")
+		if err != nil {
+			panic(err)
+		}
+		defer logFile.Close()
+		dipper.GetLogger("test", "INFO", logFile, logFile)
+	}
+	driver = &dipper.Driver{Service: "test"}
+	log = driver.GetLogger()
+	m.Run()
+}
+
+func TestExtractEvent(t *testing.T) {
+	var eventData map[string]interface{}
+	var server *http.Server
+	hookHandlerTest := func(w http.ResponseWriter, r *http.Request) {
+		eventData = extractEventData(w, r)
+		w.WriteHeader(http.StatusOK)
+		go server.Shutdown(context.Background())
+	}
+	server = &http.Server{
+		Addr: "127.0.0.1:8999",
+		Handler: http.HandlerFunc(hookHandlerTest),
+	}
+	daemon.Children.Add(1)
+	go func () {
+		defer daemon.Children.Done()
+		server.ListenAndServe()
+	}()
+	http.Get("http://127.0.0.1:8999")
+	daemon.Children.Wait()
+
+	assert.Containsf(t, eventData, "host", "host is missing in eventData")
+	assert.Containsf(t, eventData, "remoteAddr", "remoteAddr is missing in eventData")
+	assert.Equalf(t, "127.0.0.1:8999", eventData["host"], "host data mismatch")
+	assert.Containsf(t, eventData["remoteAddr"], "127.0.0.1:", "remoteAddr data mismatch")
+}

--- a/drivers/cmd/webhook/main_test.go
+++ b/drivers/cmd/webhook/main_test.go
@@ -8,12 +8,12 @@ package main
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"testing"
-	"net/http"
 
-	"github.com/honeydipper/honeydipper/pkg/dipper"
 	"github.com/honeydipper/honeydipper/internal/daemon"
+	"github.com/honeydipper/honeydipper/pkg/dipper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,11 +40,11 @@ func TestExtractEvent(t *testing.T) {
 		go server.Shutdown(context.Background())
 	}
 	server = &http.Server{
-		Addr: "127.0.0.1:8999",
+		Addr:    "127.0.0.1:8999",
 		Handler: http.HandlerFunc(hookHandlerTest),
 	}
 	daemon.Children.Add(1)
-	go func () {
+	go func() {
 		defer daemon.Children.Done()
 		server.ListenAndServe()
 	}()

--- a/drivers/cmd/webhook/main_test.go
+++ b/drivers/cmd/webhook/main_test.go
@@ -10,8 +10,8 @@ import (
 	"context"
 	"net/http"
 	"os"
-	"sync"
 	"testing"
+	"sync"
 
 	"github.com/honeydipper/honeydipper/pkg/dipper"
 	"github.com/stretchr/testify/assert"
@@ -46,8 +46,8 @@ func TestExtractEvent(t *testing.T) {
 	}
 	waitgroup.Add(1)
 	go func() {
+		defer waitgroup.Done()
 		server.ListenAndServe()
-		waitgroup.Done()
 	}()
 	resp, _ := http.Get("http://127.0.0.1:8999")
 	waitgroup.Wait()

--- a/drivers/cmd/webhook/main_test.go
+++ b/drivers/cmd/webhook/main_test.go
@@ -50,8 +50,8 @@ func TestExtractEvent(t *testing.T) {
 		server.ListenAndServe()
 	}()
 	resp, _ := http.Get("http://127.0.0.1:8999")
-	waitgroup.Wait()
 	resp.Body.Close()
+	waitgroup.Wait()
 
 	assert.Containsf(t, eventData, "host", "host is missing in eventData")
 	assert.Containsf(t, eventData, "remoteAddr", "remoteAddr is missing in eventData")


### PR DESCRIPTION
#### Description
Update extractEventData function in driver/cmd/webhook to get host and remoteAddr from request

#### This PR fixes the following issues
Fixes #85 

