### PR TITLE
fix: error in completion hook causing run away workflow sessions

### DIFF
--- a/internal/workflow/session_hook_test.go
+++ b/internal/workflow/session_hook_test.go
@@ -496,3 +496,56 @@ func TestFailureInHook(t *testing.T) {
 	}
 	syntheticTest(t, configStrHook, testcase)
 }
+
+func TestErrorInCompletionHook(t *testing.T) {
+	testcase := map[string]interface{}{
+		"workflow": &config.Workflow{},
+		"msg":      &dipper.Message{},
+		"ctx": map[string]interface{}{
+			"hooks": map[string]interface{}{
+				"on_success": "send_chat",
+			},
+		},
+		"asserts": func() {
+			mockHelper.EXPECT().SendMessage(gomock.Eq(&dipper.Message{
+				Channel: "eventbus",
+				Subject: "command",
+				Labels: map[string]string{
+					"sessionID": "2",
+				},
+				Payload: map[string]interface{}{
+					"ctx": map[string]interface{}{
+						"_meta_desc":   "",
+						"_meta_name":   "",
+						"resume_token": "//0",
+					},
+					"data":  map[string]interface{}{},
+					"event": map[string]interface{}{},
+					"function": config.Function{
+						Driver:    "foo",
+						RawAction: "bar",
+					},
+					"labels": map[string]string{
+						"status": "success",
+					},
+				},
+			})).Times(1)
+		},
+		"steps": []map[string]interface{}{
+			{
+				"sessionID": "2",
+				"msg": &dipper.Message{
+					Channel: "eventbus",
+					Subject: "return",
+					Labels: map[string]string{
+						"sessionID": "2",
+						"status":    "error",
+					},
+				},
+				"ctx": []map[string]interface{}{},
+			},
+		},
+	}
+
+	syntheticTest(t, configStrHook, testcase)
+}


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->
When an error happens in the completion hook (on_success, on_error, on_failure or on_exit), the exiting logic fails to clear the `currentHook` flag so the session never executes `complete`. This causes the session to stay in memory forever.

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
#130 