### PR TITLE
fix(config): avoid concurrent map write in config

### DIFF
--- a/cmd/honeydipper/integration_test.go
+++ b/cmd/honeydipper/integration_test.go
@@ -60,6 +60,7 @@ func intTestDaemonStartup(t *testing.T) {
 		workingBranch = ref[len(ref)-1]
 	}
 	cfg := config.Config{
+		Services: []string{"engine", "receiver", "operator"},
 		InitRepo: config.RepoInfo{
 			Repo:   "../..",
 			Branch: workingBranch,

--- a/cmd/honeydipper/main.go
+++ b/cmd/honeydipper/main.go
@@ -61,6 +61,9 @@ func initEnv() {
 	initFlags()
 	flag.Parse()
 	cfg = config.Config{InitRepo: config.RepoInfo{}, Services: flag.Args()}
+	if len(cfg.Services) == 0 {
+		cfg.Services = []string{"engine", "receiver", "operator", "api"}
+	}
 
 loop:
 	for _, s := range cfg.Services {
@@ -110,11 +113,7 @@ func start() {
 	// reset logging with configured loglevel
 	getLogger()
 
-	services := cfg.Services
-	if len(services) == 0 {
-		services = []string{"engine", "receiver", "operator", "api"}
-	}
-	for _, s := range services {
+	for _, s := range cfg.Services {
 		switch s {
 		case "engine":
 			service.StartEngine(&cfg)
@@ -140,7 +139,7 @@ func reload() {
 }
 
 func getLogger() {
-	levelstr, ok := cfg.GetDriverDataStr("daemon.loglevel")
+	levelstr, ok := cfg.GetStagedDriverDataStr("daemon.loglevel")
 	if !ok {
 		levelstr = "INFO"
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,7 +201,9 @@ func (c *Config) AdvanceStage(service string, stage int, fns ...dipper.ItemProce
 	case c.Stage < stage-1:
 		panic(ErrConfigRollback)
 	default:
-		dipper.WaitGroupDone(stageWG)
+		if !dipper.WaitGroupDone(stageWG) {
+			panic(ErrConfigRollback)
+		}
 		locker.Unlock()
 		stageWG.Wait()
 		locker.Lock()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,7 +120,7 @@ func (c *Config) Bootstrap(wd string) {
 func (c *Config) Watch() {
 	for {
 		interval := time.Minute
-		if intervalStr, ok := c.GetDriverDataStr("daemon.configCheckInterval"); ok {
+		if intervalStr, ok := c.GetStagedDriverDataStr("daemon.configCheckInterval"); ok {
 			value, err := time.ParseDuration(intervalStr)
 			if err != nil {
 				dipper.Logger.Warningf("invalid drivers.daemon.configCheckInterval %v", err)
@@ -130,7 +130,7 @@ func (c *Config) Watch() {
 		}
 		time.Sleep(interval)
 
-		if watch, ok := dipper.GetMapDataBool(c.DataSet.Drivers, "daemon.watchConfig"); !ok || watch {
+		if watch, ok := dipper.GetMapDataBool(c.Staged.Drivers, "daemon.watchConfig"); !ok || watch {
 			c.Refresh()
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-errors/errors"
@@ -20,10 +21,36 @@ import (
 	"github.com/imdario/mergo"
 )
 
+const (
+	// StageLoading means that the config is being loaded.
+	StageLoading = iota
+	// StageBooting means that the consumers are loading only essential config.
+	StageBooting
+	// StageDiscovering means discovering dynamic config data for drivers.
+	StageDiscovering
+	// StageServing means all config should be processed and serving.
+	StageServing
+)
+
+var (
+	// StageNames maps to the actual stage integers.
+	StageNames = []string{
+		"Loading",
+		"Booting",
+		"Discovering",
+		"Serving",
+	}
+
+	// ErrConfigRollback happens when daemon decides to rollback during reload.
+	ErrConfigRollback = errors.New("config rollback")
+)
+
 //nolint:gochecknoinits
 func init() {
 	gob.Register(map[string]interface{}{})
 	gob.Register([]interface{}{})
+	gob.Register(System{})
+	gob.Register(DataSet{})
 }
 
 // Config is a wrapper around the final complete configration of the daemon.
@@ -44,11 +71,45 @@ type Config struct {
 	IsDocGen      bool
 	DocSrc        string
 	DocDst        string
+	Locker        *sync.Mutex
+	RawData       *DataSet
+	Stage         int
+	Staged        *DataSet
+	StageWG       []*sync.WaitGroup
+}
+
+// ResetStage resets the stage of the config.
+func (c *Config) ResetStage() {
+	locker := &sync.Mutex{}
+	locker.Lock()
+	defer locker.Unlock()
+	if c.Locker != nil {
+		c.Locker.Lock()
+		defer c.Locker.Unlock()
+	}
+	c.Locker = locker
+	c.Stage = StageLoading
+
+	if c.StageWG != nil {
+		for _, wg := range c.StageWG {
+			dipper.WaitGroupDoneAll(wg)
+		}
+	}
+	c.StageWG = make([]*sync.WaitGroup, 3)
+	c.StageWG[StageLoading] = &sync.WaitGroup{}
+	c.StageWG[StageLoading].Add(len(c.Services))
+	c.StageWG[StageBooting] = &sync.WaitGroup{}
+	c.StageWG[StageBooting].Add(len(c.Services))
+	c.StageWG[StageDiscovering] = &sync.WaitGroup{}
+	c.StageWG[StageDiscovering].Add(len(c.Services))
 }
 
 // Bootstrap loads the configuration during daemon bootstrap.
 // WorkingDir is where git will clone remote repo into.
 func (c *Config) Bootstrap(wd string) {
+	if !c.IsConfigCheck && !c.IsDocGen {
+		c.ResetStage()
+	}
 	c.WorkingDir = wd
 	c.loadRepo(c.InitRepo)
 	c.assemble()
@@ -83,7 +144,8 @@ func (c *Config) Refresh() {
 		changeDetected = (repoRuntime.refreshRepo() || changeDetected)
 	}
 	if changeDetected {
-		c.LastRunningConfig.DataSet = c.DataSet
+		c.ResetStage()
+		c.LastRunningConfig.DataSet = c.RawData
 		c.LastRunningConfig.Loaded = map[RepoInfo]*Repo{}
 		for k, v := range c.Loaded {
 			c.LastRunningConfig.Loaded[k] = v
@@ -109,12 +171,13 @@ func (c *Config) Refresh() {
 // It requires that the OnChange variable is defined prior to invoking the function.
 func (c *Config) RollBack() {
 	if c.LastRunningConfig.DataSet != nil && c.LastRunningConfig.DataSet != c.DataSet {
-		c.DataSet = c.LastRunningConfig.DataSet
+		c.Staged = c.LastRunningConfig.DataSet
 		c.Loaded = map[RepoInfo]*Repo{}
 		for k, v := range c.LastRunningConfig.Loaded {
 			c.Loaded[k] = v
 		}
 		dipper.Logger.Warning("config rolled back to last running version")
+		c.ResetStage()
 		if c.OnChange != nil {
 			c.OnChange()
 		}
@@ -122,20 +185,71 @@ func (c *Config) RollBack() {
 }
 
 func (c *Config) assemble() {
-	c.DataSet, c.Loaded = c.Loaded[c.InitRepo].assemble(&(DataSet{}), map[RepoInfo]*Repo{})
-	c.extendAllSystems()
-	c.parseWorkflowRegex()
+	c.Staged, c.Loaded = c.Loaded[c.InitRepo].assemble(&(DataSet{}), map[RepoInfo]*Repo{})
 }
 
-func (c *Config) parseWorkflowRegex() {
-	var processor func(key string, val interface{}) (interface{}, bool)
+// AdvanceStage processes the config and advances the config into the new stage.
+func (c *Config) AdvanceStage(service string, stage int, fns ...dipper.ItemProcessor) {
+	c.Locker.Lock()
+	defer c.Locker.Unlock()
+	locker := c.Locker
+	stageWG := c.StageWG[c.Stage]
+
+	switch {
+	case c.Stage >= stage:
+		return
+	case c.Stage < stage-1:
+		panic(ErrConfigRollback)
+	default:
+		dipper.WaitGroupDone(stageWG)
+		locker.Unlock()
+		stageWG.Wait()
+		locker.Lock()
+
+		if locker != c.Locker {
+			panic(ErrConfigRollback)
+		}
+
+		dipper.Logger.Infof("[%s] service reached stage %s", service, StageNames[stage])
+		for _, fn := range fns {
+			c.RecursiveStaged(fn)
+		}
+
+		switch stage {
+		case StageBooting:
+			c.RawData = &DataSet{}
+			dipper.Must(DeepCopy(c.Staged, c.RawData))
+		case StageDiscovering:
+			c.extendAllSystems()
+		case StageServing:
+			c.RecursiveStaged(dipper.RegexParser)
+
+			c.DataSet = c.Staged
+		}
+		c.Stage = stage
+	}
+}
+
+// recursive iterates all items and their children to parse the values with give processor.
+func (c *Config) recursive(f dipper.ItemProcessor, stage bool) {
+	var processor dipper.ItemProcessor
+	target := c.DataSet
+	if stage {
+		target = c.Staged
+	}
 
 	processor = func(name string, val interface{}) (interface{}, bool) {
 		switch v := val.(type) {
 		case string:
-			return dipper.RegexParser(name, val)
+			nv, ok := f(name, val)
+			if stage {
+				return nv, ok
+			}
+			// only staged data can be changed.
+			return nil, false
 		case Rule:
 			dipper.Recursive(&v.Do, processor)
+			dipper.Recursive(&v.When, processor)
 		case Workflow:
 			dipper.Recursive(v.Match, processor)
 			dipper.Recursive(v.UnlessMatch, processor)
@@ -143,14 +257,44 @@ func (c *Config) parseWorkflowRegex() {
 			dipper.Recursive(v.Threads, processor)
 			dipper.Recursive(v.Else, processor)
 			dipper.Recursive(v.Cases, processor)
+		case Trigger:
+			dipper.Recursive(v.Match, processor)
+			dipper.Recursive(v.Parameters, processor)
+		case Function:
+			dipper.Recursive(v.Parameters, processor)
+		case System:
+			dipper.Recursive(v.Data, processor)
+			dipper.Recursive(v.Triggers, processor)
+			dipper.Recursive(v.Functions, processor)
 		}
 
 		return nil, false
 	}
 
-	dipper.Recursive(c.DataSet.Workflows, processor)
-	dipper.Recursive(c.DataSet.Rules, processor)
-	dipper.Recursive(c.DataSet.Contexts, dipper.RegexParser)
+	dipper.Logger.Debugf("[config] recursive processing workflows ...")
+	dipper.Recursive(target.Workflows, processor)
+	dipper.Logger.Debugf("[config] recursive processing rules ...")
+	dipper.Recursive(target.Rules, processor)
+	dipper.Logger.Debugf("[config] recursive processing systems ...")
+	dipper.Recursive(target.Systems, processor)
+	dipper.Logger.Debugf("[config] recursive processing contexts ...")
+	dipper.Recursive(target.Contexts, f)
+	dipper.Logger.Debugf("[config] recursive processing drivers ...")
+	for k, v := range target.Drivers {
+		if k != "daemon" {
+			dipper.Recursive(v, f)
+		}
+	}
+}
+
+// RecursiveStaged recursively process staged data.
+func (c *Config) RecursiveStaged(f dipper.ItemProcessor) {
+	c.recursive(f, true)
+}
+
+// Recursive recursively process readonly config data.
+func (c *Config) Recursive(f dipper.ItemProcessor) {
+	c.recursive(f, false)
 }
 
 func (c *Config) isRepoLoaded(repo RepoInfo) bool {
@@ -168,6 +312,29 @@ func (c *Config) loadRepo(repo RepoInfo) {
 		}
 		c.Loaded[repo] = repoRuntime
 	}
+}
+
+// GetStagedDriverData gets an item from a staged driver's data block.
+//   conn,ok := c.GetStagedDriverData("redis.connection")
+// The function returns an interface{} that could be anything.
+func (c *Config) GetStagedDriverData(path string) (ret interface{}, ok bool) {
+	if c.Staged == nil || c.Staged.Drivers == nil {
+		return nil, false
+	}
+
+	return dipper.GetMapData(c.Staged.Drivers, path)
+}
+
+// GetStagedDriverDataStr gets an item from a staged driver's data block.
+//   logLevel,ok := c.GetStagedDriverData("daemon.loglevel")
+// The function assume the return value is a string will do a type assertion.
+// upon returning.
+func (c *Config) GetStagedDriverDataStr(path string) (ret string, ok bool) {
+	if c.Staged == nil || c.Staged.Drivers == nil {
+		return "", false
+	}
+
+	return dipper.GetMapDataStr(c.Staged.Drivers, path)
 }
 
 // GetDriverData gets an item from a driver's data block.
@@ -195,7 +362,7 @@ func (c *Config) GetDriverDataStr(path string) (ret string, ok bool) {
 
 func (c *Config) extendSystem(processed map[string]bool, system string) {
 	var merged System
-	current := c.DataSet.Systems[system]
+	current := c.Staged.Systems[system]
 	for _, extend := range current.Extends {
 		parts := strings.Split(extend, "=")
 		var base, subKey string
@@ -210,8 +377,9 @@ func (c *Config) extendSystem(processed map[string]bool, system string) {
 			c.extendSystem(processed, base)
 		}
 
-		baseSys := c.DataSet.Systems[base]
-		baseCopy := dipper.Must(SystemCopy(&baseSys)).(*System)
+		baseSys := c.Staged.Systems[base]
+		baseCopy := &System{}
+		dipper.Must(DeepCopy(&baseSys, baseCopy))
 
 		if subKey == "" {
 			dipper.Must(mergeSystem(&merged, *baseCopy))
@@ -220,63 +388,62 @@ func (c *Config) extendSystem(processed map[string]bool, system string) {
 		}
 	}
 	dipper.Must(mergeSystem(&merged, current))
-	c.DataSet.Systems[system] = merged
+	c.Staged.Systems[system] = merged
 	processed[system] = true
 }
 
 func (c *Config) extendAllSystems() {
 	processed := map[string]bool{}
-	for name := range c.DataSet.Systems {
+	for name := range c.Staged.Systems {
 		if _, ok := processed[name]; !ok {
 			c.extendSystem(processed, name)
 		}
 	}
 }
 
-// SystemCopy performs a deep copy of the given system.
-func SystemCopy(s *System) (*System, error) {
-	var buf bytes.Buffer
+// DeepCopy performs a deep copy of the object.
+func DeepCopy(s interface{}, d interface{}) error {
 	if s == nil {
-		return nil, nil
-	}
-	enc := gob.NewEncoder(&buf)
-	dec := gob.NewDecoder(&buf)
-	err := enc.Encode(*s)
-	if err != nil {
-		return nil, fmt.Errorf("%w", err)
-	}
-	var scopy System
-	err = dec.Decode(&scopy)
-	if err != nil {
-		return nil, fmt.Errorf("%w", err)
+		return nil
 	}
 
-	return &scopy, nil
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	e := enc.Encode(s)
+	if e != nil {
+		return fmt.Errorf("failed to encode for deep copy: %w", e)
+	}
+
+	dec := gob.NewDecoder(&buf)
+	e = dec.Decode(d)
+	if e != nil {
+		return fmt.Errorf("failed to decode for deep copy: %w", e)
+	}
+
+	return nil
 }
 
 func mergeDataSet(d *DataSet, s DataSet) error {
-	for name, system := range s.Systems {
+	for name := range s.Systems {
+		system := s.Systems[name]
+		srcCopy := &System{}
+		dipper.Must(DeepCopy(&system, srcCopy))
 		exist, ok := d.Systems[name]
 		if ok {
-			dipper.Must(mergeSystem(&exist, system))
+			dipper.Must(mergeSystem(&exist, *srcCopy))
 		} else {
-			exist = system
+			exist = *srcCopy
 		}
 		if d.Systems == nil {
 			d.Systems = map[string]System{}
 		}
 		d.Systems[name] = exist
 	}
-
 	s.Systems = map[string]System{}
 	s.Contexts = dipper.MustDeepCopyMap(s.Contexts)
 	s.Drivers = dipper.MustDeepCopyMap(s.Drivers)
-	err := mergo.Merge(d, s, mergo.WithOverride, mergo.WithAppendSlice)
-	if err != nil {
-		return fmt.Errorf("%w", err)
-	}
 
-	return nil
+	return mergo.Merge(d, s, mergo.WithOverride, mergo.WithAppendSlice)
 }
 
 func addSubsystem(d *System, s System, key string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -273,15 +273,15 @@ func (c *Config) recursive(f dipper.ItemProcessor, stage bool) {
 		return nil, false
 	}
 
-	dipper.Logger.Debugf("[config] recursive processing workflows ...")
+	dipper.Logger.Debugf("[config] recursively processing workflows ...")
 	dipper.Recursive(target.Workflows, processor)
-	dipper.Logger.Debugf("[config] recursive processing rules ...")
+	dipper.Logger.Debugf("[config] recursively processing rules ...")
 	dipper.Recursive(target.Rules, processor)
-	dipper.Logger.Debugf("[config] recursive processing systems ...")
+	dipper.Logger.Debugf("[config] recursively processing systems ...")
 	dipper.Recursive(target.Systems, processor)
-	dipper.Logger.Debugf("[config] recursive processing contexts ...")
+	dipper.Logger.Debugf("[config] recursively processing contexts ...")
 	dipper.Recursive(target.Contexts, f)
-	dipper.Logger.Debugf("[config] recursive processing drivers ...")
+	dipper.Logger.Debugf("[config] recursively processing drivers ...")
 	for k, v := range target.Drivers {
 		if k != "daemon" {
 			dipper.Recursive(v, f)

--- a/internal/config/config_stage_test.go
+++ b/internal/config/config_stage_test.go
@@ -1,0 +1,80 @@
+// Copyright 2019 Honey Science Corporation
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build !integration
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdvanceStage(t *testing.T) {
+	cfg := &Config{
+		Services: []string{"testsvc1", "testsvc2"},
+		Staged: &DataSet{
+			Drivers: map[string]interface{}{
+				"driver1": map[string]interface{}{
+					"k1": "v1",
+				},
+			},
+		},
+	}
+	cfg.ResetStage()
+
+	processor := func(name string, val interface{}) (interface{}, bool) {
+		if v, ok := val.(string); ok && v == "v1" {
+			return "v1+", true
+		}
+		return nil, false
+	}
+
+	assert.PanicsWithValue(t, ErrConfigRollback, func() { cfg.AdvanceStage("testsvc1", StageDiscovering) }, "cannot skipping booting stage")
+	go cfg.AdvanceStage("testsvc1", StageBooting, processor)
+	time.Sleep(time.Millisecond)
+	assert.NotEqual(t, StageBooting, cfg.Stage, "config stage not advanced")
+	assert.Equal(t, "v1", cfg.Staged.Drivers["driver1"].(map[string]interface{})["k1"], "config not touched, waiting")
+	cfg.AdvanceStage("testsvc2", StageBooting, processor)
+	assert.Equal(t, StageBooting, cfg.Stage, "config stage advanced")
+	assert.Equal(t, "v1+", cfg.Staged.Drivers["driver1"].(map[string]interface{})["k1"], "config touched after advance stage")
+}
+
+func TestRollBack(t *testing.T) {
+	cfg := &Config{
+		Services: []string{"testsvc1", "testsvc2"},
+		Staged:   &DataSet{},
+		LastRunningConfig: struct {
+			DataSet *DataSet
+			Loaded  map[RepoInfo]*Repo
+		}{
+			DataSet: &DataSet{
+				Drivers: map[string]interface{}{
+					"driver1": map[string]interface{}{
+						"k1": "v1",
+					},
+				},
+			},
+			Loaded: map[RepoInfo]*Repo{},
+		},
+	}
+	cfg.ResetStage()
+	cfg.OnChange = func() {
+		assert.Equal(t, "v1", cfg.Staged.Drivers["driver1"].(map[string]interface{})["k1"], "config set to last used data")
+		go cfg.AdvanceStage("testsvc1", StageBooting)
+		cfg.AdvanceStage("testsvc2", StageBooting)
+		assert.Equal(t, StageBooting, cfg.Stage, "config stage advanced")
+	}
+
+	go cfg.AdvanceStage("testsvc1", StageBooting)
+	cfg.AdvanceStage("testsvc2", StageBooting)
+	go func() {
+		assert.PanicsWithValue(t, ErrConfigRollback, func() { cfg.AdvanceStage("testsvc1", StageDiscovering) }, "cancelled due to rollback")
+	}()
+	cfg.RollBack()
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/honeydipper/honeydipper/pkg/dipper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,7 +48,7 @@ func TestConfigGetDriverData(t *testing.T) {
 
 func TestRegexParsing(t *testing.T) {
 	config := &Config{
-		DataSet: &DataSet{
+		Staged: &DataSet{
 			Workflows: map[string]Workflow{
 				"test-workflow": {
 					Match: map[string]interface{}{
@@ -73,11 +74,10 @@ func TestRegexParsing(t *testing.T) {
 		},
 	}
 
-	assert.NotPanics(t, func() { config.parseWorkflowRegex() }, "parsing regex in config should not panic")
+	assert.NotPanics(t, func() { config.RecursiveStaged(dipper.RegexParser); config.DataSet = config.Staged }, "parsing regex in config should not panic")
 	assert.IsType(t, &regexp.Regexp{}, config.DataSet.Workflows["test-workflow"].Match.(map[string]interface{})["key1"], "workflow match regex should be parsed")
 	assert.Equal(t, "non regex", config.DataSet.Workflows["test-workflow"].Match.(map[string]interface{})["key2"], "workflow match non-regex should remain")
 	assert.IsType(t, &regexp.Regexp{}, config.DataSet.Workflows["test-workflow"].UnlessMatch.(map[string]interface{})["key3"], "workflow unless_match regex should be parsed")
 	assert.Equal(t, "non regex", config.DataSet.Workflows["test-workflow"].UnlessMatch.(map[string]interface{})["key4"], "workflow unless_match non-regex should remain")
-	assert.Equal(t, ":regex:test3", config.DataSet.Rules[0].When.Match["key5"], "rule match regex should remain for later driver parsing")
 	assert.Equal(t, "non regex", config.DataSet.Rules[0].When.Match["key6"], "rule match non-regex should remain")
 }

--- a/internal/config/function_export_test.go
+++ b/internal/config/function_export_test.go
@@ -239,8 +239,8 @@ func TestFunctionExportWithSquashedSysData(t *testing.T) {
 }
 
 func TestFunctionExportWithSubsystem(t *testing.T) {
-	cfg := Config{
-		DataSet: &DataSet{
+	cfg := &Config{
+		Staged: &DataSet{
 			Systems: map[string]System{
 				"outter": {
 					Extends: []string{
@@ -271,22 +271,23 @@ func TestFunctionExportWithSubsystem(t *testing.T) {
 		},
 	}
 
-	(&cfg).extendAllSystems()
+	cfg.extendAllSystems()
+	cfg.DataSet = cfg.Staged
 
 	result := ExportFunctionContext(
 		&Function{Target: Action{System: "outter", Function: "inner.testFunc1"}},
 		map[string]interface{}{
 			"ctx": map[string]interface{}{"path": "test/path1"},
 		},
-		&cfg,
+		cfg,
 	)
 
 	assert.Equal(t, "http://value1.value3/test/path1", result["url"])
 }
 
 func TestFunctionExportWithSubsystemParameters(t *testing.T) {
-	cfg := Config{
-		DataSet: &DataSet{
+	cfg := &Config{
+		Staged: &DataSet{
 			Systems: map[string]System{
 				"outter": {
 					Extends: []string{
@@ -321,22 +322,23 @@ func TestFunctionExportWithSubsystemParameters(t *testing.T) {
 		},
 	}
 
-	(&cfg).extendAllSystems()
+	cfg.extendAllSystems()
+	cfg.DataSet = cfg.Staged
 
 	result := ExportFunctionContext(
 		&Function{Target: Action{System: "outter", Function: "inner.testFunc1"}},
 		map[string]interface{}{
 			"ctx": map[string]interface{}{"path": "test/path1"},
 		},
-		&cfg,
+		cfg,
 	)
 
 	assert.Equal(t, "http://value1.value3/test/path1?internal-data", result["url"])
 }
 
 func TestFunctionExportWithSubsystemParentData(t *testing.T) {
-	cfg := Config{
-		DataSet: &DataSet{
+	cfg := &Config{
+		Staged: &DataSet{
 			Systems: map[string]System{
 				"outter": {
 					Extends: []string{
@@ -369,14 +371,15 @@ func TestFunctionExportWithSubsystemParentData(t *testing.T) {
 		},
 	}
 
-	(&cfg).extendAllSystems()
+	cfg.extendAllSystems()
+	cfg.DataSet = cfg.Staged
 
 	result := ExportFunctionContext(
 		&Function{Target: Action{System: "outter", Function: "inner.testFunc1"}},
 		map[string]interface{}{
 			"ctx": map[string]interface{}{"path": "test/path1"},
 		},
-		&cfg,
+		cfg,
 	)
 
 	assert.Equal(t, "http://value1.value3/test/path1?belong-to-parent", result["url"])

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -20,20 +20,20 @@ func TestDriverNewDriver(t *testing.T) {
 	// test new driver: table driven
 	testCases := map[string]interface{}{
 		"panic when driver name is missing": []interface{}{
-			map[string]interface{}{}, // driver meta
-			"driver error: driver name missing: ",  // error prefix
+			map[string]interface{}{},              // driver meta
+			"driver error: driver name missing: ", // error prefix
 		},
 		"panic when driver type is missing": []interface{}{
-			map[string]interface{}{"name": "test"}, // driver meta
-			"driver error: unsupported driver type: ",            // error prefix
+			map[string]interface{}{"name": "test"},    // driver meta
+			"driver error: unsupported driver type: ", // error prefix
 		},
 		"panic when driver type is unknown": []interface{}{
 			map[string]interface{}{"name": "test", "type": "faketype"}, // driver meta
-			"driver error: unsupported driver type: ",                                // error prefix
+			"driver error: unsupported driver type: ",                  // error prefix
 		},
 		"panic when builtin driver data missing": []interface{}{
 			map[string]interface{}{"name": "test", "type": "builtin"}, // driver meta
-			"driver error: shortName is missing for builtin driver: ",               // error prefix
+			"driver error: shortName is missing for builtin driver: ", // error prefix
 		},
 	}
 

--- a/internal/service/engine.go
+++ b/internal/service/engine.go
@@ -62,7 +62,6 @@ func StartEngine(cfg *config.Config) {
 	engine.addResponder("eventbus:return", continueSession)
 	setupEngineAPIs()
 
-	buildRuleMap(cfg)
 	engine.start()
 }
 
@@ -80,7 +79,6 @@ func createSessions(d *driver.Runtime, msg *dipper.Message) {
 		rules, ok := ruleMap[event]
 		if ok && rules != nil {
 			for _, rule := range rules {
-				dipper.Recursive(rule.Trigger.Match, engine.decryptDriverData)
 				if dipper.CompareAll(data, rule.Trigger.Match) {
 					dipper.Logger.Infof("[engine] raw event triggers an event %s.%s",
 						rule.OriginalRule.When.Source.System,

--- a/internal/service/operator.go
+++ b/internal/service/operator.go
@@ -103,7 +103,6 @@ func handleEventbusCommand(msg *dipper.Message) []RoutedMessage {
 		}).(map[string]interface{})
 	}
 	dipper.Logger.Debugf("[operator] interpolated function call %+v", finalParams)
-	dipper.Recursive(finalParams, operator.decryptDriverData)
 
 	msg.Payload = finalParams
 	if msg.Labels == nil {
@@ -196,7 +195,6 @@ func collapseFunction(s *config.System, f *config.Function) (string, string, map
 	}
 
 	if s != nil && s.Data != nil {
-		dipper.Recursive(s.Data, operator.decryptDriverData)
 		currentSysDataCopy, _ := dipper.DeepCopy(s.Data)
 		if sysData == nil {
 			sysData = map[string]interface{}{}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -138,9 +138,9 @@ func (s *Service) GetStream(feature string) io.Writer {
 }
 
 func (s *Service) decryptDriverData(key string, val interface{}) (ret interface{}, replace bool) {
-	dipper.Logger.Debugf("[%s] decrypting %s", s.name, key)
 	if str, ok := val.(string); ok {
 		if strings.HasPrefix(str, "ENC[") {
+			dipper.Logger.Debugf("[%s] decrypting %s", s.name, key)
 			parts := strings.SplitN(str[4:len(str)-1], ",", 2)
 			encDriver := parts[0]
 			data := []byte(parts[1])
@@ -185,9 +185,9 @@ func (s *Service) loadFeature(feature string) (affected bool, driverName string,
 	if strings.HasPrefix(feature, "driver:") {
 		driverName = feature[7:]
 	} else {
-		driverName, ok = s.config.GetDriverDataStr(fmt.Sprintf("daemon.featureMap.%s.%s", s.name, feature))
+		driverName, ok = s.config.GetStagedDriverDataStr(fmt.Sprintf("daemon.featureMap.%s.%s", s.name, feature))
 		if !ok {
-			driverName, ok = s.config.GetDriverDataStr(fmt.Sprintf("daemon.featureMap.global.%s", feature))
+			driverName, ok = s.config.GetStagedDriverDataStr(fmt.Sprintf("daemon.featureMap.global.%s", feature))
 		}
 		if !ok {
 			panic("driver not defined for the feature")
@@ -195,21 +195,18 @@ func (s *Service) loadFeature(feature string) (affected bool, driverName string,
 	}
 	dipper.Logger.Infof("[%s] mapping feature %s to driver %s", s.name, feature, driverName)
 
-	driverData, _ := s.config.GetDriverData(driverName)
+	driverData, _ := s.config.GetStagedDriverData(driverName)
 	var dynamicData interface{}
 	if strings.HasPrefix(feature, "driver:") {
 		dynamicData = s.dynamicFeatureData[feature]
 	}
 
 	var driverHandler driver.Handler
-	if driverMeta, ok := s.config.GetDriverData(fmt.Sprintf("daemon.drivers.%s", driverName)); ok {
+	if driverMeta, ok := s.config.GetStagedDriverData(fmt.Sprintf("daemon.drivers.%s", driverName)); ok {
 		driverHandler = driver.NewDriver(driverMeta.(map[string]interface{}))
 	} else {
 		panic("unable to get driver metadata")
 	}
-
-	dipper.Recursive(driverData, s.decryptDriverData)
-	dipper.Recursive(dynamicData, s.decryptDriverData)
 
 	dipper.Logger.Debugf("[%s] driver %s meta %v", s.name, driverName, driverHandler.Meta())
 	driverRuntime := driver.Runtime{
@@ -275,11 +272,17 @@ func (s *Service) coldReload(driverRuntime *driver.Runtime, oldRuntime *driver.R
 func (s *Service) start() {
 	go func() {
 		dipper.Logger.Infof("[%s] starting service", s.name)
+		s.config.AdvanceStage(s.name, config.StageBooting)
 		featureList := s.getFeatureList()
 		s.loadRequiredFeatures(featureList, true)
 		go s.serviceLoop()
 		time.Sleep(time.Second)
+		s.config.AdvanceStage(s.name, config.StageDiscovering, s.decryptDriverData)
 		s.loadAdditionalFeatures(featureList)
+		s.config.AdvanceStage(s.name, config.StageServing)
+		if s.ServiceReload != nil {
+			s.ServiceReload(s.config)
+		}
 		s.healthy = true
 		go s.metricsLoop()
 	}()
@@ -287,50 +290,47 @@ func (s *Service) start() {
 
 // Reload the service when configuration changes are detected.
 func (s *Service) Reload() {
-	dipper.Logger.Infof("[%s] reloading service", s.name)
-	var featureList map[string]bool
+	defer func() {
+		if r := recover(); r != nil {
+			s.healthy = false
+			if errors.Is(r.(error), config.ErrConfigRollback) {
+				dipper.Logger.Errorf("[%s] reverting config initiated outside of the service", s.name)
 
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				s.healthy = false
-				dipper.Logger.Errorf("[%s] reverting config due to fatal failure %v", s.name, r)
-				s.config.RollBack()
+				return
 			}
-		}()
-		if s.ServiceReload != nil {
-			s.ServiceReload(s.config)
+			dipper.Logger.Errorf("[%s] reverting config due to fatal failure %v", s.name, r)
+			s.config.RollBack()
 		}
-		featureList = s.getFeatureList()
-		s.loadRequiredFeatures(featureList, false)
 	}()
-
+	dipper.Logger.Infof("[%s] reloading service", s.name)
+	s.config.AdvanceStage(s.name, config.StageBooting)
+	featureList := s.getFeatureList()
+	s.loadRequiredFeatures(featureList, false)
+	s.config.AdvanceStage(s.name, config.StageDiscovering, s.decryptDriverData)
 	s.loadAdditionalFeatures(featureList)
+	s.config.AdvanceStage(s.name, config.StageServing)
+	if s.ServiceReload != nil {
+		s.ServiceReload(s.config)
+	}
 	s.healthy = true
 	s.removeUnusedFeatures(featureList)
 }
 
 func (s *Service) getFeatureList() map[string]bool {
 	featureList := map[string]bool{}
-	if cfgItem, ok := s.config.GetDriverData("daemon.features.global"); ok {
+	if cfgItem, ok := s.config.GetStagedDriverData("daemon.features.global"); ok {
 		for _, feature := range cfgItem.([]interface{}) {
 			featureName := feature.(map[string]interface{})["name"].(string)
 			featureList[featureName], _ = dipper.GetMapDataBool(feature, "required")
 		}
 	}
-	if cfgItem, ok := s.config.GetDriverData("daemon.features." + s.name); ok {
+	if cfgItem, ok := s.config.GetStagedDriverData("daemon.features." + s.name); ok {
 		for _, feature := range cfgItem.([]interface{}) {
 			featureName := feature.(map[string]interface{})["name"].(string)
 			featureList[featureName], _ = dipper.GetMapDataBool(feature, "required")
 		}
 	}
-	if s.DiscoverFeatures != nil {
-		s.dynamicFeatureData = s.DiscoverFeatures(s.config.DataSet)
-		for name := range s.dynamicFeatureData {
-			featureList[name] = false
-		}
-	}
-	dipper.Logger.Debugf("[%s] final feature list %+v", s.name, featureList)
+	dipper.Logger.Debugf("[%s] preliminary feature list %+v", s.name, featureList)
 
 	return featureList
 }
@@ -397,6 +397,14 @@ func (s *Service) loadRequiredFeatures(featureList map[string]bool, boot bool) {
 }
 
 func (s *Service) loadAdditionalFeatures(featureList map[string]bool) {
+	if s.DiscoverFeatures != nil {
+		s.dynamicFeatureData = s.DiscoverFeatures(s.config.Staged)
+		for name := range s.dynamicFeatureData {
+			featureList[name] = false
+		}
+	}
+	dipper.Logger.Debugf("[%s] final feature list %+v", s.name, featureList)
+
 	for feature, required := range featureList {
 		if !required {
 			affected, driverName, err := s.loadFeature(feature)
@@ -429,6 +437,7 @@ func (s *Service) loadAdditionalFeatures(featureList map[string]bool) {
 func (s *Service) serviceLoop() {
 	daemon.Children.Add(1)
 	defer daemon.Children.Done()
+
 	for !daemon.ShuttingDown {
 		var cases []reflect.SelectCase
 		var orderedRuntimes []*driver.Runtime

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -218,7 +218,8 @@ func TestServiceRemoveEmitter(t *testing.T) {
 	}()
 
 	newCfg := &config.Config{
-		DataSet: &config.DataSet{
+		Services: []string{"testsvc"},
+		Staged: &config.DataSet{
 			Drivers: map[string]interface{}{
 				"daemon": map[string]interface{}{
 					"features": map[string]interface{}{
@@ -239,6 +240,7 @@ func TestServiceRemoveEmitter(t *testing.T) {
 		},
 	}
 	svc.config = newCfg
+	svc.config.ResetStage()
 
 	time.Sleep(100 * time.Millisecond)
 	assert.NotPanics(t, svc.Reload, "service reload should not panic when emitter is removed")
@@ -392,7 +394,8 @@ func TestServiceReplaceEmitter(t *testing.T) {
 	}()
 
 	newCfg := &config.Config{
-		DataSet: &config.DataSet{
+		Services: []string{"testsvc"},
+		Staged: &config.DataSet{
 			Drivers: map[string]interface{}{
 				"daemon": map[string]interface{}{
 					"featureMap": map[string]interface{}{
@@ -421,6 +424,7 @@ func TestServiceReplaceEmitter(t *testing.T) {
 		},
 	}
 	svc.config = newCfg
+	svc.config.ResetStage()
 
 	time.Sleep(100 * time.Millisecond)
 	assert.NotPanics(t, svc.Reload, "service reload should not panic when emitter is changed")

--- a/pkg/dipper/mapUtils.go
+++ b/pkg/dipper/mapUtils.go
@@ -128,8 +128,11 @@ func MustGetMapDataBool(from interface{}, path string) bool {
 	panic(fmt.Errorf("%w: not a bool: %s", ErrMapError, path))
 }
 
+// ItemProcessor is a function processing one of the items in a data structure.
+type ItemProcessor func(key string, val interface{}) (newval interface{}, ok bool)
+
 // Recursive : enumerate all the data element deep into the map call the function provided.
-func Recursive(from interface{}, process func(key string, val interface{}) (newval interface{}, ok bool)) {
+func Recursive(from interface{}, process ItemProcessor) {
 	RecursiveWithPrefix(nil, "", "", from, process)
 }
 
@@ -139,7 +142,7 @@ func RecursiveWithPrefix(
 	prefixes string,
 	key interface{},
 	from interface{},
-	process func(key string, val interface{}) (newval interface{}, ok bool),
+	process ItemProcessor,
 ) {
 	keyStr := fmt.Sprintf("%v", key)
 	newPrefixes := keyStr

--- a/pkg/dipper/sync.go
+++ b/pkg/dipper/sync.go
@@ -1,0 +1,30 @@
+// Copyright 2019 Honey Science Corporation
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package dipper is a library used for developing drivers for Honeydipper.
+package dipper
+
+import "sync"
+
+// WaitGroupDone is a way to safely decrement the counter for a WaitGroup.
+func WaitGroupDone(wg *sync.WaitGroup) {
+	defer func() {
+		_ = recover()
+	}()
+
+	wg.Done()
+}
+
+// WaitGroupDoneAll is a way to safely release the whole WaitGroup.
+func WaitGroupDoneAll(wg *sync.WaitGroup) {
+	defer func() {
+		_ = recover()
+	}()
+
+	for {
+		wg.Done()
+	}
+}

--- a/pkg/dipper/sync.go
+++ b/pkg/dipper/sync.go
@@ -10,12 +10,17 @@ package dipper
 import "sync"
 
 // WaitGroupDone is a way to safely decrement the counter for a WaitGroup.
-func WaitGroupDone(wg *sync.WaitGroup) {
+func WaitGroupDone(wg *sync.WaitGroup) (ok bool) {
 	defer func() {
-		_ = recover()
+		if recover() != nil {
+			ok = false
+		}
 	}()
 
 	wg.Done()
+	ok = true
+
+	return ok
 }
 
 // WaitGroupDoneAll is a way to safely release the whole WaitGroup.


### PR DESCRIPTION
#### Description
The concurrent map writes are usually caused by updating to
the configuration when the services decrypt some piece of
data, or a regexp is parsed.

This commit changes how the configuration handles the updating
of the configs. Instead of, delaying the decryption and regexp
parsing to later time, the config module will take care of them
at the startup of the services.

The config process will be divided into multiple stages, and
all the services will be synchronized to use the configuration
according to the stages. Also introduced a `RawData` to holds
the raw data for use in rollback and re-decrypt, if necessary.
The configuration becomes readonly to services.

 * Add stages and the synchronizing variables to config
 * Put decryption and regexp parsing into stages
 * Remove scattered calls for decryption and regexp parsing
 * Add a `RawData` in config to keep `Rollback` working
 * Fixing tests accordingly

#### This PR fixes the following issues
Fixes #354
