### PR TITLE
fix(configcheck): exit non-zero on context errors

### DIFF
--- a/cmd/honeydipper/configcheck.go
+++ b/cmd/honeydipper/configcheck.go
@@ -70,6 +70,7 @@ func runConfigCheck(cfg *config.Config) int {
 						contextErrors = true
 					}
 					fmt.Printf("context(%s): %s\n", contextName, aurora.Red(errMsg))
+					ret = 1
 				}
 			}
 		}


### PR DESCRIPTION
#### Description
Context errors weren't causing configcheck to exit with a non-0 exit code

* Return 1 on context error
* Add test coverage for runConfigCheck() return code

#### This PR fixes the following issues
Fixes #255
