### PR TITLE
fix(workflow): avoid concurrent map write in mergeContext

### DIFF
--- a/internal/workflow/continue.go
+++ b/internal/workflow/continue.go
@@ -87,6 +87,11 @@ func (w *Session) routeNext(msg *dipper.Message) int {
 
 // mergeContext merges child workflow exported context to parent workflow.
 func (w *Session) mergeContext(exports []map[string]interface{}) {
+	// for multi-thread workflows, we might have multiple child workflows
+	// complete at the same time, and try merging context back at the same
+	// time and causing concurrent map write, thus using lock to avoid that.
+	w.ctxLock.Lock()
+	defer w.ctxLock.Unlock()
 	for _, export := range exports {
 		w.ctx = dipper.MergeMap(w.ctx, export)
 		w.processNoExport(export)

--- a/internal/workflow/session.go
+++ b/internal/workflow/session.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/honeydipper/honeydipper/internal/config"
 	"github.com/honeydipper/honeydipper/pkg/dipper"
@@ -29,6 +30,7 @@ type Session struct {
 	loopCount      int   // counter for looping
 	parent         string
 	ctx            map[string]interface{}
+	ctxLock        *sync.Mutex
 	event          map[string]interface{}
 	exported       []map[string]interface{}
 	elseBranch     *config.Workflow

--- a/internal/workflow/store.go
+++ b/internal/workflow/store.go
@@ -7,6 +7,8 @@
 package workflow
 
 import (
+	"sync"
+
 	"github.com/honeydipper/honeydipper/internal/config"
 	"github.com/honeydipper/honeydipper/internal/daemon"
 	"github.com/honeydipper/honeydipper/pkg/dipper"
@@ -50,6 +52,7 @@ func (s *SessionStore) newSession(parent string, eventUUID string, wf *config.Wo
 		store:    s,
 		EventID:  eventUUID,
 		workflow: wf,
+		ctxLock:  &sync.Mutex{},
 	}
 
 	performing := w.setPerforming("")


### PR DESCRIPTION
#### Description
In mutli-threaded workflows, multiple child workflows might complete
at the same time, and might try merging their exports at the same time.
To avoid concurrent map write, we use a lock to ensure only one thread
can run `mergeContext`

#### This PR fixes the following issues
Fixes #356 
