### PR TITLE
chore: Use 'require' as Renovate deptype

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "packageRules": [
     {
       "depTypeList": [
-        "dependencies"
+        "require"
       ],
       "semanticCommitType": "fix"
     }


### PR DESCRIPTION
#### Description
* For most of the Go deps we want to update, the type seems to be set to 'require' vs. 'dependencies'.

#### This PR fixes the following issues
n/a