### PR TITLE
chore(codefresh): migrate to main for honeydipper-sphinx

### DIFF
--- a/.codefresh/honeydipper-sphinx.yml
+++ b/.codefresh/honeydipper-sphinx.yml
@@ -9,7 +9,7 @@ steps:
     revision: main
   generate_doc:
     title: 'generate docs'
-    image: honeydipper/honeydipper:1.0.2
+    image: honeydipper/honeydipper:2.1.2
     environment:
       - DOCSRC=docgen
       - DOCDST=source
@@ -22,11 +22,11 @@ steps:
       - mkdir -p ~/.ssh
       - echo -n "${SSH_KEY}" | base64 -d > ~/.ssh/id_rsa
       - chmod 600 ~/.ssh/id_rsa
-      - echo $'Host github.com\n  StrictHostKeyChecking no\n  UserKnownHostsFile /dev/null\n' > ~/.ssh/config
+      - ssh-keyscan github.com > /etc/ssh/ssh_known_hosts
       - git remote add update "git@github.com:honeydipper/honeydipper-sphinx.git"
       - git config --global user.email "codefresh@honeydipper.io"
       - git config --global user.name "codefresh bot"
-      - 'git diff --exit-code && git commit -am "docs: update version ${{CF_RELEASE_TAG}} from ${{CF_SHORT_REVISION}}"'
-      - git push -u update master
+      - 'git diff --exit-code || git commit -am "docs: update version ${{CF_RELEASE_TAG}} from ${{CF_SHORT_REVISION}}"'
+      - git push -u update main
       - 'git checkout -b ${{CF_RELEASE_TAG}}'
       - 'git push -u --force update ${{CF_RELEASE_TAG}}'


### PR DESCRIPTION
#### Description
 * Use `main` branch for `honeydipper-sphinx` building
 * Use `ssh-keyscan` to avoid ignoring host key check
 * Correct the diff and commit statement

#### This PR fixes the following issues
N/A