### PR TITLE
chore: Dependency updates should be type fix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,13 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "depTypeList": [
+        "dependencies"
+      ],
+      "semanticCommitType": "fix"
+    }
   ]
 }


### PR DESCRIPTION
#### Description
* Code dependency updates as `fix(deps)` vs `chore(deps)`

#### This PR fixes the following issues
n/a