### PR TITLE
feat(drivers): spanner and k8s createJob allows retry

### DIFF
--- a/pkg/dipper/errorHandling.go
+++ b/pkg/dipper/errorHandling.go
@@ -47,3 +47,11 @@ func PanicError(args ...interface{}) {
 		}
 	}
 }
+
+// Must is used to catch function return with error
+func Must(ret interface{}, err error) interface{} {
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}


### PR DESCRIPTION
#### Description
The `createJob` function will try to look for the job with the same name or uniq identifier,
and if found, will return it instead of creating a new one. This will allow the call to be
retried if the call was timed out waiting for API return.

k8s job template needs to have a field `honeydipper-unique-identifier` to specify the uniq identifier.
Dataflow jobs will use their name as the unique identifier.

#### This PR fixes the following issues
N/A

#### Notes
The two commits are cherry picked from the `CH-api5` branch. I intend to release them sooner. Let's do `rebase merge` so it won't conflict with the `CH-api5` brach.
