### PR TITLE
fix: dep ensure ran out of memory when building @ codefresh.io

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/honeydipper/honeydipper
 
 RUN apk add --no-cache git gcc libc-dev
 COPY ./ ./
-RUN go get -u github.com/golang/dep/cmd/dep && dep ensure
+RUN go get -u github.com/golang/dep/cmd/dep && dep ensure -vendor-only
 RUN go install ./... && rm /go/bin/dep
 
 FROM alpine:3.10


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->
The build process on codefresh.io is limited to use only 1G memory.  The `dep ensure` might be consuming too much memory.  By adding a `-vendor-only`, we are reducing the complexity and hopefully reduce the memory demand.
#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
