### PR TITLE
test(api): response test timing issue

### DIFF
--- a/internal/api/response_test.go
+++ b/internal/api/response_test.go
@@ -107,7 +107,7 @@ func TestTypeAllAPIResponse(t *testing.T) {
 		},
 		returnMessages: []ReturnMessage{
 			{
-				Delay: 30 * time.Millisecond,
+				Delay: 3000 * time.Millisecond,
 				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",
@@ -119,7 +119,7 @@ func TestTypeAllAPIResponse(t *testing.T) {
 				},
 			},
 			{
-				Delay: 30 * time.Millisecond,
+				Delay: 3000 * time.Millisecond,
 				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",
@@ -164,7 +164,7 @@ func TestTypeFirstAPIResponse(t *testing.T) {
 		},
 		returnMessages: []ReturnMessage{
 			{
-				Delay: 30 * time.Millisecond,
+				Delay: 3000 * time.Millisecond,
 				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",
@@ -210,7 +210,7 @@ func TestTypeMatchAPIResponse(t *testing.T) {
 		},
 		returnMessages: []ReturnMessage{
 			{
-				Delay: 30 * time.Millisecond,
+				Delay: 3000 * time.Millisecond,
 				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",
@@ -222,7 +222,7 @@ func TestTypeMatchAPIResponse(t *testing.T) {
 				},
 			},
 			{
-				Delay: 30 * time.Millisecond,
+				Delay: 3000 * time.Millisecond,
 				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",
@@ -266,7 +266,7 @@ func TestTypeMatchAPIResponseReturnError(t *testing.T) {
 		},
 		returnMessages: []ReturnMessage{
 			{
-				Delay: 30 * time.Millisecond,
+				Delay: 3000 * time.Millisecond,
 				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",
@@ -278,7 +278,7 @@ func TestTypeMatchAPIResponseReturnError(t *testing.T) {
 				},
 			},
 			{
-				Delay: 30 * time.Millisecond,
+				Delay: 3000 * time.Millisecond,
 				Msg: &dipper.Message{
 					Channel: "eventbus",
 					Subject: "api",


### PR DESCRIPTION

#### Description

Similar to request tests issue in #351 and #352, response
tests also have the timing issues, probably due to that Circle
steals too much CPU cycles from the container. Increasing the
timeout should make it less likely, if not completely avoid
the timing issues.

#### This PR fixes the following issues
N/A