### PR TITLE
fix: uses concurrent safe reading function while reading Result map

### DIFF
--- a/internal/workflow/session.go
+++ b/internal/workflow/session.go
@@ -135,7 +135,7 @@ func (w *Session) injectNamedCTX(name string, msg *dipper.Message) {
 
 	namedCTXs, ok := contexts[name]
 	if name[0] != '_' && !ok {
-		dipper.Logger.Panicf("[workflow] named workflow %s not defined", name)
+		dipper.Logger.Panicf("[workflow] named context %s not defined", name)
 	}
 	if namedCTXs != nil {
 		envData := w.buildEnvData(msg)

--- a/pkg/dipper/rpc.go
+++ b/pkg/dipper/rpc.go
@@ -114,7 +114,7 @@ func (c *RPCCaller) CallRawNoWait(feature string, method string, params []byte, 
 // HandleReturn : receiving return of a RPC call
 func (c *RPCCaller) HandleReturn(m *Message) {
 	rpcID := m.Labels["rpcID"]
-	result := c.Result[rpcID]
+	result := IDMapGet(&c.Result, rpcID).(chan interface{})
 
 	reason, ok := m.Labels["error"]
 


### PR DESCRIPTION
#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
Fixes #121 
- Currently, we are reading the Result map by directly accessing it, We switched it to use IDMapGet in order to utilize the Mutex Lock to make this operation concurrently safe
- Correct typo in the context missing panic message in our session
