### PR TITLE
test(api): timeout for TypeAllAPITimeout test

### DIFF
--- a/internal/api/test_fixtures/TypeAllAPITimeout.yaml
+++ b/internal/api/test_fixtures/TypeAllAPITimeout.yaml
@@ -8,7 +8,12 @@ def:
   reqType: 1
   service: foo
   object: event
+  ackTimeout: 1000
   timeout: 1
+
+# store config
+config:
+  writeTimeout: 2000
 
 # mock incoming call
 path: /test_type_all


### PR DESCRIPTION
#### Description

This test also needs a longer `ackTimeout`.

#### This PR fixes the following issues
N/A