### PR TITLE
fix: safe reading function for sessions map

### DIFF
--- a/internal/workflow/continue.go
+++ b/internal/workflow/continue.go
@@ -211,7 +211,7 @@ func (w *Session) complete(msg *dipper.Message) {
 	}
 	dipper.Logger.Infof("[workflow] session [%s] completing with msg labels %+v", w.ID, msg.Labels)
 	if w.ID != "" {
-		if _, ok := w.store.sessions[w.ID]; ok {
+		if dipper.IDMapGet(&w.store.sessions, w.ID) != nil {
 			if w.currentHook == "" {
 				w.processExport(msg)
 			}


### PR DESCRIPTION

#### Description
Currently, the complete function of Session struct is reading the sessions map by directly accessing it. We switch this to use IDMapGet to utilize the Mutex lock to make this operation concurrently safe


#### This PR fixes the following issues
Fixes #142 
