### PR TITLE
fix(dipper): map modifier handle nil value gracefully

### DIFF
--- a/pkg/dipper/mapUtils.go
+++ b/pkg/dipper/mapUtils.go
@@ -335,12 +335,12 @@ func mergeModifier(dst map[string]interface{}) {
 		switch {
 		case k[len(k)-1] == '+': // append
 			ev, ok := dst[k[:len(k)-1]]
-			if !ok {
+			if !ok || ev == nil {
 				dst[k[:len(k)-1]] = v
 			} else {
 				if vstr, ok := v.(string); ok {
 					dst[k[:len(k)-1]] = ev.(string) + vstr
-				} else {
+				} else if v != nil {
 					dst[k[:len(k)-1]] = reflect.AppendSlice(reflect.ValueOf(ev), reflect.ValueOf(v)).Interface()
 				}
 			}

--- a/pkg/dipper/mapUtils_test.go
+++ b/pkg/dipper/mapUtils_test.go
@@ -126,3 +126,59 @@ func TestDeepCopy(t *testing.T) {
 	assert.NotEqual(t, src, ret)
 	assert.Nil(t, err)
 }
+
+func TestMerge(t *testing.T) {
+
+	testCases := []map[string]interface{}{
+		map[string]interface{}{
+			"name": "append modifier with nil in src",
+			"dst": map[string]interface{}{
+				"f1": "d1",
+				"f2": []interface{}{"item1", "item2"},
+			},
+			"src": map[string]interface{}{
+				"f2+": nil,
+			},
+			"expect": map[string]interface{}{
+				"f1": "d1",
+				"f2": []interface{}{"item1", "item2"},
+			},
+		},
+		{
+			"name": "append modifier with nil in dst",
+			"dst": map[string]interface{}{
+				"f1": "d1",
+				"f2": nil,
+			},
+			"src": map[string]interface{}{
+				"f2+": []interface{}{"item1", "item2"},
+			},
+			"expect": map[string]interface{}{
+				"f1": "d1",
+				"f2": []interface{}{"item1", "item2"},
+			},
+		},
+		{
+			"name": "append modifier missing key in dst",
+			"dst": map[string]interface{}{
+				"f1": "d1",
+			},
+			"src": map[string]interface{}{
+				"f2+": []interface{}{"item1", "item2"},
+			},
+			"expect": map[string]interface{}{
+				"f1": "d1",
+				"f2": []interface{}{"item1", "item2"},
+			},
+		},
+	}
+	for _, c := range testCases {
+		d, _ := c["dst"].(map[string]interface{})
+		s := c["src"]
+		e := c["expect"]
+		n := c["name"]
+
+		assert.NotPanics(t, func() { MergeMap(d, s) })
+		assert.Equal(t, e, d, n)
+	}
+}


### PR DESCRIPTION

#### Description
 * Make sure `nil` won't cause any errors when processing merge modifier
 * Add tests

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
N/A