### PR TITLE
ci: Probot configuration for semantic-release

### DIFF
--- a/semantic.yml
+++ b/semantic.yml
@@ -1,0 +1,9 @@
+# https://github.com/probot/semantic-pull-requests#configuration
+
+# Always validate the PR title AND all the commits
+titleAndCommits: true
+
+# Allow use of Merge commits (eg on github: "Merge branch 'master' into
+# feature/ride-unicorns") this is only relevant when using commitsOnly: true
+# (or titleAndCommits: true)
+allowMergeCommits: true


### PR DESCRIPTION
#### Description
- Probot configuration for semantic-release

This is one style we could allow; otherwise, we could force on PR titles only, and force squash-merging.

#### This PR fixes the following issues
n/a