### PR TITLE
feat(cmd): enforcing variable timeout for functions

### DIFF
--- a/drivers/cmd/gcloud-dataflow/main.go
+++ b/drivers/cmd/gcloud-dataflow/main.go
@@ -97,7 +97,7 @@ func createJob(msg *dipper.Message) {
 
 	var dataflowService = getDataflowService(serviceAccountBytes)
 
-	execContext, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	execContext, cancel := context.WithTimeout(context.Background(), time.Second*driver.APITimeout)
 	var result *dataflow.Job
 	func() {
 		defer cancel()
@@ -140,7 +140,7 @@ func getJob(msg *dipper.Message) {
 		result *dataflow.Job
 		err    error
 	)
-	execContext, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	execContext, cancel := context.WithTimeout(context.Background(), time.Second*driver.APITimeout)
 	func() {
 		defer cancel()
 		if len(location) == 0 {
@@ -198,7 +198,7 @@ func findJobByName(msg *dipper.Message) {
 	)
 
 	for job == nil {
-		execContext, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		execContext, cancel := context.WithTimeout(context.Background(), time.Second*driver.APITimeout)
 		func() {
 			defer cancel()
 			result, err = listJobCall.Context(execContext).Do()
@@ -278,7 +278,7 @@ func waitForJob(msg *dipper.Message) {
 			break
 		default:
 			func() {
-				execContext, cancel := context.WithTimeout(context.Background(), time.Second*10)
+				execContext, cancel := context.WithTimeout(context.Background(), time.Second*driver.APITimeout)
 				defer cancel()
 				if len(location) == 0 {
 					result, err = dataflowService.Projects.Jobs.Get(project, jobID).Context(execContext).Do()
@@ -331,7 +331,7 @@ func updateJob(msg *dipper.Message) {
 
 	var dataflowService = getDataflowService(serviceAccountBytes)
 
-	execContext, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	execContext, cancel := context.WithTimeout(context.Background(), time.Second*driver.APITimeout)
 	var result *dataflow.Job
 	func() {
 		defer cancel()

--- a/drivers/cmd/gcloud-gke/main.go
+++ b/drivers/cmd/gcloud-gke/main.go
@@ -107,7 +107,7 @@ func getKubeCfg(msg *dipper.Message) {
 
 	containerService, token := getGKEService(serviceAccountBytes)
 
-	execContext, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	execContext, cancel := context.WithTimeout(context.Background(), time.Second*driver.APITimeout)
 	var (
 		clusterObj *container.Cluster
 		err        error

--- a/drivers/cmd/gcloud-kms/main.go
+++ b/drivers/cmd/gcloud-kms/main.go
@@ -45,7 +45,7 @@ func decrypt(msg *dipper.Message) {
 	if !ok {
 		panic(errors.New("key not configured"))
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*driver.APITimeout)
 	defer cancel()
 	req := &kmspb.DecryptRequest{
 		Name:       name,

--- a/drivers/cmd/kubernetes/main.go
+++ b/drivers/cmd/kubernetes/main.go
@@ -40,35 +40,12 @@ const StatusFailure = "failure"
 
 var log *logging.Logger
 var err error
-var k8stimeout time.Duration
 
 func initFlags() {
 	flag.Usage = func() {
 		fmt.Printf("%s [ -h ] <service name>\n", os.Args[0])
 		fmt.Println("    This driver supports services including receiver, workflow, operator etc")
 		fmt.Println("  This program provides honeydipper with capability of interacting with kuberntes")
-	}
-}
-
-func loadOptions(m *dipper.Message) {
-	timeoutOption, ok := driver.GetOption("timeout")
-	if ok {
-		switch timeoutVal := timeoutOption.(type) {
-		case string:
-			timeout, err := strconv.Atoi(timeoutVal)
-			if err != nil {
-				k8stimeout = time.Duration(timeout)
-			} else {
-				driver.GetLogger().Warningf("[%s] invalid timeout '%s' for k8s operations, using default 10s", driver.Service, timeoutVal)
-			}
-		case int:
-			k8stimeout = time.Duration(timeoutVal)
-		default:
-			driver.GetLogger().Warningf("[%s] invalid timeout setting for k8s operations, using default 10s", driver.Service)
-		}
-	}
-	if k8stimeout == 0 {
-		k8stimeout = time.Duration(10)
 	}
 }
 
@@ -84,8 +61,7 @@ func main() {
 	driver.Commands["createJob"] = createJob
 	driver.Commands["waitForJob"] = waitForJob
 	driver.Commands["getJobLog"] = getJobLog
-	driver.Start = loadOptions
-	driver.Reload = loadOptions
+	driver.Reload = func(*dipper.Message) {}
 	driver.Run()
 }
 
@@ -103,7 +79,7 @@ func getJobLog(m *dipper.Message) {
 	search.Kind = "Pod"
 
 	client := k8client.CoreV1().Pods(nameSpace)
-	ctx, cancel := context.WithTimeout(context.Background(), k8stimeout*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), driver.APITimeout*time.Second)
 	defer cancel()
 	pods, err := client.List(ctx, search)
 	if err != nil || len(pods.Items) < 1 {
@@ -131,7 +107,7 @@ func getJobLog(m *dipper.Message) {
 		podlogs := map[string]string{}
 		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
 			func() {
-				ctx, cancel := context.WithTimeout(context.Background(), k8stimeout*time.Second)
+				ctx, cancel := context.WithTimeout(context.Background(), driver.APITimeout*time.Second)
 				defer cancel()
 				stream, err := client.GetLogs(pod.Name, &corev1.PodLogOptions{Container: container.Name}).Stream(ctx)
 				defer stream.Close()
@@ -253,7 +229,7 @@ func createJob(m *dipper.Message) {
 	log.Debugf("[%s] source %+v job spec %+v", driver.Service, dipper.MustGetMapData(m.Payload, "job"), jobSpec)
 
 	jobclient := k8client.BatchV1().Jobs(nameSpace)
-	ctx, cancel := context.WithTimeout(context.Background(), k8stimeout*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), driver.APITimeout*time.Second)
 	defer cancel()
 	jobResult, err := jobclient.Create(ctx, &jobSpec, metav1.CreateOptions{})
 	if err != nil {
@@ -288,7 +264,7 @@ func recycleDeployment(m *dipper.Message) {
 	// to accurately identify the replicaset, we have to retrieve the revision
 	// from the deployment
 	deploymentclient := k8client.AppsV1().Deployments(nameSpace)
-	ctx, cancel := context.WithTimeout(context.Background(), k8stimeout*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), driver.APITimeout*time.Second)
 	defer cancel()
 	if useLabelSelector {
 		deployments, err := deploymentclient.List(ctx, metav1.ListOptions{LabelSelector: deploymentName})
@@ -315,7 +291,7 @@ func recycleDeployment(m *dipper.Message) {
 	revision := deployment.Annotations["deployment.kubernetes.io/revision"]
 
 	rsclient := k8client.AppsV1().ReplicaSets(nameSpace)
-	ctxRsList, cancelRsList := context.WithTimeout(context.Background(), k8stimeout*time.Second)
+	ctxRsList, cancelRsList := context.WithTimeout(context.Background(), driver.APITimeout*time.Second)
 	defer cancelRsList()
 	rs, err := rsclient.List(ctxRsList, metav1.ListOptions{LabelSelector: labels})
 	if err != nil || len(rs.Items) == 0 {
@@ -336,7 +312,7 @@ func recycleDeployment(m *dipper.Message) {
 		log.Panicf("[%s] unable to figure out which is current replicaset for %s", driver.Service, deploymentName)
 	}
 
-	ctxDel, cancelDel := context.WithTimeout(context.Background(), k8stimeout*time.Second)
+	ctxDel, cancelDel := context.WithTimeout(context.Background(), driver.APITimeout*time.Second)
 	defer cancelDel()
 	err = rsclient.Delete(ctxDel, rsName, metav1.DeleteOptions{})
 	if err != nil {

--- a/internal/service/operator.go
+++ b/internal/service/operator.go
@@ -110,7 +110,7 @@ func operatorRoute(msg *dipper.Message) (ret []RoutedMessage) {
 		msg.Labels["method"] = rawaction
 		retry := dipper.InterpolateStr("$?ctx.retry,params.retry", map[string]interface{}{
 			"ctx":    ctx,
-			"params": params,
+			"params": finalParams,
 		})
 		if retry != "" {
 			msg.Labels["retry"] = retry
@@ -119,12 +119,21 @@ func operatorRoute(msg *dipper.Message) (ret []RoutedMessage) {
 		}
 		backoff := dipper.InterpolateStr("$?ctx.backoff_ms,params.backoff_ms", map[string]interface{}{
 			"ctx":    ctx,
-			"params": params,
+			"params": finalParams,
 		})
 		if backoff != "" {
 			msg.Labels["backoff_ms"] = backoff
 		} else {
 			delete(msg.Labels, "backoff_ms")
+		}
+		timeout := dipper.InterpolateStr("$?ctx.timeout,params.timeout", map[string]interface{}{
+			"ctx":    ctx,
+			"params": finalParams,
+		})
+		if timeout != "" {
+			msg.Labels["timeout"] = timeout
+		} else {
+			delete(msg.Labels, "timeout")
 		}
 
 		ret = []RoutedMessage{

--- a/pkg/dipper/commandHandler_test.go
+++ b/pkg/dipper/commandHandler_test.go
@@ -39,9 +39,10 @@ func TestCommandRetry(t *testing.T) {
 
 	m := &Message{
 		Labels: map[string]string{
-			"method":    "test",
-			"retry":     "2",
-			"sessionID": "1",
+			"method":     "test",
+			"retry":      "2",
+			"sessionID":  "1",
+			"backoff_ms": "10",
 		},
 	}
 
@@ -65,9 +66,10 @@ func TestCommandRetry(t *testing.T) {
 	counter = 0
 	m = &Message{
 		Labels: map[string]string{
-			"method":    "test",
-			"retry":     "1",
-			"sessionID": "2",
+			"method":     "test",
+			"retry":      "1",
+			"sessionID":  "2",
+			"backoff_ms": "10",
 		},
 	}
 

--- a/pkg/dipper/driver.go
+++ b/pkg/dipper/driver.go
@@ -9,6 +9,7 @@ package dipper
 import (
 	"io"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/op/go-logging"
@@ -30,6 +31,7 @@ type Driver struct {
 	Stop            MessageHandler
 	Reload          MessageHandler
 	ReadySignal     chan bool
+	APITimeout      time.Duration
 }
 
 // NewDriver : create a blank driver object
@@ -99,6 +101,16 @@ func (d *Driver) ReceiveOptions(msg *Message) {
 	d.Options = msg.Payload
 	Logger = nil
 	d.GetLogger()
+	d.APITimeout = time.Duration(10)
+	apiTimeoutStr, ok := d.GetOptionStr("api_timeout")
+	if ok {
+		apiTimeout, e := strconv.Atoi(apiTimeoutStr)
+		if e != nil {
+			Logger.Warningf("[%s] invalid api timeout, using default", d.Service)
+		} else {
+			d.APITimeout = time.Duration(apiTimeout)
+		}
+	}
 	d.ReadySignal <- true
 }
 


### PR DESCRIPTION
#### Description
 * enforcing the function variable timeout on driver framework level
 * change the existing drivers to use this timeout settings for the long ops
 * allowing setting API level timeout from driver config
 * the default function level timeout is set to 30s
 * the default api level timeout is set to 10s
 * the default function level backoff period is set to 1s

#### This PR fixes the following issues
Fixes #229 
