### PR TITLE
docs: update docs to refer to 1.0.0 instead of release candidates

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -74,7 +74,7 @@ Once the values file is prepared, you can run the `helm install` command like be
 helm install --values values.yaml orchestrator incubator/honeydipper
 ```
 
-If you want to use an older version of the chart, (as of now, the latest one is 0.1.3), use `--version` to specify the chart version. By default, the chart uses the latest stable version of the Honeydipper daemon docker image, (latest is `DipperCL-rc5` as of now).  You can change the version by specifying `--set daemon.image.tag=x.x.x` in your `helm install` command.
+If you want to use an older version of the chart, (as of now, the latest one is 0.1.3), use `--version` to specify the chart version. By default, the chart uses the latest stable version of the Honeydipper daemon docker image, (latest is `1.0.0` as of now).  You can change the version by specifying `--set daemon.image.tag=x.x.x` in your `helm install` command.
 
 ---
 Currently, the chart is available from incubator repo, and the [honeydipper repo](https://hub.helm.sh/charts/honeydipper/honeydipper) from helm hub as well. You may also choose to customize and build the chart by yourself following below steps.
@@ -107,7 +107,7 @@ spec:
     spec:
       containers:
         - name: honeydipper-daemon
-          image: honeydipper/honeydipper:DipperCL-rc5
+          image: honeydipper/honeydipper:1.0.0
           imagePullPolicy: Always
           env:
             - name: REPO
@@ -139,7 +139,7 @@ selector:
 ### Running as docker container
 
 ```bash
-docker run -it -e 'REPO=git@github.com/example/honeydipper-config.git' -e "DIPPER_SSH_KEY=$(cat ~/.ssh/id_rsa)"  honeydipper/honeydipper:DipperCL-rc5
+docker run -it -e 'REPO=git@github.com/example/honeydipper-config.git' -e "DIPPER_SSH_KEY=$(cat ~/.ssh/id_rsa)"  honeydipper/honeydipper:1.0.0
 ```
 
 Replace the repo url with your own, and specify the private key path for accessing the private repo remotely. You may replace the value of `DIPPER_SSH_KEY` with a deploy key for your config repo.

--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -250,7 +250,7 @@ In order to build the document for local viewing, follow below steps.
  5. generating the source document for sphinx
     ```bash
     cd honeydipper-sphinx
-    docker run -it -v docgen:/docgen -v source:/source -e DOCSRC=/docgen -e DOCDST=/source honeydipper/honeydipper:DipperCL-rc5 docgen
+    docker run -it -v $PWD/docgen:/docgen -v $PWD/source:/source -e DOCSRC=/docgen -e DOCDST=/source honeydipper/honeydipper:1.0.0 docgen
     ```
  6. build the documents
     ```bash


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->
Updating the documents where `DipperCL-rc?` was mentioned to use `1.0.0`.
#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
