### PR TITLE
fix(k8s): cascading deletion of pods when deleting jobs

### DIFF
--- a/drivers/cmd/kubernetes/main.go
+++ b/drivers/cmd/kubernetes/main.go
@@ -78,7 +78,8 @@ func deleteJob(m *dipper.Message) {
 	client := k8client.BatchV1().Jobs(nameSpace)
 	ctx, cancel := context.WithTimeout(context.Background(), driver.APITimeout*time.Second)
 	defer cancel()
-	err := client.Delete(ctx, jobName, metav1.DeleteOptions{})
+	deletePropagation := metav1.DeletePropagationBackground
+	err := client.Delete(ctx, jobName, metav1.DeleteOptions{PropagationPolicy: &deletePropagation})
 	if err != nil {
 		log.Panicf("[%s] unable to delete the job %s: %+v", driver.Service, jobName, err)
 	}


### PR DESCRIPTION

#### Description
When deleting k8s jobs, the succeeded pods were orphan'ed and left for the k8s cluster to GC them until a threshold is reached. With this change, the pods will be deleted as well.

#### This PR fixes the following issues

Fixes #280 
