### PR TITLE
refactor(configcheck): update error formatting

### DIFF
--- a/cmd/honeydipper/configcheck.go
+++ b/cmd/honeydipper/configcheck.go
@@ -20,13 +20,13 @@ import (
 
 const (
 	// ErrorFieldCollision is the error message when two conflicting fields are set
-	ErrorFieldCollision = "cannot define both `%s` and `%s`"
+	ErrorFieldCollision = `cannot define both "%s" and "%s"`
 	// ErrorNotDefined is the error message when an required asset is not defined
-	ErrorNotDefined = "%s `%s` not defined"
+	ErrorNotDefined = `%s "%s" not defined`
 	// ErrorNotAllowed is the message when a field is not allowed due to missing pairing field
-	ErrorNotAllowed = "field `%s` not allowed without pairing field"
+	ErrorNotAllowed = `field "%s" not allowed without pairing field`
 	// ErrorNotAList is the message when a field is supposed to be a list
-	ErrorNotAList = "field `%s` must be a list or something interpolated into a list"
+	ErrorNotAList = `field "%s" must be a list or something interpolated into a list`
 )
 
 type dipperCLError struct {
@@ -65,7 +65,7 @@ func runConfigCheck(cfg *config.Config) int {
 				errMsg := checkContext(cfg, wfName)
 				if len(errMsg) > 0 {
 					if !contextErrors {
-						fmt.Printf("\nFound error in Contexts\n")
+						fmt.Printf("\nFound errors in contexts:\n")
 						fmt.Println("─────────────────────────────────────────────────────────────")
 						contextErrors = true
 					}
@@ -84,7 +84,7 @@ func runConfigCheck(cfg *config.Config) int {
 				"_": aurora.Cyan("truncated ..."),
 			}
 			if !ruleErrors {
-				fmt.Printf("\nFound error in Rules\n")
+				fmt.Printf("\nFound errors in rules:\n")
 				fmt.Println("─────────────────────────────────────────────────────────────")
 				ruleErrors = true
 			}
@@ -98,7 +98,7 @@ func runConfigCheck(cfg *config.Config) int {
 		location, errMsg := checkWorkflow(workflow, cfg)
 		if len(errMsg) > 0 {
 			if !workflowErrors {
-				fmt.Printf("\nFound error in Workflows\n")
+				fmt.Printf("\nFound errors in workflows:\n")
 				fmt.Println("─────────────────────────────────────────────────────────────")
 				workflowErrors = true
 			}

--- a/cmd/honeydipper/configcheck_test.go
+++ b/cmd/honeydipper/configcheck_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCheckObjectExistsWorkFlowDoesNotExist(t *testing.T) {
-	defer recoverAssertion("workflow `test-fail` not defined", t)
+	defer recoverAssertion(`workflow "test-fail" not defined`, t)
 	workflows := map[string]config.Workflow{
 		"test-wf": config.Workflow{
 			Name: "test",
@@ -34,7 +34,7 @@ func TestCheckObjectExists(t *testing.T) {
 }
 
 func TestCheckWorkflowDriverCallDriver(t *testing.T) {
-	defer recoverAssertion("driver `test-driver` not defined", t)
+	defer recoverAssertion(`driver "test-driver" not defined`, t)
 	cfg := &config.Config{
 		DataSet: &config.DataSet{
 			Drivers: map[string]interface{}{
@@ -47,7 +47,7 @@ func TestCheckWorkflowDriverCallDriver(t *testing.T) {
 }
 
 func TestCheckWorkflowDriverFunctionDriver(t *testing.T) {
-	defer recoverAssertion("driver `test-driver` not defined", t)
+	defer recoverAssertion(`driver "test-driver" not defined`, t)
 	cfg := &config.Config{
 		DataSet: &config.DataSet{
 			Drivers: map[string]interface{}{
@@ -77,14 +77,14 @@ var wfFunctionTestCases = []struct {
 		&config.Config{DataSet: &config.DataSet{Systems: map[string]config.System{
 			"system_does_not_exist": config.System{Functions: map[string]config.Function{"test_function": config.Function{Driver: "web"}}},
 		}}},
-		"system `test_system` not defined",
+		`system "test_system" not defined`,
 	},
 	{
 		config.Workflow{Name: "test", CallFunction: "test_system.test_function"},
 		&config.Config{DataSet: &config.DataSet{Systems: map[string]config.System{
 			"test_system": config.System{Functions: map[string]config.Function{"test_function_does_not_exist": config.Function{Driver: "web"}}},
 		}}},
-		"test_system function `test_function` not defined",
+		`test_system function "test_function" not defined`,
 	},
 	{
 		config.Workflow{Name: "test", Function: config.Function{Target: config.Action{System: "test_system", Function: "test_function"}}},
@@ -98,14 +98,14 @@ var wfFunctionTestCases = []struct {
 		&config.Config{DataSet: &config.DataSet{Systems: map[string]config.System{
 			"not_exist": config.System{Functions: map[string]config.Function{"test_function": config.Function{Driver: "web"}}},
 		}}},
-		"system `test_system` not defined",
+		`system "test_system" not defined`,
 	},
 	{
 		config.Workflow{Name: "test", Function: config.Function{Target: config.Action{System: "test_system", Function: "test_function"}}},
 		&config.Config{DataSet: &config.DataSet{Systems: map[string]config.System{
 			"test_system": config.System{Functions: map[string]config.Function{"not_exist": config.Function{Driver: "web"}}},
 		}}},
-		"test_system function `test_function` not defined",
+		`test_system function "test_function" not defined`,
 	},
 }
 
@@ -131,19 +131,19 @@ var wfActionTestCases = []struct {
 	},
 	{
 		config.Workflow{Name: "test", Workflow: "test_workflow", CallFunction: "blah"},
-		"cannot define both `call_workflow` and `call_function`",
+		`cannot define both "call_workflow" and "call_function"`,
 	},
 	{
 		config.Workflow{Name: "test", Workflow: "test_workflow", Steps: []config.Workflow{config.Workflow{}}},
-		"cannot define both `call_workflow` and `steps`",
+		`cannot define both "call_workflow" and "steps"`,
 	},
 	{
 		config.Workflow{Name: "test", Workflow: "test_workflow", CallDriver: "blah", Switch: "switch"},
-		"cannot define both `call_workflow` and `call_driver`",
+		`cannot define both "call_workflow" and "call_driver"`,
 	},
 	{
 		config.Workflow{Name: "test", Workflow: "test_workflow", Switch: "switch"},
-		"cannot define both `call_workflow` and `switch`",
+		`cannot define both "call_workflow" and "switch"`,
 	},
 }
 
@@ -164,10 +164,10 @@ var wfConditionsTestCases = []struct {
 	out string
 }{
 	{config.Workflow{Name: "test", Match: "match"}, ""},
-	{config.Workflow{Name: "test", Match: "match", UnlessMatch: "UnlessMatch"}, "cannot define both `if_match` and `unless_match`"},
-	{config.Workflow{Name: "test", Else: "else"}, "field `else` not allowed without pairing field"},
+	{config.Workflow{Name: "test", Match: "match", UnlessMatch: "UnlessMatch"}, `cannot define both "if_match" and "unless_match"`},
+	{config.Workflow{Name: "test", Else: "else"}, `field "else" not allowed without pairing field`},
 	{config.Workflow{Name: "test", If: []string{"1", "2"}, Else: "else"}, ""},
-	{config.Workflow{Name: "test", UntilAll: []string{"1", "2"}, While: []string{"1", "2"}}, "cannot define both `while` and `until_all`"},
+	{config.Workflow{Name: "test", UntilAll: []string{"1", "2"}, While: []string{"1", "2"}}, `cannot define both "while" and "until_all"`},
 }
 
 func TestCheckWorkflowConditions(t *testing.T) {
@@ -182,12 +182,12 @@ func testCheckWorkflowConditionsHelper(t *testing.T, wf config.Workflow, out str
 }
 
 func TestCheckIsListString(t *testing.T) {
-	defer recoverAssertion("field `test` must be a list or something interpolated into a list", t)
+	defer recoverAssertion(`field "test" must be a list or something interpolated into a list`, t)
 	checkIsList("test", "notList")
 }
 
 func TestCheckIsListMap(t *testing.T) {
-	defer recoverAssertion("field `test` must be a list or something interpolated into a list", t)
+	defer recoverAssertion(`field "test" must be a list or something interpolated into a list`, t)
 	checkIsList("test", make(map[string]int))
 }
 


### PR DESCRIPTION
#### Description
* Use double quotes instead of backticks around strings in configcheck output
* Slight rewording / reformatting on headings

#### This PR fixes the following issues
