### PR TITLE
fix(drivers): driver panic due to closed channel during retry

### DIFF
--- a/drivers/cmd/gcloud-dataflow/main.go
+++ b/drivers/cmd/gcloud-dataflow/main.go
@@ -272,10 +272,12 @@ func waitForJob(msg *dipper.Message) {
 		result *dataflow.Job
 		err    error
 	)
+
+loop:
 	for {
 		select {
 		case <-expired:
-			break
+			break loop
 		default:
 			func() {
 				execContext, cancel := context.WithTimeout(context.Background(), time.Second*driver.APITimeout)
@@ -293,7 +295,7 @@ func waitForJob(msg *dipper.Message) {
 						"error": fmt.Sprintf("failed to call polling method: %+v", err),
 					},
 				}
-				break
+				break loop
 			}
 
 			if status, ok := terminatedStates[result.CurrentState]; ok {
@@ -306,7 +308,7 @@ func waitForJob(msg *dipper.Message) {
 						"reason": result.CurrentState,
 					},
 				}
-				break
+				break loop
 			}
 			time.Sleep(time.Duration(interval) * time.Second)
 		}

--- a/drivers/cmd/kubernetes/main.go
+++ b/drivers/cmd/kubernetes/main.go
@@ -204,10 +204,11 @@ func waitForJob(m *dipper.Message) {
 
 	jobStatus := StatusSuccess
 	reason := []string{}
+loop:
 	for {
 		select {
 		case <-ctxWatch.Done():
-			break
+			break loop
 		case evt := <-jobstatus.ResultChan():
 			job := evt.Object.(*batchv1.Job)
 			if len(job.Status.Conditions) > 0 && job.Status.Active == 0 {
@@ -226,7 +227,7 @@ func waitForJob(m *dipper.Message) {
 						"reason": strings.Join(reason, "\n"),
 					},
 				}
-				break
+				break loop
 			}
 		}
 	}

--- a/pkg/dipper/commandHandler_test.go
+++ b/pkg/dipper/commandHandler_test.go
@@ -11,13 +11,14 @@ package dipper
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCommandRetry(t *testing.T) {
+func TestCommandRetrySuccess(t *testing.T) {
 	var b = bytes.Buffer{}
 	counter := 0
 
@@ -61,10 +62,32 @@ func TestCommandRetry(t *testing.T) {
 	assert.Equal(t, 2, counter, "should fail twice")
 	ret := FetchMessage(&b)
 	assert.Equal(t, "success", ret.Labels["status"], "should return success after retry")
+}
+
+func TestCommandRetryFailure(t *testing.T) {
+	var b = bytes.Buffer{}
+	counter := 0
 
 	b.Reset()
 	counter = 0
-	m = &Message{
+
+	subject := CommandProvider{
+		ReturnWriter: &b,
+		Channel:      "test",
+		Subject:      "test",
+
+		Commands: map[string]MessageHandler{
+			"test": func(m *Message) {
+				if counter < 2 {
+					counter++
+					panic(fmt.Errorf("please retry"))
+				}
+				m.Reply <- Message{}
+			},
+		},
+	}
+
+	m := &Message{
 		Labels: map[string]string{
 			"method":     "test",
 			"retry":      "1",
@@ -75,7 +98,7 @@ func TestCommandRetry(t *testing.T) {
 
 	subject.Router(m)
 
-	sleepCount = 0
+	sleepCount := 0
 	for sleepCount < 100 && m.Reply != nil {
 		time.Sleep(time.Millisecond * 5)
 		sleepCount++
@@ -86,6 +109,80 @@ func TestCommandRetry(t *testing.T) {
 	}
 
 	assert.Equal(t, 2, counter, "should fail twice")
-	ret = FetchMessage(&b)
+	ret := FetchMessage(&b)
 	assert.Equal(t, "error", ret.Labels["status"], "should return error after retry error")
+}
+
+func TestCommandRetryRougueFunction(t *testing.T) {
+	var b = bytes.Buffer{}
+	counter := 0
+
+	b.Reset()
+	counter = 0
+
+	subject := CommandProvider{
+		ReturnWriter: &b,
+		Channel:      "test",
+		Subject:      "test",
+
+		Commands: map[string]MessageHandler{
+			"test": func(m *Message) {
+				switch counter {
+				case 0:
+					counter++
+					panic(fmt.Errorf("please retry"))
+				case 1:
+					counter++
+					m.Reply <- Message{
+						Labels: map[string]string{
+							"error": "second failure 1",
+						},
+					}
+					m.Reply <- Message{
+						Labels: map[string]string{
+							"error": "second failure 2",
+						},
+					}
+					m.Reply <- Message{
+						Labels: map[string]string{
+							"error": "second failure 3",
+						},
+					}
+				case 2:
+					counter++
+				}
+				m.Reply <- Message{
+					Payload: map[string]interface{}{
+						"counter": strconv.Itoa(counter),
+					},
+				}
+			},
+		},
+	}
+
+	m := &Message{
+		Labels: map[string]string{
+			"method":     "test",
+			"retry":      "2",
+			"sessionID":  "2",
+			"backoff_ms": "10",
+		},
+	}
+
+	subject.Router(m)
+
+	sleepCount := 0
+	for sleepCount < 100 && m.Reply != nil {
+		time.Sleep(time.Millisecond * 5)
+		sleepCount++
+	}
+
+	if sleepCount == 100 {
+		assert.Fail(t, "timeout waiting for retry to send result")
+	}
+
+	assert.Equal(t, 3, counter, "should fail twice")
+	ret := FetchMessage(&b)
+	assert.Equal(t, "success", ret.Labels["status"], "should return error after retry error")
+	assert.Equal(t, "3", ret.Payload.(map[string]interface{})["counter"], "should return the final counter")
 }


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->

 * Find and fix all functions with faulty `break` statement
 * Avoid reusing `rchan` after it is closed
 * passing a separate `Message` for each attempt in retry 
 * Added a testcase for dealing with **rogue** functions

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->

Fixes #250 
