### PR TITLE
fix(config): regex patterns in unless_match and dollar interpolation default val with comma

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,6 +137,7 @@ func (c *Config) parseWorkflowRegex() {
 			dipper.Recursive(&v.Do, processor)
 		case Workflow:
 			dipper.Recursive(v.Match, processor)
+			dipper.Recursive(v.UnlessMatch, processor)
 			dipper.Recursive(v.Steps, processor)
 			dipper.Recursive(v.Threads, processor)
 			dipper.Recursive(v.Else, processor)

--- a/pkg/dipper/interpolation_test.go
+++ b/pkg/dipper/interpolation_test.go
@@ -26,17 +26,20 @@ func TestInterpolateStr(t *testing.T) {
 }
 
 func TestInterpolate(t *testing.T) {
-	parsed := Interpolate(map[string]interface{}{
-		"notmpl":    "raw",
-		"templated": " this is used by {{ index . \"user\" }}",
-		"map_with_template": map[string]interface{}{
-			"deep": " another {{ index . \"type\" }}",
-		},
-		"yaml_with_template": `:yaml:
+	parsed := Interpolate(
+		map[string]interface{}{
+			"notmpl":    "raw",
+			"templated": " this is used by {{ index . \"user\" }}",
+			"map_with_template": map[string]interface{}{
+				"deep": " another {{ index . \"type\" }}",
+			},
+			"default_user": "$ctx.v1,ctx.v2,'default, value with comma'",
+			"yaml_with_template": `:yaml:
 ---
 test:
   - 1 {{ index (index . "list") "one" }}
-  - 2 {{ index (index . "list") "two" }}`},
+  - 2 {{ index (index . "list") "two" }}`,
+		},
 		map[string]interface{}{
 			"user": "test",
 			"type": "direct",
@@ -58,6 +61,7 @@ test:
 					"2 two",
 				},
 			},
+			"default_user": "default, value with comma",
 		},
 		parsed,
 		"interpolating a map of templates",

--- a/pkg/dipper/mapUtils_test.go
+++ b/pkg/dipper/mapUtils_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRecusive(t *testing.T) {
+func TestRecursive(t *testing.T) {
 	type testStruct struct {
 		Field1 string
 		Field2 []int


### PR DESCRIPTION

#### Description

 * Parsing regex pattern in `unless_match` workflow field
 * Ensuring dollar interpolation not omit the commas in default value

#### This PR fixes the following issues
Fixes #187 
Fixes #188 

