### PR TITLE
fix(workflow): revert simplify export

### DIFF
--- a/internal/workflow/main_test.go
+++ b/internal/workflow/main_test.go
@@ -106,7 +106,7 @@ func syntheticTest(t *testing.T, configStr string, testcase map[string]interface
 			timeout = num.(time.Duration)
 		}
 		go func() {
-			store.ContinueSession(teststep["sessionID"].(string), teststep["msg"].(*dipper.Message), teststep["ctx"].(map[string]interface{}))
+			store.ContinueSession(teststep["sessionID"].(string), teststep["msg"].(*dipper.Message), []map[string]interface{}{teststep["ctx"].(map[string]interface{})})
 			daemon.Children.Wait()
 			signal <- 1
 		}()

--- a/internal/workflow/session.go
+++ b/internal/workflow/session.go
@@ -31,7 +31,7 @@ type Session struct {
 	parent         string
 	ctx            map[string]interface{}
 	event          map[string]interface{}
-	exported       map[string]interface{}
+	exported       []map[string]interface{}
 	elseBranch     *config.Workflow
 	inFlyFunction  *config.Function
 	store          *SessionStore
@@ -48,7 +48,7 @@ type Session struct {
 type SessionHandler interface {
 	prepare(msg *dipper.Message, parent interface{}, ctx map[string]interface{})
 	execute(msg *dipper.Message)
-	continueExec(msg *dipper.Message, exports map[string]interface{})
+	continueExec(msg *dipper.Message, exports []map[string]interface{})
 	onError()
 	GetName() string
 	GetDescription() string
@@ -56,7 +56,7 @@ type SessionHandler interface {
 	GetEventID() string
 	GetEventName() string
 	GetStatus() (string, string)
-	GetExported() map[string]interface{}
+	GetExported() []map[string]interface{}
 	Watch() <-chan struct{}
 }
 
@@ -467,7 +467,7 @@ func (w *Session) GetStatus() (string, string) {
 }
 
 // GetExported returns the exported data from the session.
-func (w *Session) GetExported() map[string]interface{} {
+func (w *Session) GetExported() []map[string]interface{} {
 	return w.exported
 }
 

--- a/internal/workflow/store.go
+++ b/internal/workflow/store.go
@@ -68,7 +68,7 @@ func (s *SessionStore) StartSession(wf *config.Workflow, msg *dipper.Message, ct
 }
 
 // ContinueSession resume a session with given dipper message.
-func (s *SessionStore) ContinueSession(sessionID string, msg *dipper.Message, exports map[string]interface{}) {
+func (s *SessionStore) ContinueSession(sessionID string, msg *dipper.Message, exports []map[string]interface{}) {
 	defer dipper.SafeExitOnError("[workflow] error when continuing workflow session %s", sessionID)
 	w := dipper.IDMapGet(&s.sessions, sessionID).(SessionHandler)
 	defer w.onError()


### PR DESCRIPTION

#### Description

reverting commit cffb8b3f3fb075be0001f7a6271f427d08617f93

This change although simplifies the process of exports, but it
does not handle layered exports well, and breaks exports with
appending merge modifier.

#### This PR fixes the following issues
N/A