### PR TITLE
fix(drivers): k8s getJobLog misplaced Close statement

### DIFF
--- a/drivers/cmd/kubernetes/main.go
+++ b/drivers/cmd/kubernetes/main.go
@@ -149,12 +149,12 @@ func getJobLog(m *dipper.Message) {
 				defer cancel()
 				stream, err := client.GetLogs(pod.Name, &corev1.PodLogOptions{Container: container.Name}).Stream(ctx)
 				if err != nil {
-					defer stream.Close()
 					podlogs[container.Name] = fmt.Sprintf("Error: unable to fetch the logs from the container %s.%s", pod.Name, container.Name)
 					messages = append(messages, podlogs[container.Name])
 					log.Warningf("[%s] unable to fetch the logs for the pod %s container %s: %+v", driver.Service, pod.Name, container.Name, err)
 					returnStatus = StatusFailure
 				} else {
+					defer stream.Close()
 					containerlog, err := ioutil.ReadAll(stream)
 					if err != nil {
 						podlogs[container.Name] = fmt.Sprintf("Error: unable to read the logs from the stream %s.%s", pod.Name, container.Name)

--- a/pkg/dipper/commandHandler.go
+++ b/pkg/dipper/commandHandler.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"strconv"
 	"time"
+
+	"github.com/go-errors/errors"
 )
 
 const (
@@ -133,6 +135,8 @@ func (p *CommandProvider) Router(msg *Message) {
 
 		defer func() {
 			if r := recover(); r != nil && replyChannel != nil {
+				Logger.Warningf("Resuming after command error: %v", r)
+				Logger.Warning(errors.Wrap(r, 1).ErrorStack())
 				replyChannel <- Message{
 					Labels: map[string]string{
 						"error": fmt.Sprintf("%+v", r),


### PR DESCRIPTION

#### Description
 * The `Close` statement in `getJobLog` was moved to the wrong branch of the `if`. This causes
   invalid point exceptions for all k8s jobs that failed in `initContainers`.
 * Use `errors.Wrap` in `commandHandler` to show the stack trace in log for
   easier troubleshooting.

#### This PR fixes the following issues
N/A
