### PR TITLE
chore: adjust renovatebot run frequency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base"
   ],
+  "schedule": ["on Monday every 2 weeks"],
   "packageRules": [
     {
       "depTypeList": [


### PR DESCRIPTION

#### Description
I think releasing every two weeks is a reasonable schedule, so we should adjust renovate to also run every two weeks. This should make renovate PRs less noisy.

#### This PR fixes the following issues
N/A
