### PR TITLE
style: minor style and code updates for go reportcard

### DIFF
--- a/cmd/honeydipper/configcheck_test.go
+++ b/cmd/honeydipper/configcheck_test.go
@@ -28,8 +28,8 @@ func TestRunConfigCheck(t *testing.T) {
 			&config.Config{
 				DataSet: &config.DataSet{},
 				Loaded: map[config.RepoInfo]*config.Repo{
-					config.RepoInfo{Repo: "good one"}: &config.Repo{Errors: nil},
-					config.RepoInfo{Repo: "bad one"}:  &config.Repo{Errors: []config.Error{config.Error{Error: fmt.Errorf("error converting YAML to JSON: yaml: %s", "test.yaml"), File: "test"}}},
+					{Repo: "good one"}: {Errors: nil},
+					{Repo: "bad one"}:  {Errors: []config.Error{{Error: fmt.Errorf("error converting YAML to JSON: yaml: %s", "test.yaml"), File: "test"}}},
 				},
 			},
 			1,
@@ -58,7 +58,7 @@ func TestRunConfigCheck(t *testing.T) {
 		[]interface{}{
 			&config.Config{
 				DataSet: &config.DataSet{
-					Workflows: map[string]config.Workflow{"test-workflow": config.Workflow{Workflow: "dne"}},
+					Workflows: map[string]config.Workflow{"test-workflow": {Workflow: "dne"}},
 				},
 			},
 			1,
@@ -77,7 +77,7 @@ func TestRunConfigCheck(t *testing.T) {
 func TestCheckObjectExistsWorkFlowDoesNotExist(t *testing.T) {
 	defer recoverAssertion(`workflow "test-fail" not defined`, t)
 	workflows := map[string]config.Workflow{
-		"test-wf": config.Workflow{
+		"test-wf": {
 			Name: "test",
 		},
 	}
@@ -87,7 +87,7 @@ func TestCheckObjectExistsWorkFlowDoesNotExist(t *testing.T) {
 func TestCheckObjectExists(t *testing.T) {
 	defer recoverAssertion("", t)
 	workflows := map[string]config.Workflow{
-		"test-wf": config.Workflow{
+		"test-wf": {
 			Name: "test",
 		},
 	}
@@ -129,42 +129,42 @@ var wfFunctionTestCases = []struct {
 	{
 		config.Workflow{Name: "test", CallFunction: "test_system.test_function"},
 		&config.Config{DataSet: &config.DataSet{Systems: map[string]config.System{
-			"test_system": config.System{Functions: map[string]config.Function{"test_function": config.Function{Driver: "web"}}},
+			"test_system": {Functions: map[string]config.Function{"test_function": {Driver: "web"}}},
 		}}},
 		"",
 	},
 	{
 		config.Workflow{Name: "test", CallFunction: "test_system.test_function"},
 		&config.Config{DataSet: &config.DataSet{Systems: map[string]config.System{
-			"system_does_not_exist": config.System{Functions: map[string]config.Function{"test_function": config.Function{Driver: "web"}}},
+			"system_does_not_exist": {Functions: map[string]config.Function{"test_function": {Driver: "web"}}},
 		}}},
 		`system "test_system" not defined`,
 	},
 	{
 		config.Workflow{Name: "test", CallFunction: "test_system.test_function"},
 		&config.Config{DataSet: &config.DataSet{Systems: map[string]config.System{
-			"test_system": config.System{Functions: map[string]config.Function{"test_function_does_not_exist": config.Function{Driver: "web"}}},
+			"test_system": {Functions: map[string]config.Function{"test_function_does_not_exist": {Driver: "web"}}},
 		}}},
 		`test_system function "test_function" not defined`,
 	},
 	{
 		config.Workflow{Name: "test", Function: config.Function{Target: config.Action{System: "test_system", Function: "test_function"}}},
 		&config.Config{DataSet: &config.DataSet{Systems: map[string]config.System{
-			"test_system": config.System{Functions: map[string]config.Function{"test_function": config.Function{Driver: "web"}}},
+			"test_system": {Functions: map[string]config.Function{"test_function": {Driver: "web"}}},
 		}}},
 		"",
 	},
 	{
 		config.Workflow{Name: "test", Function: config.Function{Target: config.Action{System: "test_system", Function: "test_function"}}},
 		&config.Config{DataSet: &config.DataSet{Systems: map[string]config.System{
-			"not_exist": config.System{Functions: map[string]config.Function{"test_function": config.Function{Driver: "web"}}},
+			"not_exist": {Functions: map[string]config.Function{"test_function": {Driver: "web"}}},
 		}}},
 		`system "test_system" not defined`,
 	},
 	{
 		config.Workflow{Name: "test", Function: config.Function{Target: config.Action{System: "test_system", Function: "test_function"}}},
 		&config.Config{DataSet: &config.DataSet{Systems: map[string]config.System{
-			"test_system": config.System{Functions: map[string]config.Function{"not_exist": config.Function{Driver: "web"}}},
+			"test_system": {Functions: map[string]config.Function{"not_exist": {Driver: "web"}}},
 		}}},
 		`test_system function "test_function" not defined`,
 	},
@@ -195,7 +195,7 @@ var wfActionTestCases = []struct {
 		`cannot define both "call_workflow" and "call_function"`,
 	},
 	{
-		config.Workflow{Name: "test", Workflow: "test_workflow", Steps: []config.Workflow{config.Workflow{}}},
+		config.Workflow{Name: "test", Workflow: "test_workflow", Steps: []config.Workflow{{}}},
 		`cannot define both "call_workflow" and "steps"`,
 	},
 	{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -49,7 +49,7 @@ func TestRegexParsing(t *testing.T) {
 	config := &Config{
 		DataSet: &DataSet{
 			Workflows: map[string]Workflow{
-				"test-workflow": Workflow{
+				"test-workflow": {
 					Match: map[string]interface{}{
 						"key1": ":regex:test1",
 						"key2": "non regex",
@@ -61,7 +61,7 @@ func TestRegexParsing(t *testing.T) {
 				},
 			},
 			Rules: []Rule{
-				Rule{
+				{
 					When: Trigger{
 						Match: map[string]interface{}{
 							"key5": ":regex:test3",

--- a/internal/config/function_export_test.go
+++ b/internal/config/function_export_test.go
@@ -18,7 +18,7 @@ func TestFunctionExport(t *testing.T) {
 	cfg := Config{
 		DataSet: &DataSet{
 			Systems: map[string]System{
-				"test": System{
+				"test": {
 					Data: map[string]interface{}{
 						"key1": "value1",
 						"key2": map[string]interface{}{
@@ -26,7 +26,7 @@ func TestFunctionExport(t *testing.T) {
 						},
 					},
 					Functions: map[string]Function{
-						"testFunc1": Function{
+						"testFunc1": {
 							Driver:    "testDriver",
 							RawAction: "action",
 							Export: map[string]interface{}{
@@ -74,7 +74,7 @@ func TestFunctionExportWithParameters(t *testing.T) {
 	cfg := Config{
 		DataSet: &DataSet{
 			Systems: map[string]System{
-				"test": System{
+				"test": {
 					Data: map[string]interface{}{
 						"key1": "value1",
 						"key2": map[string]string{
@@ -82,7 +82,7 @@ func TestFunctionExportWithParameters(t *testing.T) {
 						},
 					},
 					Functions: map[string]Function{
-						"testFunc1": Function{
+						"testFunc1": {
 							Driver:    "testDriver",
 							RawAction: "action",
 							Parameters: map[string]interface{}{
@@ -129,7 +129,7 @@ func TestFunctionExportWithSquashedParameters(t *testing.T) {
 	cfg := Config{
 		DataSet: &DataSet{
 			Systems: map[string]System{
-				"test": System{
+				"test": {
 					Data: map[string]interface{}{
 						"key1": "this_should_not_be_used",
 						"key2": map[string]string{
@@ -137,7 +137,7 @@ func TestFunctionExportWithSquashedParameters(t *testing.T) {
 						},
 					},
 					Functions: map[string]Function{
-						"testFunc1": Function{
+						"testFunc1": {
 							Driver:    "testDriver",
 							RawAction: "action",
 							Parameters: map[string]interface{}{
@@ -147,7 +147,7 @@ func TestFunctionExportWithSquashedParameters(t *testing.T) {
 						},
 					},
 				},
-				"test2": System{
+				"test2": {
 					Data: map[string]interface{}{
 						"key1": "value1",
 						"key2": map[string]string{
@@ -155,7 +155,7 @@ func TestFunctionExportWithSquashedParameters(t *testing.T) {
 						},
 					},
 					Functions: map[string]Function{
-						"testFunc2": Function{
+						"testFunc2": {
 							Target: Action{
 								System:   "test",
 								Function: "testFunc1",
@@ -189,12 +189,12 @@ func TestFunctionExportWithSquashedSysData(t *testing.T) {
 	cfg := Config{
 		DataSet: &DataSet{
 			Systems: map[string]System{
-				"test": System{
+				"test": {
 					Data: map[string]interface{}{
 						"key4": "value4",
 					},
 					Functions: map[string]Function{
-						"testFunc1": Function{
+						"testFunc1": {
 							Driver:    "testDriver",
 							RawAction: "action",
 							Parameters: map[string]interface{}{
@@ -203,7 +203,7 @@ func TestFunctionExportWithSquashedSysData(t *testing.T) {
 						},
 					},
 				},
-				"test2": System{
+				"test2": {
 					Data: map[string]interface{}{
 						"key1": "value1",
 						"key2": map[string]string{
@@ -212,7 +212,7 @@ func TestFunctionExportWithSquashedSysData(t *testing.T) {
 						"key4": "this_should_not_be_used",
 					},
 					Functions: map[string]Function{
-						"testFunc2": Function{
+						"testFunc2": {
 							Target: Action{
 								System:   "test",
 								Function: "testFunc1",
@@ -242,7 +242,7 @@ func TestFunctionExportWithSubsystem(t *testing.T) {
 	cfg := Config{
 		DataSet: &DataSet{
 			Systems: map[string]System{
-				"outter": System{
+				"outter": {
 					Extends: []string{
 						"inner=test",
 					},
@@ -250,7 +250,7 @@ func TestFunctionExportWithSubsystem(t *testing.T) {
 						"key1": "should-not-be-used",
 					},
 				},
-				"test": System{
+				"test": {
 					Data: map[string]interface{}{
 						"key1": "value1",
 						"key2": map[string]interface{}{
@@ -258,7 +258,7 @@ func TestFunctionExportWithSubsystem(t *testing.T) {
 						},
 					},
 					Functions: map[string]Function{
-						"testFunc1": Function{
+						"testFunc1": {
 							Driver:    "testDriver",
 							RawAction: "action",
 							Export: map[string]interface{}{
@@ -288,7 +288,7 @@ func TestFunctionExportWithSubsystemParameters(t *testing.T) {
 	cfg := Config{
 		DataSet: &DataSet{
 			Systems: map[string]System{
-				"outter": System{
+				"outter": {
 					Extends: []string{
 						"inner=test",
 					},
@@ -296,7 +296,7 @@ func TestFunctionExportWithSubsystemParameters(t *testing.T) {
 						"key1": "should-not-be-used",
 					},
 				},
-				"test": System{
+				"test": {
 					Data: map[string]interface{}{
 						"key1": "value1",
 						"key2": map[string]interface{}{
@@ -305,7 +305,7 @@ func TestFunctionExportWithSubsystemParameters(t *testing.T) {
 						"key5": "internal-data",
 					},
 					Functions: map[string]Function{
-						"testFunc1": Function{
+						"testFunc1": {
 							Driver:    "testDriver",
 							RawAction: "action",
 							Parameters: map[string]interface{}{
@@ -338,7 +338,7 @@ func TestFunctionExportWithSubsystemParentData(t *testing.T) {
 	cfg := Config{
 		DataSet: &DataSet{
 			Systems: map[string]System{
-				"outter": System{
+				"outter": {
 					Extends: []string{
 						"inner=test",
 					},
@@ -347,7 +347,7 @@ func TestFunctionExportWithSubsystemParentData(t *testing.T) {
 						"key2": "belong-to-parent",
 					},
 				},
-				"test": System{
+				"test": {
 					Data: map[string]interface{}{
 						"key1": "value1",
 						"key2": map[string]interface{}{
@@ -356,7 +356,7 @@ func TestFunctionExportWithSubsystemParentData(t *testing.T) {
 						"key5": "internal-data",
 					},
 					Functions: map[string]Function{
-						"testFunc1": Function{
+						"testFunc1": {
 							Driver:    "testDriver",
 							RawAction: "action",
 							Export: map[string]interface{}{

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -208,7 +208,7 @@ func TestServiceRemoveEmitter(t *testing.T) {
 					Channel: "test",
 					Subject: "noerror",
 				}:
-					dipper.Logger.Infof("writen msg no. %+v", i)
+					dipper.Logger.Infof("written msg no. %+v", i)
 					time.Sleep(10 * time.Millisecond)
 				default:
 					dipper.Logger.Infof("unable to write, server shutdown")
@@ -305,7 +305,7 @@ func TestServiceEmitterCrashing(t *testing.T) {
 					Channel: "test",
 					Subject: "noerror",
 				}:
-					dipper.Logger.Infof("writen msg no. %+v", i)
+					dipper.Logger.Infof("written msg no. %+v", i)
 					time.Sleep(10 * time.Millisecond)
 				default:
 					dipper.Logger.Infof("unable to write, server shutdown")
@@ -382,7 +382,7 @@ func TestServiceReplaceEmitter(t *testing.T) {
 					Channel: "test",
 					Subject: "noerror",
 				}:
-					dipper.Logger.Infof("writen msg no. %+v", i)
+					dipper.Logger.Infof("written msg no. %+v", i)
 					time.Sleep(10 * time.Millisecond)
 				default:
 					dipper.Logger.Infof("unable to write, server shutdown")

--- a/internal/workflow/session_context_test.go
+++ b/internal/workflow/session_context_test.go
@@ -60,11 +60,11 @@ contexts:
 
 	w = s.newSession("", &config.Workflow{Name: "workflow1"}).(*Session)
 	w.prepare(&dipper.Message{}, nil, map[string]interface{}{})
-	assert.Equal(t, "bar_context", w.ctx["foo"], "inheriting from default context targetted to 'workflow1'")
+	assert.Equal(t, "bar_context", w.ctx["foo"], "inheriting from default context targeted to 'workflow1'")
 
 	w = s.newSession("", &config.Workflow{Name: "workflow2"}).(*Session)
 	w.prepare(&dipper.Message{}, nil, map[string]interface{}{})
-	assert.Equal(t, "bar_event", w.ctx["foo"], "inheriting from event context targetted to 'workflow2'")
+	assert.Equal(t, "bar_event", w.ctx["foo"], "inheriting from event context targeted to 'workflow2'")
 
 	w = s.newSession("", &config.Workflow{Name: "workflow1", Context: "override"}).(*Session)
 	w.prepare(&dipper.Message{}, nil, map[string]interface{}{})

--- a/pkg/dipper/commandHandler.go
+++ b/pkg/dipper/commandHandler.go
@@ -36,7 +36,7 @@ func (p *CommandProvider) Init(channel string, subject string, defaultWriter io.
 	p.Subject = subject
 }
 
-// ReturnError: send an error message return to caller and create an error
+// ReturnError : send an error message return to caller and create an error
 func (p *CommandProvider) ReturnError(call *Message, pattern string, args ...interface{}) error {
 	errText := fmt.Sprintf(pattern, args...)
 	p.Return(call, &Message{
@@ -139,7 +139,7 @@ func (p *CommandProvider) Router(msg *Message) {
 }
 
 // UnpackLabels loads necessary variables out of the labels
-func (p *CommandProvider) UnpackLabels(msg *Message) (retry int, timeout, backoff_ms time.Duration) {
+func (p *CommandProvider) UnpackLabels(msg *Message) (retry int, timeout, backoffMs time.Duration) {
 	var err error
 
 	retryStr, _ := msg.Labels["retry"]
@@ -156,9 +156,9 @@ func (p *CommandProvider) UnpackLabels(msg *Message) (retry int, timeout, backof
 		if err != nil {
 			panic(p.ReturnError(msg, "[operator] invalid backoff_ms: %s", backoffStr))
 		}
-		backoff_ms = time.Duration(backoffVal)
+		backoffMs = time.Duration(backoffVal)
 	} else {
-		backoff_ms = 1000
+		backoffMs = 1000
 	}
 
 	timeoutStr, _ := msg.Labels["timeout"]
@@ -172,5 +172,5 @@ func (p *CommandProvider) UnpackLabels(msg *Message) (retry int, timeout, backof
 		timeout = 30
 	}
 
-	return retry, timeout, backoff_ms
+	return retry, timeout, backoffMs
 }

--- a/pkg/dipper/mapUtils_test.go
+++ b/pkg/dipper/mapUtils_test.go
@@ -130,7 +130,7 @@ func TestDeepCopy(t *testing.T) {
 func TestMerge(t *testing.T) {
 
 	testCases := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"name": "append modifier with nil in src",
 			"dst": map[string]interface{}{
 				"f1": "d1",


### PR DESCRIPTION
#### Description
Some tweaks based on the report at https://goreportcard.com/report/github.com/honeydipper/honeydipper

* fix misspellings
* simplify via gofmt
* use camelcase for backoffMs

For this last one, not sure if we should rename the label itself?
Also not sure if any of this will cause big headaches with #294, so could wait and redo this after that if that's better

We might want to add their badge as well?

#### This PR fixes the following issues