### PR TITLE
chore(build): go install ran into oom @ codefresh.io

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,11 +1,16 @@
 FROM golang:1.12.9-alpine AS build
 
+ARG GOINSTALLOPTS=
+ARG GOGC=
+
+ENV GOGC=$GOGC
+
 WORKDIR /go/src/github.com/honeydipper/honeydipper
 
 RUN apk add --no-cache git gcc libc-dev
 COPY ./ ./
-RUN go get -u github.com/golang/dep/cmd/dep && dep ensure -vendor-only
-RUN go install ./... && rm /go/bin/dep
+RUN go get -u github.com/golang/dep/cmd/dep && dep ensure
+RUN go install $GOINSTALLOPTS ./...
 
 FROM alpine:3.10
 


### PR DESCRIPTION
#### Description

The build pipeline is limited to only 1G ram. Since upgrading to go1.12.9, the `go install` commands seems consuming more RAM and causing the build process to be killed. Earlier PR #118 was trying to reduce the memory footprint of the `dep ensure` command which was not addressing the right issue.

This PR reverts #118, and also adds option for the build process to take parameters from the build pipeline to adjust how the build is made.  By specifying `GOGC=50`, and `GOINSTALLOPTS="-p 1"` in the pipeline, the build process is now able complete.  

#### This PR fixes the following issues
n/a
