### PR TITLE
fix(config): function export should arrange parent subsystem data properly

### DIFF
--- a/internal/workflow/continue.go
+++ b/internal/workflow/continue.go
@@ -117,7 +117,7 @@ func (w *Session) processExport(msg *dipper.Message) {
 		status := msg.Labels["status"]
 
 		if w.inFlyFunction != nil && status != SessionStatusError {
-			export := config.ExportFunctionContext(nil, w.inFlyFunction, envData, w.store.Helper.GetConfig())
+			export := config.ExportFunctionContext(w.inFlyFunction, envData, w.store.Helper.GetConfig())
 			delete(envData, "sysData")
 			w.processNoExport(export)
 			if len(export) > 0 {

--- a/pkg/dipper/mapUtils.go
+++ b/pkg/dipper/mapUtils.go
@@ -245,6 +245,9 @@ func LockCheckDeleteMap(lock *sync.Mutex, resource interface{}, key interface{},
 
 // DeepCopyMap : performs a deep copy of the given map m.
 func DeepCopyMap(m map[string]interface{}) (map[string]interface{}, error) {
+	if m == nil {
+		return nil, nil
+	}
 	ret, err := DeepCopy(m)
 	if err != nil {
 		return nil, err

--- a/pkg/dipper/mapUtils_test.go
+++ b/pkg/dipper/mapUtils_test.go
@@ -95,3 +95,34 @@ func TestRecursive(t *testing.T) {
 		assert.Equal(t, testExpects[i], testValue, "recursive test case %v failed", i)
 	}
 }
+
+func TestDeepCopyNil(t *testing.T) {
+	var ret interface{}
+	var err error
+	assert.NotPanics(t, func() { ret, err = DeepCopy(nil) })
+	assert.Nil(t, ret)
+	assert.Nil(t, err)
+}
+
+func TestDeepCopyNilMap(t *testing.T) {
+	var ret interface{}
+	var err error
+	assert.NotPanics(t, func() { ret, err = DeepCopyMap(nil) })
+	assert.Nil(t, ret)
+	assert.Nil(t, err)
+}
+
+func TestDeepCopy(t *testing.T) {
+	var ret interface{}
+	var err error
+	src := map[string]interface{}{
+		"key1": "value1",
+		"key2": 2,
+		"key3": true,
+	}
+	assert.NotPanics(t, func() { ret, err = DeepCopy(src) })
+	assert.Equal(t, src, ret)
+	src["key3"] = false
+	assert.NotEqual(t, src, ret)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
#### Description
* rewrite the `ExportFunctionContext` func to ensure the parent/subsystem data are arranged
* allow merging and deep copying nil
* more tests for the the changes

#### This PR fixes the following issues

Fixes #269 
