### PR TITLE
refactor: lint and style updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
   golangci-lint:
     <<: *defaults
     docker:
-      - image: golangci/golangci-lint:v1.31.0-alpine
+      - image: golangci/golangci-lint:v1.33.0-alpine
     steps:
       - checkout
       - run: golangci-lint run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,17 @@
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.29.x # use fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: v1.33.x # use fixed version to not introduce new linters unexpectedly
 
 linters:
   enable-all: true
   disable:
+    - exhaustive
+    - exhaustivestruct
     # code to be refactored at some point
     # but seems necessary to have global variables
     - gochecknoglobals
     - wsl
-    - exhaustive
 
 linters-settings:
   lll:

--- a/cmd/honeydipper/configcheck_test.go
+++ b/cmd/honeydipper/configcheck_test.go
@@ -120,7 +120,7 @@ func TestCheckWorkflowDriverFunctionDriver(t *testing.T) {
 	checkWorkflowDriver(workflow, cfg)
 }
 
-// TestCheckWorkflowFunction
+// TestCheckWorkflowFunction.
 var wfFunctionTestCases = []struct {
 	wf  config.Workflow
 	cfg *config.Config
@@ -181,7 +181,7 @@ func testCheckWorkflowFunctionHelper(t *testing.T, wf config.Workflow, cfg *conf
 	checkWorkflowFunction(wf, cfg)
 }
 
-// TestCheckWorkflowActions
+// TestCheckWorkflowActions.
 var wfActionTestCases = []struct {
 	in  config.Workflow
 	out string
@@ -219,7 +219,7 @@ func testCheckWorkflowActionsHelper(t *testing.T, wf config.Workflow, out string
 	checkWorkflowActions(wf)
 }
 
-// TestWorkFlowConditions
+// TestWorkFlowConditions.
 var wfConditionsTestCases = []struct {
 	in  config.Workflow
 	out string
@@ -299,7 +299,7 @@ func TestHasInterpolation(t *testing.T) {
 	}
 }
 
-// helper func
+// helper func.
 func recoverAssertion(out string, t *testing.T) {
 	expected := out
 	var msg string

--- a/internal/api/request.go
+++ b/internal/api/request.go
@@ -12,13 +12,8 @@ import (
 	"github.com/honeydipper/honeydipper/pkg/dipper"
 )
 
-const (
-	// APIErrorNoAck means not able to receive ACK for the API call.
-	APIErrorNoAck dipper.Error = "no ack"
-
-	// DefaultAPIReapTimeout is the timeout in seconds before a API result is abandoned.
-	DefaultAPIReapTimeout time.Duration = 30
-)
+// DefaultAPIReapTimeout is the timeout in seconds before a API result is abandoned.
+const DefaultAPIReapTimeout time.Duration = 30
 
 // Request represents a live API call.
 type Request struct {
@@ -110,11 +105,11 @@ func (a *Request) postACK() {
 	defer close(a.received)
 	switch {
 	case a.reqType != TypeFirst && len(a.acks) == 0:
-		a.err = APIErrorNoAck
+		a.err = ErrAPINoACK
 	case a.timeout != InfiniteDuration:
 		select {
 		case <-time.After(a.timeout):
-			a.err = dipper.TimeoutError
+			a.err = dipper.ErrTimeout
 		case <-a.received:
 		}
 	default:

--- a/internal/api/request_test.go
+++ b/internal/api/request_test.go
@@ -49,10 +49,10 @@ func requestTest(t *testing.T, caseName string) (*Store, *RequestTestCase) {
 	dipper.Must(mapstructure.Decode(buffer, c))
 
 	// convert all times from test definition to milliseconds
-	c.Def.AckTimeout = c.Def.AckTimeout * time.Millisecond
-	c.Def.Timeout = c.Def.Timeout * time.Millisecond
+	c.Def.AckTimeout *= time.Millisecond
+	c.Def.Timeout *= time.Millisecond
 	for i := range c.Returns {
-		c.Returns[i].Delay = c.Returns[i].Delay * time.Millisecond
+		c.Returns[i].Delay *= time.Millisecond
 	}
 
 	ctrl := gomock.NewController(t)
@@ -75,6 +75,7 @@ func requestTest(t *testing.T, caseName string) (*Store, *RequestTestCase) {
 	nextUUID := func() string {
 		uuid := uuids[0]
 		uuids = uuids[1:]
+
 		return uuid
 	}
 	l.newUUID = nextUUID
@@ -114,6 +115,7 @@ func requestTest(t *testing.T, caseName string) (*Store, *RequestTestCase) {
 	}
 
 	l.HandleHTTPRequest(mockReqCtx, c.Def)
+
 	return l, c
 }
 

--- a/internal/api/response_test.go
+++ b/internal/api/response_test.go
@@ -52,6 +52,7 @@ func responseTest(t *testing.T, c *ResponseTestCase) {
 		case <-msgAvailable:
 		case <-time.After(delay):
 		}
+
 		return m
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ package config
 import (
 	"bytes"
 	"encoding/gob"
+	"fmt"
 	"strings"
 	"time"
 
@@ -242,12 +243,12 @@ func SystemCopy(s *System) (*System, error) {
 	dec := gob.NewDecoder(&buf)
 	err := enc.Encode(*s)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w", err)
 	}
 	var scopy System
 	err = dec.Decode(&scopy)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w", err)
 	}
 
 	return &scopy, nil
@@ -271,8 +272,11 @@ func mergeDataSet(d *DataSet, s DataSet) error {
 	s.Contexts = dipper.MustDeepCopyMap(s.Contexts)
 	s.Drivers = dipper.MustDeepCopyMap(s.Drivers)
 	err := mergo.Merge(d, s, mergo.WithOverride, mergo.WithAppendSlice)
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
 
-	return err
+	return nil
 }
 
 func addSubsystem(d *System, s System, key string) {
@@ -304,7 +308,7 @@ func mergeSystem(d *System, s System) error {
 		if exist, ok := d.Triggers[name]; ok {
 			err := mergo.Merge(&exist, trigger, mergo.WithOverride, mergo.WithAppendSlice)
 			if err != nil {
-				return err
+				return fmt.Errorf("%w", err)
 			}
 			if exist.Description == "" {
 				exist.Description = trigger.Description
@@ -326,7 +330,7 @@ func mergeSystem(d *System, s System) error {
 		if ok {
 			err := mergo.Merge(&exist, function, mergo.WithOverride, mergo.WithAppendSlice)
 			if err != nil {
-				return err
+				return fmt.Errorf("%w", err)
 			}
 			if exist.Description == "" {
 				exist.Description = function.Description
@@ -342,7 +346,7 @@ func mergeSystem(d *System, s System) error {
 
 	err := mergo.Merge(&d.Data, s.Data, mergo.WithOverride, mergo.WithAppendSlice)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w", err)
 	}
 
 	d.Extends = append(d.Extends, s.Extends...)

--- a/internal/config/file_reference.go
+++ b/internal/config/file_reference.go
@@ -7,6 +7,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path"
@@ -15,15 +16,13 @@ import (
 	"github.com/honeydipper/honeydipper/pkg/dipper"
 )
 
-const (
-	// FileError is all errors when accessing a file.
-	FileError dipper.Error = "file error"
-)
+// ErrFileError is all errors when accessing a file.
+var ErrFileError = errors.New("file error")
 
 func (c *Repo) normalizeFilePath(cwd string, file string) string {
 	fullpath := path.Clean(path.Join(c.root, cwd, file))
 	if !strings.HasPrefix(fullpath, c.root+"/") {
-		panic(fmt.Errorf("invalid path: %s: %w", fullpath, FileError))
+		panic(fmt.Errorf("%w: invalid path: %s", ErrFileError, fullpath))
 	}
 
 	return fullpath

--- a/internal/driver/builtin.go
+++ b/internal/driver/builtin.go
@@ -42,10 +42,10 @@ func builtinPath() string {
 func (d *BuiltinDriver) Acquire() {
 	shortName, ok := d.meta.HandlerData["shortName"].(string)
 	if !ok || shortName == "" {
-		panic(fmt.Errorf("shortName is missing for builtin driver: %s: %w", d.meta.Name, DriverError))
+		panic(fmt.Errorf("%w: shortName is missing for builtin driver: %s", ErrDriverError, d.meta.Name))
 	}
 	if strings.ContainsRune(shortName, os.PathSeparator) {
-		panic(fmt.Errorf("shortName has path separator in driver: %s: %w", d.meta.Name, DriverError))
+		panic(fmt.Errorf("%w: shortName has path separator in driver: %s", ErrDriverError, d.meta.Name))
 	}
 
 	d.meta.Executable = filepath.Join(builtinPath(), shortName)
@@ -65,7 +65,7 @@ func (d *BuiltinDriver) Prepare() {
 	}
 
 	if !ok {
-		panic(fmt.Errorf("arguments in driver %s should be a list of strings: %w", d.meta.Name, DriverError))
+		panic(fmt.Errorf("%w: arguments in driver %s should be a list of strings", ErrDriverError, d.meta.Name))
 	}
 
 	for _, v := range argsList {

--- a/internal/driver/builtin_test.go
+++ b/internal/driver/builtin_test.go
@@ -32,15 +32,15 @@ func TestBuiltinAcquire(t *testing.T) {
 	testCases := map[string]interface{}{
 		"panic when shortName is missing": []interface{}{
 			&BuiltinDriver{meta: &Meta{HandlerData: map[string]interface{}{}}},
-			"shortName is missing ", // error prefix
+			"driver error: shortName is missing ", // error prefix
 		},
 		"panic when using relative path with / in shortName": []interface{}{
 			&BuiltinDriver{meta: &Meta{HandlerData: map[string]interface{}{"shortName": "../fakecmd"}}},
-			"shortName has path separator ", // error prefix
+			"driver error: shortName has path separator ", // error prefix
 		},
 		"panic when using absolute path with / in shortName": []interface{}{
 			&BuiltinDriver{meta: &Meta{HandlerData: map[string]interface{}{"shortName": "/usr/bin/fakecmd"}}},
-			"shortName has path separator ", // error prefix
+			"driver error: shortName has path separator ", // error prefix
 		},
 		"has full path in Executable": []interface{}{
 			&BuiltinDriver{meta: &Meta{HandlerData: map[string]interface{}{"shortName": "testDriver"}}},
@@ -88,7 +88,7 @@ func TestBuiltinPrepare(t *testing.T) {
 		},
 		"panic when arguments is not a list": []interface{}{
 			&BuiltinDriver{meta: &Meta{HandlerData: map[string]interface{}{"arguments": false}}},
-			"arguments in driver ", // error prefix
+			"driver error: arguments in driver ", // error prefix
 		},
 	}
 

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -7,6 +7,7 @@
 package driver
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,13 +18,11 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-const (
-	// DriverError is the base for all driver related error.
-	DriverError dipper.Error = "driver error"
+// ErrDriverError is the base for all driver related error.
+var ErrDriverError = errors.New("driver error")
 
-	// DriverMessageBuffer is the size of the driver message buffer.
-	DriverMessageBuffer = 10
-)
+// DriverMessageBuffer is the size of the driver message buffer.
+const DriverMessageBuffer = 10
 
 // Handler provides common functions for handling a driver.
 type Handler interface {
@@ -44,7 +43,7 @@ func NewDriver(data map[string]interface{}) Handler {
 	}
 
 	if meta.Name == "" {
-		panic(fmt.Errorf("driver name missing: %+v: %w", meta, DriverError))
+		panic(fmt.Errorf("%w: driver name missing: %+v", ErrDriverError, meta))
 	}
 
 	var dh Handler
@@ -53,14 +52,14 @@ func NewDriver(data map[string]interface{}) Handler {
 	case "builtin":
 		dh = NewBuiltinDriver(&meta)
 	default:
-		panic(fmt.Errorf("unsupported driver type: %s: %w", meta.Type, DriverError))
+		panic(fmt.Errorf("%w: unsupported driver type: %s", ErrDriverError, meta.Type))
 	}
 
 	dh.Acquire()
 	dh.Prepare()
 
 	if meta.Executable == "" {
-		panic(fmt.Errorf("executable not defined for driver: %s: %w", meta.Name, DriverError))
+		panic(fmt.Errorf("%w: executable not defined for driver: %s", ErrDriverError, meta.Name))
 	}
 
 	return dh

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -21,19 +21,19 @@ func TestDriverNewDriver(t *testing.T) {
 	testCases := map[string]interface{}{
 		"panic when driver name is missing": []interface{}{
 			map[string]interface{}{}, // driver meta
-			"driver name missing: ",  // error prefix
+			"driver error: driver name missing: ",  // error prefix
 		},
 		"panic when driver type is missing": []interface{}{
 			map[string]interface{}{"name": "test"}, // driver meta
-			"unsupported driver type: ",            // error prefix
+			"driver error: unsupported driver type: ",            // error prefix
 		},
 		"panic when driver type is unknown": []interface{}{
 			map[string]interface{}{"name": "test", "type": "faketype"}, // driver meta
-			"unsupported driver type: ",                                // error prefix
+			"driver error: unsupported driver type: ",                                // error prefix
 		},
 		"panic when builtin driver data missing": []interface{}{
 			map[string]interface{}{"name": "test", "type": "builtin"}, // driver meta
-			"shortName is missing for builtin driver: ",               // error prefix
+			"driver error: shortName is missing for builtin driver: ",               // error prefix
 		},
 	}
 

--- a/internal/service/operator.go
+++ b/internal/service/operator.go
@@ -7,6 +7,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -16,12 +17,12 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-const (
-	// OperatorError is the base for all operator related error.
-	OperatorError dipper.Error = "operator error"
-)
+var (
+	// ErrOperatorError is the base for all operator related error.
+	ErrOperatorError = errors.New("operator error")
 
-var operator *Service
+	operator *Service
+)
 
 // StartOperator starts the operator service.
 func StartOperator(cfg *config.Config) {
@@ -76,7 +77,7 @@ func handleEventbusCommand(msg *dipper.Message) []RoutedMessage {
 
 	worker := operator.getDriverRuntime("driver:" + driver)
 	if worker == nil {
-		panic(fmt.Errorf("not defined: %s: %w", driver, OperatorError))
+		panic(fmt.Errorf("%w: not defined: %s", ErrOperatorError, driver))
 	}
 	finalParams := params
 	if params != nil {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -202,7 +202,7 @@ func TestServiceRemoveEmitter(t *testing.T) {
 		defer daemon.Children.Done()
 
 		assert.NotPanics(t, func() {
-			for i := 0; i < 50; i = i + 1 {
+			for i := 0; i < 50; i++ {
 				select {
 				case svc.driverRuntimes["driver:d1"].Stream <- dipper.Message{
 					Channel: "test",
@@ -299,7 +299,7 @@ func TestServiceEmitterCrashing(t *testing.T) {
 		defer daemon.Children.Done()
 
 		assert.NotPanics(t, func() {
-			for i := 0; i < 50; i = i + 1 {
+			for i := 0; i < 50; i++ {
 				select {
 				case svc.driverRuntimes["driver:d1"].Stream <- dipper.Message{
 					Channel: "test",
@@ -376,7 +376,7 @@ func TestServiceReplaceEmitter(t *testing.T) {
 		defer daemon.Children.Done()
 
 		assert.NotPanics(t, func() {
-			for i := 0; i < 50; i = i + 1 {
+			for i := 0; i < 50; i++ {
 				select {
 				case svc.driverRuntimes["driver:d1"].Stream <- dipper.Message{
 					Channel: "test",

--- a/internal/workflow/session.go
+++ b/internal/workflow/session.go
@@ -8,6 +8,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -15,10 +16,8 @@ import (
 	"github.com/honeydipper/honeydipper/pkg/dipper"
 )
 
-const (
-	// WorkflowError is the base error for all workflow related errors.
-	WorkflowError dipper.Error = "workflow error"
-)
+// ErrWorkflowError is the base error for all workflow related errors.
+var ErrWorkflowError = errors.New("workflow error")
 
 // Session is the data structure about a running workflow and its definition.
 type Session struct {
@@ -222,7 +221,7 @@ func (w *Session) initCTX(msg *dipper.Message) {
 			}
 			name, ok := n.(string)
 			if !ok {
-				panic(fmt.Errorf("expected list of strings in contexts in workflow: %s: %w", w.workflow.Name, WorkflowError))
+				panic(fmt.Errorf("%w: expected list of strings in contexts in workflow: %s", ErrWorkflowError, w.workflow.Name))
 			}
 			if name != "" {
 				// at this stage the hooks flag is added only through `context` not `contexts`
@@ -413,7 +412,7 @@ func (w *Session) prepare(msg *dipper.Message, parent interface{}, ctx map[strin
 func (w *Session) createChildSessionWithName(name string, msg *dipper.Message) *Session {
 	src, ok := w.store.Helper.GetConfig().DataSet.Workflows[name]
 	if !ok {
-		panic(fmt.Errorf("not defined: %s: %w", name, WorkflowError))
+		panic(fmt.Errorf("%w: not defined: %s", ErrWorkflowError, name))
 	}
 	if src.Name == "" {
 		src.Name = name

--- a/pkg/dipper/comm.go
+++ b/pkg/dipper/comm.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -124,7 +125,7 @@ func FetchRawMessage(in io.Reader) (msg *Message) {
 	)
 
 	_, err := fmt.Fscanln(in, &channel, &subject, &numLabels, &size)
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		panic(err)
 	} else if err != nil {
 		errMsg := fmt.Sprintf("%+v", err)
@@ -258,12 +259,12 @@ func MessageCopy(m *Message) (*Message, error) {
 	dec := gob.NewDecoder(&buf)
 	err := enc.Encode(*m)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w", err)
 	}
 	var mcopy Message
 	err = dec.Decode(&mcopy)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w", err)
 	}
 
 	return &mcopy, nil

--- a/pkg/dipper/commandHandler.go
+++ b/pkg/dipper/commandHandler.go
@@ -50,7 +50,7 @@ func (p *CommandProvider) ReturnError(call *Message, pattern string, args ...int
 	})
 	Logger.Warningf("[operator] %s", errText)
 
-	return Error(errText)
+	return errors.New(errText)
 }
 
 // Return : return a value to rpc caller.

--- a/pkg/dipper/errorHandling.go
+++ b/pkg/dipper/errorHandling.go
@@ -16,7 +16,7 @@ func (e Error) Error() string {
 	return string(e)
 }
 
-// Is check if a given error matches this error.
+// Is : check whether the given error matches this error.
 func (e Error) Is(target error) bool {
 	if t, ok := target.(Error); ok {
 		return t == e

--- a/pkg/dipper/errorHandling.go
+++ b/pkg/dipper/errorHandling.go
@@ -8,23 +8,6 @@ package dipper
 
 import "github.com/go-errors/errors"
 
-// Error type is a simple error type used by dipper.
-type Error string
-
-// Error gives the message of the Error.
-func (e Error) Error() string {
-	return string(e)
-}
-
-// Is : check whether the given error matches this error.
-func (e Error) Is(target error) bool {
-	if t, ok := target.(Error); ok {
-		return t == e
-	}
-
-	return false
-}
-
 // SafeExitOnError : use this function in defer statement to ignore errors.
 func SafeExitOnError(args ...interface{}) {
 	if r := recover(); r != nil {

--- a/pkg/dipper/interpolation.go
+++ b/pkg/dipper/interpolation.go
@@ -8,6 +8,7 @@ package dipper
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 	"text/template"
@@ -17,10 +18,8 @@ import (
 	"github.com/ghodss/yaml"
 )
 
-const (
-	// InterpolationError represents all errors thrown due to failure to interpolate.
-	InterpolationError Error = "config error"
-)
+// ErrInterpolationError represents all errors thrown due to failure to interpolate.
+var ErrInterpolationError = errors.New("config error")
 
 // FuncMap : used to add functions to the go templates.
 var FuncMap = template.FuncMap{
@@ -87,13 +86,13 @@ func InterpolateDollarStr(v string, data interface{}) interface{} {
 
 	quote := strings.IndexAny(parsed, "\"'`")
 	if allowNull && quote >= 0 {
-		panic(fmt.Errorf("allow nil combine with default value: %s: %w", v, InterpolationError))
+		panic(fmt.Errorf("%w: allow nil combine with default value: %s", ErrInterpolationError, v))
 	}
 
 	var keys []string
 	if quote > 0 {
 		if parsed[quote-1] != ',' {
-			panic(fmt.Errorf("missing comma: %s: %w", v, InterpolationError))
+			panic(fmt.Errorf("%w: missing comma: %s", ErrInterpolationError, v))
 		}
 		keys = strings.Split(parsed[:quote-1], ",")
 	} else if quote < 0 {
@@ -113,7 +112,7 @@ func InterpolateDollarStr(v string, data interface{}) interface{} {
 
 	if quote >= 0 {
 		if parsed[quote] != parsed[len(parsed)-1] {
-			panic(fmt.Errorf("quotes not matching: %s: %w", parsed, InterpolationError))
+			panic(fmt.Errorf("%w: quotes not matching: %s", ErrInterpolationError, parsed))
 		}
 
 		return parsed[quote+1 : len(parsed)-1]
@@ -122,7 +121,7 @@ func InterpolateDollarStr(v string, data interface{}) interface{} {
 	if allowNull {
 		return nil
 	}
-	panic(fmt.Errorf("invalid path: %s: %w", v[1:], InterpolationError))
+	panic(fmt.Errorf("%w: invalid path: %s", ErrInterpolationError, v[1:]))
 }
 
 // Interpolate : go through the map data structure to find and parse all the templates.

--- a/pkg/dipper/mapUtils.go
+++ b/pkg/dipper/mapUtils.go
@@ -7,6 +7,7 @@
 package dipper
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -16,13 +17,8 @@ import (
 	"github.com/imdario/mergo"
 )
 
-const (
-	// MapError are all errors thrown in map manipulation.
-	MapError Error = "map error"
-
-	// MergeError are all errors throw during map merge and combin.
-	MergeError Error = "merge error"
-)
+// ErrMapError are all errors thrown in map manipulation.
+var ErrMapError = errors.New("map error")
 
 // GetMapData : get the data from the deep map following a KV path.
 func GetMapData(from interface{}, path string) (ret interface{}, ok bool) {
@@ -65,7 +61,7 @@ func GetMapData(from interface{}, path string) (ret interface{}, ok bool) {
 func MustGetMapData(from interface{}, path string) interface{} {
 	ret, ok := GetMapData(from, path)
 	if !ok {
-		panic(fmt.Errorf("path not valid: %s: %w", path, MapError))
+		panic(fmt.Errorf("%w: path not valid: %s", ErrMapError, path))
 	}
 
 	return ret
@@ -129,7 +125,7 @@ func MustGetMapDataBool(from interface{}, path string) bool {
 			return flag
 		}
 	}
-	panic(fmt.Errorf("not a bool: %s: %w", path, MapError))
+	panic(fmt.Errorf("%w: not a bool: %s", ErrMapError, path))
 }
 
 // Recursive : enumerate all the data element deep into the map call the function provided.
@@ -192,7 +188,7 @@ func RecursiveWithPrefix(
 					vparent.Field(key.(int)).Set(vval)
 				}
 			default:
-				panic(fmt.Errorf("unable to change: %s in %s: %w", key, prefixes, MapError))
+				panic(fmt.Errorf("%w: unable to change: %s in %s", ErrMapError, key, prefixes))
 			}
 		}
 	}
@@ -273,7 +269,7 @@ func DeepCopyMap(m map[string]interface{}) (map[string]interface{}, error) {
 	}
 	retMap, ok := ret.(map[string]interface{})
 	if !ok {
-		return nil, fmt.Errorf("not a map: %w", MapError)
+		return nil, fmt.Errorf("%w: not a map", ErrMapError)
 	}
 
 	return retMap, nil


### PR DESCRIPTION
#### Description
- update golang-ci in Circlel config to latest
- update pinned golangci-lint-version to match version in CI
- wrap errors
- use builtin errors (refactor by @Charles546)
- switch from a = a * b to a *= b and i = i + 1 to i++
- disable exhaustivestruct
- other minor formatting / stylle changes

#### This PR fixes the following issues
Closes #336 