### PR TITLE
refactor(api): use casbin authorization library

### DIFF
--- a/drivers/cmd/auth-simple/main.go
+++ b/drivers/cmd/auth-simple/main.go
@@ -32,7 +32,7 @@ var (
 	ErrSkipped = errors.New("skipped")
 
 	// EmptySubject is used for an authenticated user without a defined subject.
-	_EmptySubject = map[string]interface{}{}
+	_EmptySubject = ""
 )
 
 func initFlags() {
@@ -66,7 +66,7 @@ func authWebRequest(m *dipper.Message) {
 	}
 
 	var err error
-	var subject map[string]interface{}
+	var subject string
 	for _, scheme := range schemes {
 		switch scheme.(string) {
 		case "basic":
@@ -88,14 +88,14 @@ func authWebRequest(m *dipper.Message) {
 	panic(err)
 }
 
-func tokenAuth(m *dipper.Message) (map[string]interface{}, error) {
+func tokenAuth(m *dipper.Message) (string, error) {
 	const prefix = "bearer "
 	authHash, ok := dipper.GetMapDataStr(m.Payload, "headers.Authorization.0")
 	if !ok {
 		authHash, ok = dipper.GetMapDataStr(m.Payload, "headers.authorization.0")
 	}
 	if !ok || len(authHash) < len(prefix) || !strings.EqualFold(authHash[:len(prefix)], prefix) {
-		return nil, ErrSkipped
+		return _EmptySubject, ErrSkipped
 	}
 	token := []byte(authHash[len(prefix):])
 
@@ -112,22 +112,22 @@ func tokenAuth(m *dipper.Message) (map[string]interface{}, error) {
 				if !ok || subject == nil {
 					return _EmptySubject, nil
 				}
-				return subject.(map[string]interface{}), nil
+				return subject.(string), nil
 			}
 		}
 	}
 
-	return nil, ErrInvalidBearerToken
+	return _EmptySubject, ErrInvalidBearerToken
 }
 
-func basicAuth(m *dipper.Message) (map[string]interface{}, error) {
+func basicAuth(m *dipper.Message) (string, error) {
 	const prefix = "basic "
 	authHash, ok := dipper.GetMapDataStr(m.Payload, "headers.Authorization.0")
 	if !ok {
 		authHash, ok = dipper.GetMapDataStr(m.Payload, "headers.authorization.0")
 	}
 	if !ok || len(authHash) < len(prefix) || !strings.EqualFold(authHash[:len(prefix)], prefix) {
-		return nil, ErrSkipped
+		return _EmptySubject, ErrSkipped
 	}
 	req := &http.Request{
 		Header: http.Header{
@@ -136,7 +136,7 @@ func basicAuth(m *dipper.Message) (map[string]interface{}, error) {
 	}
 	user, pass, ok := req.BasicAuth()
 	if !ok {
-		return nil, ErrInvalidBasicAuth
+		return _EmptySubject, ErrInvalidBasicAuth
 	}
 	passBytes := []byte(pass)
 
@@ -153,10 +153,10 @@ func basicAuth(m *dipper.Message) (map[string]interface{}, error) {
 				if !ok || subject == nil {
 					return _EmptySubject, nil
 				}
-				return subject.(map[string]interface{}), nil
+				return subject.(string), nil
 			}
 		}
 	}
 
-	return nil, ErrInvalidBasicCreds
+	return _EmptySubject, ErrInvalidBasicCreds
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
+	github.com/casbin/casbin/v2 v2.11.3
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-errors/errors v1.1.1
@@ -26,6 +27,7 @@ require (
 	github.com/mitchellh/mapstructure v1.3.2
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
+	github.com/qiangmzsx/string-adapter/v2 v2.1.0
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,7 @@ cloud.google.com/go v0.57.0 h1:EpMNVUorLiZIELdMZbCYX/ByTFCdoYopYAGxaGVz9ms=
 cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
 cloud.google.com/go v0.62.0 h1:RmDygqvj27Zf3fCQjQRtLyC7KwFcHkeJitcO0OoGOcA=
 cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOYc=
+cloud.google.com/go v0.65.0 h1:Dg9iHVQfrhq82rUNu9ZxUDrJLaxFUe/HlCVaLyRruq8=
 cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHObY=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
@@ -60,6 +61,8 @@ github.com/DataDog/datadog-go v3.7.2+incompatible h1:o4QtYjBU/rG58VPh8Ne6F65YiMY
 github.com/DataDog/datadog-go v3.7.2+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/sketches-go v0.0.0-20190923095040-43f19ad77ff7 h1:qELHH0AWCvf98Yf+CNIJx9vOZOfHFDDzgDRYsnNk/vs=
 github.com/DataDog/sketches-go v0.0.0-20190923095040-43f19ad77ff7/go.mod h1:Q5DbzQ+3AkgGwymQO7aZFNP7ns2lZKGtvRBzRXfdi60=
+github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1:1G1pk05UrOh0NlF1oeaaix1x8XzrfjIDK47TY0Zehcw=
+github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
@@ -77,6 +80,10 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/benbjohnson/clock v1.0.3 h1:vkLuvpK4fmtSCuo60+yC63p7y0BmQ8gm5ZXGuBCJyXg=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
+github.com/casbin/casbin/v2 v2.1.0 h1:FqE47qR7PNFrhh/mQFRqlXWdAM0lObvn/cl8ydyxi1c=
+github.com/casbin/casbin/v2 v2.1.0/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
+github.com/casbin/casbin/v2 v2.11.3 h1:nGpcPrD8KVhKjla29qGqe6ijKGD3Qkn+jP3S5hvgZ9U=
+github.com/casbin/casbin/v2 v2.11.3/go.mod h1:XXtYGrs/0zlOsJMeRteEdVi/FsB0ph7KgNfjoCoJUD8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -300,6 +307,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/qiangmzsx/string-adapter/v2 v2.1.0 h1:q0y8TPa/sTwtriJPRe8gWL++PuZ+XbOUuvKU+hvtTYs=
+github.com/qiangmzsx/string-adapter/v2 v2.1.0/go.mod h1:PElPB7b7HnGKTsuADAffFpOQXHqjEGJz1+U1a6yR5wA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -342,8 +351,7 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de h1:ikNHVSjEfnvz6sxdSPCaPt572qowuyMDMJLLm3Db3ig=
-golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -409,6 +417,7 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -416,6 +425,7 @@ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43 h1:ld7aEMNHoBnnDAX15v1T6z31v8HwR2A9FYOuAhWqkwc=
 golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -458,6 +468,7 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121 h1:rITEj+UZHYC927n8GT97eC3zrpzXdb/voyeOuVKS46o=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200803210538-64077c9b5642 h1:B6caxRw+hozq68X2MY7jEpZh/cr4/aHLv9xU8Kkadrw=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -520,6 +531,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -576,8 +588,6 @@ google.golang.org/genproto v0.0.0-20200526151428-9bb895338b15/go.mod h1:YsZOwe1m
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20200731012542-8145dea6a485 h1:wTk5DQB3+1darAz4Ldomo0r5bUOCKX7gilxQ4sb2kno=
-google.golang.org/genproto v0.0.0-20200731012542-8145dea6a485/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d h1:92D1fum1bJLKSdr11OJ+54YeCMCGYIygTA7R/YZxH5M=
@@ -594,6 +604,7 @@ google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKa
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0 h1:M5a8xTlYTxwMn5ZFkwhRabsygDY5G8TYLyQDBxJNAxE=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.31.0 h1:T7P4R73V3SSDPhH7WW7ATbfViLtmamH0DKrP3f9AuDI=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/internal/api/def.go
+++ b/internal/api/def.go
@@ -13,13 +13,14 @@ import (
 
 // Def is a structure defines how an API should be handled in api service.
 type Def struct {
-	path       string
-	name       string
-	method     string
-	reqType    int
-	service    string
-	ackTimeout time.Duration
-	timeout    time.Duration
+	Path       string
+	Object     string
+	Name       string
+	Method     string
+	ReqType    int
+	Service    string
+	AckTimeout time.Duration
+	Timeout    time.Duration
 }
 
 const (
@@ -38,11 +39,11 @@ const (
 func GetDefs() map[string]map[string]Def {
 	return map[string]map[string]Def{
 		"events/:eventID/wait": {
-			http.MethodGet: {name: "eventWait", reqType: TypeMatch, service: "engine", timeout: InfiniteDuration},
+			http.MethodGet: {Object: "event", Name: "eventWait", ReqType: TypeMatch, Service: "engine", Timeout: InfiniteDuration},
 		},
 		"events": {
-			http.MethodGet:  {name: "eventList", reqType: TypeAll, service: "engine"},
-			http.MethodPost: {name: "eventAdd", reqType: TypeFirst, service: "receiver"},
+			http.MethodGet:  {Object: "event", Name: "eventList", ReqType: TypeAll, Service: "engine"},
+			http.MethodPost: {Object: "event", Name: "eventAdd", ReqType: TypeFirst, Service: "receiver"},
 		},
 	}
 }
@@ -52,9 +53,9 @@ func GetDefsByName() map[string]Def {
 	ret := map[string]Def{}
 	for path, defs := range GetDefs() {
 		for method, def := range defs {
-			def.path = path
-			def.method = method
-			ret[def.name] = def
+			def.Path = path
+			def.Method = method
+			ret[def.Name] = def
 		}
 	}
 	return ret

--- a/internal/api/main_test.go
+++ b/internal/api/main_test.go
@@ -27,14 +27,14 @@ func TestMain(m *testing.M) {
 }
 
 type TestStep struct {
-	feature         string
-	method          string
-	expectedMessage interface{}
-	returnMessage   interface{}
-	err             error
+	Feature         string
+	Method          string
+	ExpectedMessage interface{}
+	ReturnMessage   interface{}
+	Err             error
 }
 
 type ReturnMessage struct {
-	delay time.Duration
-	msg   *dipper.Message
+	Delay time.Duration
+	Msg   *dipper.Message
 }

--- a/internal/api/request.go
+++ b/internal/api/request.go
@@ -47,6 +47,10 @@ type Request struct {
 // Dispatch sends the call to the intended services.
 func (a *Request) Dispatch() {
 	if a.ready == nil {
+		a.ready = make(chan byte)
+		a.results = map[string]interface{}{}
+		a.store.SaveRequest(a)
+
 		dipper.Must(a.store.caller.Call("api-broadcast", "send", map[string]interface{}{
 			"broadcastSubject": "call",
 			"labels": map[string]interface{}{
@@ -57,9 +61,6 @@ func (a *Request) Dispatch() {
 			},
 			"data": a.params,
 		}))
-		a.ready = make(chan byte)
-		a.results = map[string]interface{}{}
-		a.store.SaveRequest(a)
 
 		go func() {
 			defer dipper.SafeExitOnError("error waiting on acks for API call [%s]", a.uuid)

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -105,7 +105,7 @@ func (rf *ResponseFactory) NewResponse(caller dipper.RPCCaller, eventbus io.Writ
 		dipper.Logger.Warningf("Unknown API method: %s", method)
 		return nil
 	}
-	switch def.reqType {
+	switch def.ReqType {
 	case TypeAll:
 		go func() {
 			defer dipper.SafeExitOnError("failed to send ack for api [%s]", method)

--- a/internal/api/response_test.go
+++ b/internal/api/response_test.go
@@ -73,8 +73,8 @@ func responseTest(t *testing.T, c *ResponseTestCase) {
 		go c.mockAPI(resp, c)
 
 		for i, st := range c.returnMessages {
-			if m := waitForMsg(st.delay); m != nil {
-				assert.Equal(t, st.msg, m)
+			if m := waitForMsg(st.Delay); m != nil {
+				assert.Equal(t, st.Msg, m)
 			} else {
 				assert.Fail(t, fmt.Sprintf("timeout at step %d", i))
 			}
@@ -85,7 +85,7 @@ func responseTest(t *testing.T, c *ResponseTestCase) {
 func TestTypeAllAPIResponse(t *testing.T) {
 	c := &ResponseTestCase{
 		defsByName: map[string]Def{
-			"test": {name: "test", reqType: TypeAll},
+			"test": {Name: "test", ReqType: TypeAll},
 		},
 		msg: &dipper.Message{
 			Labels: map[string]string{
@@ -106,8 +106,8 @@ func TestTypeAllAPIResponse(t *testing.T) {
 		},
 		returnMessages: []ReturnMessage{
 			{
-				delay: 30 * time.Millisecond,
-				msg: &dipper.Message{
+				Delay: 30 * time.Millisecond,
+				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",
 					Labels: map[string]string{
@@ -118,8 +118,8 @@ func TestTypeAllAPIResponse(t *testing.T) {
 				},
 			},
 			{
-				delay: 30 * time.Millisecond,
-				msg: &dipper.Message{
+				Delay: 30 * time.Millisecond,
+				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",
 					Labels: map[string]string{
@@ -141,7 +141,7 @@ func TestTypeAllAPIResponse(t *testing.T) {
 func TestTypeFirstAPIResponse(t *testing.T) {
 	c := &ResponseTestCase{
 		defsByName: map[string]Def{
-			"test": {name: "test", reqType: TypeFirst},
+			"test": {Name: "test", ReqType: TypeFirst},
 		},
 		shouldLock: true,
 		msg: &dipper.Message{
@@ -163,8 +163,8 @@ func TestTypeFirstAPIResponse(t *testing.T) {
 		},
 		returnMessages: []ReturnMessage{
 			{
-				delay: 30 * time.Millisecond,
-				msg: &dipper.Message{
+				Delay: 30 * time.Millisecond,
+				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",
 					Labels: map[string]string{
@@ -186,7 +186,7 @@ func TestTypeFirstAPIResponse(t *testing.T) {
 func TestTypeMatchAPIResponse(t *testing.T) {
 	c := &ResponseTestCase{
 		defsByName: map[string]Def{
-			"test": {name: "test", reqType: TypeMatch},
+			"test": {Name: "test", ReqType: TypeMatch},
 		},
 		msg: &dipper.Message{
 			Labels: map[string]string{
@@ -209,8 +209,8 @@ func TestTypeMatchAPIResponse(t *testing.T) {
 		},
 		returnMessages: []ReturnMessage{
 			{
-				delay: 30 * time.Millisecond,
-				msg: &dipper.Message{
+				Delay: 30 * time.Millisecond,
+				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",
 					Labels: map[string]string{
@@ -221,8 +221,8 @@ func TestTypeMatchAPIResponse(t *testing.T) {
 				},
 			},
 			{
-				delay: 30 * time.Millisecond,
-				msg: &dipper.Message{
+				Delay: 30 * time.Millisecond,
+				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",
 					Labels: map[string]string{
@@ -244,7 +244,7 @@ func TestTypeMatchAPIResponse(t *testing.T) {
 func TestTypeMatchAPIResponseReturnError(t *testing.T) {
 	c := &ResponseTestCase{
 		defsByName: map[string]Def{
-			"test": {name: "test", reqType: TypeMatch},
+			"test": {Name: "test", ReqType: TypeMatch},
 		},
 		msg: &dipper.Message{
 			Labels: map[string]string{
@@ -265,8 +265,8 @@ func TestTypeMatchAPIResponseReturnError(t *testing.T) {
 		},
 		returnMessages: []ReturnMessage{
 			{
-				delay: 30 * time.Millisecond,
-				msg: &dipper.Message{
+				Delay: 30 * time.Millisecond,
+				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",
 					Labels: map[string]string{
@@ -277,8 +277,8 @@ func TestTypeMatchAPIResponseReturnError(t *testing.T) {
 				},
 			},
 			{
-				delay: 30 * time.Millisecond,
-				msg: &dipper.Message{
+				Delay: 30 * time.Millisecond,
+				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",
 					Labels: map[string]string{
@@ -298,7 +298,7 @@ func TestTypeMatchAPIResponseReturnError(t *testing.T) {
 func TestAPIResponseUnknownAPI(t *testing.T) {
 	c := &ResponseTestCase{
 		defsByName: map[string]Def{
-			"test": {name: "test", reqType: TypeMatch},
+			"test": {Name: "test", ReqType: TypeMatch},
 		},
 		msg: &dipper.Message{
 			Labels: map[string]string{
@@ -319,7 +319,7 @@ func TestAPIResponseUnknownAPI(t *testing.T) {
 func TestAPIResponseLockFailure(t *testing.T) {
 	c := &ResponseTestCase{
 		defsByName: map[string]Def{
-			"test": {name: "test", reqType: TypeFirst},
+			"test": {Name: "test", ReqType: TypeFirst},
 		},
 		shouldLock:   true,
 		lockingError: fmt.Errorf("busy"),

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -169,6 +169,11 @@ func (l *Store) setupAuthorization() {
 	l.enforcer = dipper.Must(casbin.NewEnforcer(models, policies)).(*casbin.Enforcer)
 }
 
+// Enforce checks if the action is allowed based on rules.
+func (l *Store) Enforce(args ...interface{}) (bool, error) {
+	return l.enforcer.Enforce(args...)
+}
+
 // AuthMiddleware is a middleware handles auth.
 func (l *Store) AuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {

--- a/internal/api/test_fixtures/TypeAllAPI.yaml
+++ b/internal/api/test_fixtures/TypeAllAPI.yaml
@@ -1,0 +1,49 @@
+---
+# mock api definition to be tested
+def:
+  path: /test_type_all
+  name: test_type_all
+  method: GET
+  # TypeAll
+  reqType: 1
+  service: foo
+  object: event
+
+# mock incoming call
+path: /test_type_all
+
+# exepected messages sent to services
+steps:
+  - feature: api-broadcast
+    method: send
+    expectedMessage:
+      broadcastSubject: call
+      labels:
+        fn: test_type_all
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        service: foo
+        content-type: application/json
+      data: {}
+
+# mock return messages received from services
+returns:
+  - delay: 1
+    msg:
+      labels:
+        type: ack
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        from: bar
+  - delay: 1
+    msg:
+      labels:
+        type: result
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        from: bar
+      payload:
+        result: all
+
+# expected end result
+expectedCode: 200
+expectedContent:
+  bar:
+    result: all

--- a/internal/api/test_fixtures/TypeAllAPITimeout.yaml
+++ b/internal/api/test_fixtures/TypeAllAPITimeout.yaml
@@ -1,0 +1,42 @@
+---
+# mock api definition to be tested
+def:
+  path: /test_type_all
+  name: test_type_all
+  method: GET
+  # TypeAll
+  reqType: 1
+  service: foo
+  object: event
+  timeout: 1
+
+# mock incoming call
+path: /test_type_all
+
+# exepected messages sent to services
+steps:
+  - feature: api-broadcast
+    method: send
+    expectedMessage:
+      broadcastSubject: call
+      labels:
+        fn: test_type_all
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        service: foo
+        content-type: application/json
+      data: {}
+
+# mock return messages received from services
+returns:
+  - delay: 1
+    msg:
+      labels:
+        type: ack
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        from: bar
+  # only ack, result timed out
+
+# expected end result
+expectedCode: 500
+expectedContent:
+  error: timeout

--- a/internal/api/test_fixtures/TypeFirstAPI.yaml
+++ b/internal/api/test_fixtures/TypeFirstAPI.yaml
@@ -1,0 +1,44 @@
+---
+# mock api definition to be tested
+def:
+  path: /test_type_first
+  name: test_type_first
+  method: GET
+  # TypeFirst
+  reqType: 0
+  service: foo
+  object: event
+
+# mock incoming call
+path: /test_type_first
+
+# expected messages sent to services
+steps:
+  - feature: api-broadcast
+    method: send
+    expectedMessage:
+      broadcastSubject: call
+      labels:
+        fn: test_type_first
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        service: foo
+        content-type: application/json
+      data: {}
+
+# mock return messages received from services
+returns:
+  # no ack
+  - delay: 2
+    msg:
+      labels:
+        type: result
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        from: bar
+      payload:
+        result: all
+
+# expected end result
+expectedCode: 200
+expectedContent:
+  bar:
+    result: all

--- a/internal/api/test_fixtures/TypeMatchAPI.yaml
+++ b/internal/api/test_fixtures/TypeMatchAPI.yaml
@@ -1,0 +1,50 @@
+---
+# mock api definition to be tested
+def:
+  path: /test_type_match
+  name: test_type_match
+  method: GET
+  # TypeMatch
+  reqType: 2
+  service: foo
+  object: event
+
+
+# mock incoming call
+path: /test_type_match
+
+# exepected messages sent to services
+steps:
+  - feature: api-broadcast
+    method: send
+    expectedMessage:
+      broadcastSubject: call
+      labels:
+        fn: test_type_match
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        service: foo
+        content-type: application/json
+      data: {}
+
+# mock return messages received from services
+returns:
+  - delay: 1
+    msg:
+      labels:
+        type: ack
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        from: bar
+  - delay: 1
+    msg:
+      labels:
+        type: result
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        from: bar
+      payload:
+        result: matched
+
+# expected end result
+expectedCode: 200
+expectedContent:
+  bar:
+    result: matched

--- a/internal/api/test_fixtures/TypeMatchAPILongRequest.yaml
+++ b/internal/api/test_fixtures/TypeMatchAPILongRequest.yaml
@@ -1,0 +1,54 @@
+---
+# mock api definition to be tested
+def:
+  path: /test_type_match
+  name: test_type_match
+  method: GET
+  # TypeMatch
+  reqType: 2
+  service: foo
+  object: event
+  timeout: 0
+
+# test config
+config:
+  writeTimeout: 6
+
+# mock incoming call
+path: /test_type_match
+
+# exepected messages sent to services
+steps:
+  - feature: api-broadcast
+    method: send
+    expectedMessage:
+      broadcastSubject: call
+      labels:
+        fn: test_type_match
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        service: foo
+        content-type: application/json
+      data: {}
+
+# mock return messages received from services
+returns:
+  - delay: 1
+    msg:
+      labels:
+        type: ack
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        from: bar
+  - delay: 11000
+    msg:
+      labels:
+        type: result
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        from: bar
+      payload:
+        result: matched
+
+# expected end result
+expectedCode: 202
+expectedContent:
+  results: {}
+  uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl

--- a/internal/api/test_fixtures/TypeMatchAPINoMatch.yaml
+++ b/internal/api/test_fixtures/TypeMatchAPINoMatch.yaml
@@ -1,0 +1,34 @@
+---
+# mock api definition to be tested
+def:
+  path: /test_type_match
+  name: test_type_match
+  method: GET
+  # TypeMatch
+  reqType: 2
+  service: foo
+  object: event
+
+# mock incoming call
+path: /test_type_match
+
+# exepected messages sent to services
+steps:
+  - feature: api-broadcast
+    method: send
+    expectedMessage:
+      broadcastSubject: call
+      labels:
+        fn: test_type_match
+        uuid: 34ik-ijo3i4jt84932-aiau3kegkjrl
+        service: foo
+        content-type: application/json
+      data: {}
+
+# mock return messages received from services
+returns: []
+
+# expected end result
+expectedCode: 404
+expectedContent:
+  error: object not found

--- a/internal/api/test_fixtures/UnauthorizedAPI.yaml
+++ b/internal/api/test_fixtures/UnauthorizedAPI.yaml
@@ -1,0 +1,22 @@
+---
+# mock api definition to be tested
+def:
+  path: /test_type_match
+  name: test_type_match
+  method: GET
+  # TypeMatch
+  reqType: 2
+  service: foo
+  object: event
+
+# mock incoming call
+subject: someone
+path: /test_type_match
+
+# should pass the authorization or not
+shouldAuthorize: false
+
+# expected end result
+expectedCode: 403
+expectedContent:
+  errors: not allowed

--- a/internal/api/test_fixtures/common.yaml
+++ b/internal/api/test_fixtures/common.yaml
@@ -1,0 +1,35 @@
+---
+# test config
+config:
+  auth:
+    casbin:
+      models:
+        - |-
+          [request_definition]
+          r = sub, obj, act
+
+          [policy_definition]
+          p = sub, obj, act
+
+          [policy_effect]
+          e = some(where (p.eft == allow))
+
+          [matchers]
+          m = r.sub == p.sub && r.obj == p.obj && r.act == p.act
+
+      policies:
+        - |-
+          p, test, event, GET
+
+# mock uuids
+uuids:
+  - 34ik-ijo3i4jt84932-aiau3kegkjrl
+
+# mock incoming call
+subject: test
+content-type: application/json
+payload: {}
+
+# should pass the authorization or not
+shouldAuthorize: true
+

--- a/internal/config/repo.go
+++ b/internal/config/repo.go
@@ -55,6 +55,11 @@ func (c *Repo) isFileLoaded(filename string) bool {
 	return c.files[filename]
 }
 
+// ReadFile reads a file from the repo.
+func (c *Repo) ReadFile(filename string) ([]byte, error) {
+	return ioutil.ReadFile(path.Join(c.root, filename[1:]))
+}
+
 func (c *Repo) loadFile(filename string) {
 	defer c.recovering(filename, "")
 


### PR DESCRIPTION
#### Description
 * switch authorization to use casbin library
 * move request_test cases from code to yamls in fixtures
 * adjust auth_simple driver to return simple subject
 * run tests against the auth rules using `configcheck`

#### This PR fixes the following issues
N/A