### PR TITLE
fix(config): Wrapping WaitGroup.Wait in AdvanceStage

### DIFF
--- a/cmd/honeydipper/docgen.go
+++ b/cmd/honeydipper/docgen.go
@@ -30,6 +30,9 @@ import (
 const (
 	// DefaultHTTPRequestTimeout is the default timeout for a HTTP request.
 	DefaultHTTPRequestTimeout time.Duration = time.Second * 10
+
+	// DocGenService is the name of the DocGen service.
+	DocGenService = "docgen"
 )
 
 // DocItem describe a item or a group of items in the document output.
@@ -201,9 +204,12 @@ func createItem(item DocItem, envData map[string]interface{}, cfg *config.Config
 			currentRepo := &config.Config{
 				InitRepo:      v,
 				IsConfigCheck: false,
+				Services:      []string{DocGenService},
 			}
 			currentRepo.Bootstrap("/tmp")
-			envData["current_repo"] = currentRepo.DataSet
+			currentRepo.AdvanceStage(DocGenService, config.StageBooting)
+			currentRepo.AdvanceStage(DocGenService, config.StageDiscovering)
+			envData["current_repo"] = currentRepo.Staged
 		}
 	}
 

--- a/cmd/honeydipper/main.go
+++ b/cmd/honeydipper/main.go
@@ -161,8 +161,7 @@ func main() {
 		defer func() {
 			os.Exit(exitCode)
 		}()
-		cfg.Bootstrap("/tmp")
-		exitCode = runConfigCheck(&cfg)
+		exitCode = loadAndRunConfigCheck(&cfg)
 	case cfg.IsDocGen:
 		runDocGen(&cfg)
 	default:

--- a/cmd/honeydipper/main_test.go
+++ b/cmd/honeydipper/main_test.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Honey Science Corporation
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/honeydipper/honeydipper/pkg/dipper"
+)
+
+func TestMain(m *testing.M) {
+	if dipper.Logger == nil {
+		logFile, err := os.Create("test.log")
+		if err != nil {
+			panic(err)
+		}
+		defer logFile.Close()
+		dipper.GetLogger("test", "INFO", logFile, logFile)
+	}
+	os.Exit(m.Run())
+}

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -435,8 +436,6 @@ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BG
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43 h1:ld7aEMNHoBnnDAX15v1T6z31v8HwR2A9FYOuAhWqkwc=
 golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20201203001011-0b49973bad19 h1:ZD+2Sd/BnevwJp8PSli8WgGAGzb9IZtxBsv1iZMYeEA=
-golang.org/x/oauth2 v0.0.0-20201203001011-0b49973bad19/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5 h1:Lm4OryKCca1vehdsWogr9N4t7NfZxLbJoc/H0w4K4S4=
 golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -205,7 +205,7 @@ func (c *Config) AdvanceStage(service string, stage int, fns ...dipper.ItemProce
 			panic(ErrConfigRollback)
 		}
 		locker.Unlock()
-		stageWG.Wait()
+		dipper.WaitGroupWait(stageWG)
 		locker.Lock()
 
 		if locker != c.Locker {

--- a/pkg/dipper/sync.go
+++ b/pkg/dipper/sync.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Honey Science Corporation
+// Copyright 2020 Honey Science Corporation
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -32,4 +32,13 @@ func WaitGroupDoneAll(wg *sync.WaitGroup) {
 	for {
 		wg.Done()
 	}
+}
+
+// WaitGroupWait is a wrapper for safely waiting for a WaitGroup.
+func WaitGroupWait(wg *sync.WaitGroup) {
+	defer func() {
+		_ = recover()
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
#### Description
In PR #358, we altered how `config` was loaded, this breaks
the `docgen` and `configcheck`. We need to use `Staged` dataset
instead of the live one. Also, need to advance the config to
discovered stage to ensure all systems are extended.

Also, there is a bug in the `AdvanceStage` method, that the
`WaitGroup.Wait` may panic if previous call to `Done` paniced.
We should wrap it.

#### This PR fixes the following issues
N/A