### PR TITLE
test(api): longer timeout in api test

### DIFF
--- a/internal/api/test_fixtures/TypeAllAPI.yaml
+++ b/internal/api/test_fixtures/TypeAllAPI.yaml
@@ -8,6 +8,11 @@ def:
   reqType: 1
   service: foo
   object: event
+  ackTimeout: 1000
+
+# store config
+config:
+  writeTimeout: 2000
 
 # mock incoming call
 path: /test_type_all

--- a/internal/api/test_fixtures/TypeFirstAPI.yaml
+++ b/internal/api/test_fixtures/TypeFirstAPI.yaml
@@ -8,6 +8,11 @@ def:
   reqType: 0
   service: foo
   object: event
+  ackTimeout: 1000
+
+# store config
+config:
+  writeTimeout: 2000
 
 # mock incoming call
 path: /test_type_first


### PR DESCRIPTION

#### Description

Keeps getting timeout in Circle test, it is unpredictable
how long it takes for a go `channel` to communicate between
two go routines. Using a longer timeout to avoid test
failures.

#### This PR fixes the following issues
N/A