### PR TITLE
docs: updating init config for setup_local guide

### DIFF
--- a/docs/howtos/setup_local.md
+++ b/docs/howtos/setup_local.md
@@ -75,10 +75,9 @@ drivers:
 rules:
   - when:
       driver: webhook
-      conditions:
+      if_match:
         url: /health
-    do:
-      content: noop
+    do: {}
 EOF
 git add init.yaml
 git commit -m 'init' -a


### PR DESCRIPTION
#### Description
updating init config for setup_local guide

#### This PR fixes the following issues
The configurations for setup_local guide has been outdated and needs to be updated. This will fix the problem of people can't start honeydipper 
