### PR TITLE
feat(engine): function/event data export into context

### DIFF
--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -24,7 +24,8 @@ type Trigger struct {
 	RawEvent   string                 `json:"rawevent,omitempty"`
 	Conditions map[string]interface{} `json:"conditions,omitempty"`
 	// A trigger should have only one of source event a raw event.
-	Source Event `json:"source,omitempty"`
+	Source Event                  `json:"source,omitempty"`
+	Export map[string]interface{} `json:"export,omitempty"`
 }
 
 // Function is the datastructure hold the information to run actions.
@@ -33,7 +34,8 @@ type Function struct {
 	RawAction  string                   `json:"rawaction,omitempty"`
 	Parameters map[string](interface{}) `json:"parameters,omitempty"`
 	// An action should have only one of target action or a raw action.
-	Target Action `json:"target,omitempty"`
+	Target Action                 `json:"target,omitempty"`
+	Export map[string]interface{} `json:"export,omitempty"`
 }
 
 // System is an abstract construct to group data, trigger and function definitions.
@@ -50,6 +52,7 @@ type Workflow struct {
 	Condition string `json:"condition,omitempty"`
 	Content   interface{}
 	Data      map[string]interface{}
+	Export    map[string]interface{}
 }
 
 // Rule is a data structure defining what action to take when certain event happen.

--- a/internal/service/operator.go
+++ b/internal/service/operator.go
@@ -56,7 +56,7 @@ func operatorRoute(msg *dipper.Message) (ret []RoutedMessage) {
 			data = map[string]interface{}{}
 		}
 		event, _ := dipper.GetMapData(msg.Payload, "event")
-		wfdata, _ := dipper.GetMapData(msg.Payload, "wfdata")
+		ctx, _ := dipper.GetMapData(msg.Payload, "ctx")
 		funcDef, ok := dipper.GetMapData(msg.Payload, "function")
 		if !ok {
 			dipper.Logger.Panicf("[operator] no function received")
@@ -76,24 +76,26 @@ func operatorRoute(msg *dipper.Message) (ret []RoutedMessage) {
 		}
 		finalParams := params
 		if params != nil {
-			// interpolate twice for giving an chance for using sysData in wfdata
-			if wfdata != nil {
-				wfdata = dipper.Interpolate(wfdata, map[string]interface{}{
+			// interpolate twice for giving an chance for using sysData in ctx
+			if ctx != nil {
+				ctx = dipper.Interpolate(ctx, map[string]interface{}{
 					"sysData": sysData,
 					"data":    data,
 					"event":   event,
 					"labels":  msg.Labels,
-					"wfdata":  wfdata,
+					"wfdata":  ctx,
+					"ctx":     ctx,
 					"params":  params,
 				}).(map[string]interface{})
 			}
-			// use interpolated wfdata to assemble final params
+			// use interpolated ctx to assemble final params
 			finalParams = dipper.Interpolate(params, map[string]interface{}{
 				"sysData": sysData,
 				"data":    data,
 				"event":   event,
 				"labels":  msg.Labels,
-				"wfdata":  wfdata,
+				"ctx":     ctx,
+				"wfdata":  ctx,
 				"params":  params,
 			}).(map[string]interface{})
 		}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -31,7 +31,7 @@ func TestServiceLoopCatchError(t *testing.T) {
 	svc := &Service{
 		name: "testsvc",
 		driverRuntimes: map[string]*driver.Runtime{
-			"d1": &driver.Runtime{
+			"d1": {
 				State: driver.DriverAlive,
 				Handler: driver.NewDriver(map[string]interface{}{
 					"name": "testdriver1",
@@ -43,14 +43,14 @@ func TestServiceLoopCatchError(t *testing.T) {
 			},
 		},
 		responders: map[string][]MessageResponder{
-			"test:error1": []MessageResponder{
+			"test:error1": {
 				func(d *driver.Runtime, m *dipper.Message) {
 					panic(fmt.Errorf("error in responder"))
 				},
 			},
 		},
 		transformers: map[string][]func(*driver.Runtime, *dipper.Message) *dipper.Message{
-			"test:error2": []func(*driver.Runtime, *dipper.Message) *dipper.Message{
+			"test:error2": {
 				func(d *driver.Runtime, m *dipper.Message) *dipper.Message {
 					panic(fmt.Errorf("error in transformer"))
 				},
@@ -160,7 +160,7 @@ func TestServiceRemoveEmitter(t *testing.T) {
 	svc := &Service{
 		name: "testsvc",
 		driverRuntimes: map[string]*driver.Runtime{
-			"driver:d1": &driver.Runtime{
+			"driver:d1": {
 				State: driver.DriverAlive,
 				Handler: driver.NewDriver(map[string]interface{}{
 					"name": "d1",
@@ -170,7 +170,7 @@ func TestServiceRemoveEmitter(t *testing.T) {
 					},
 				}),
 			},
-			"emitter": &driver.Runtime{
+			"emitter": {
 				State: driver.DriverAlive,
 				Handler: driver.NewDriver(map[string]interface{}{
 					"name": "test-emitter",
@@ -257,7 +257,7 @@ func TestServiceEmitterCrashing(t *testing.T) {
 	svc := &Service{
 		name: "testsvc",
 		driverRuntimes: map[string]*driver.Runtime{
-			"driver:d1": &driver.Runtime{
+			"driver:d1": {
 				State: driver.DriverAlive,
 				Handler: driver.NewDriver(map[string]interface{}{
 					"name": "d1",
@@ -267,7 +267,7 @@ func TestServiceEmitterCrashing(t *testing.T) {
 					},
 				}),
 			},
-			"emitter": &driver.Runtime{
+			"emitter": {
 				State: driver.DriverAlive,
 				Handler: driver.NewDriver(map[string]interface{}{
 					"name": "test-emitter",
@@ -332,7 +332,7 @@ func TestServiceReplaceEmitter(t *testing.T) {
 	svc := &Service{
 		name: "testsvc",
 		driverRuntimes: map[string]*driver.Runtime{
-			"driver:d1": &driver.Runtime{
+			"driver:d1": {
 				State: driver.DriverAlive,
 				Handler: driver.NewDriver(map[string]interface{}{
 					"name": "d1",
@@ -342,7 +342,7 @@ func TestServiceReplaceEmitter(t *testing.T) {
 					},
 				}),
 			},
-			"emitter": &driver.Runtime{
+			"emitter": {
 				State: driver.DriverAlive,
 				Handler: driver.NewDriver(map[string]interface{}{
 					"name": "test-emitter",


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
This PR adds export feature to `Trigger`, `Function` and `Workflow` as described in issue #99. It still maintains backward compatibility for now.  The `wfdata` is still available in interpolation, the `Data` field of `Workflow` remains. But, we can start using `ctx` and migrating all `wfdata` to `ctx`.

<!--
Add a description of your pull request.
-->

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
Fixes #99 partially