### PR TITLE
fix(services): api service discovery using staged dataset

### DIFF
--- a/cmd/honeydipper/test_fixtures/bootstrap/daemon.yaml
+++ b/cmd/honeydipper/test_fixtures/bootstrap/daemon.yaml
@@ -5,12 +5,14 @@ drivers:
     featureMap:
       global:
         eventbus: redisqueue
+        api-broadcast: api-broadcast
     features:
       global:
         - name: "driver:gcloud-kms"
           required: true
         - name: "eventbus"
           required: true
+        - name: api-broadcast
       operator:
         - name: "driver:gcloud-gke"
         - name: "driver:gcloud-dataflow"
@@ -46,4 +48,38 @@ drivers:
         type: builtin
         handlerData:
           shortName: kubernetes
+      auth-simple:
+        name: auth-simple
+        type: builtin
+        handlerData:
+          shortName: auth-simple
+      api-broadcast:
+        name: api-broadcast
+        type: builtin
+        handlerData:
+          shortName: redispubsub
 
+    services:
+      api:
+        auth-providers:
+          - auth-simple
+        auth:
+          casbin:
+            models:
+              - |
+                [request_definition]
+                r = sub, obj, act
+
+                [policy_definition]
+                p = sub, obj, act
+
+                [policy_effect]
+                e = some(where (p.eft == allow))
+
+                [matchers]
+                m = r.sub == p.sub && (r.obj == p.obj || p.obj == "*") && (r.act == p.act || p.act == "*")
+
+            policies:
+              - |
+                # define basic policy effects
+                p, admin, *, *

--- a/cmd/honeydipper/test_fixtures/bootstrap/drivers.yaml
+++ b/cmd/honeydipper/test_fixtures/bootstrap/drivers.yaml
@@ -3,7 +3,18 @@ drivers:
   redisqueue:
     connection:
       Addr: localhost:6379
+  api-broadcast:
+    topic: honeydipper:api-broadcast
+    channel: api
+    connection:
+      Addr: 127.0.0.1:6379
   webhook:
     Addr: "127.0.0.1:8081"
   gcloud-kms:
     keyname: projects/test-project/locations/us-central1/keyRings/secure_config/cryptoKeys/kube_secrets
+  auth-simple:
+    schemes:
+      - token
+    tokens:
+      - token: '$2y$05$3XXyVmdtvdLS1i2gV4qPZO0EPDwEL8BiVlTWQM4fYXEz4UysQaixu'
+        subject: admin

--- a/internal/service/api.go
+++ b/internal/service/api.go
@@ -124,7 +124,7 @@ func handleAPIMessage(d *driver.Runtime, m *dipper.Message) {
 // APIFeatures figures out what features need to be loaded for API services.
 func APIFeatures(s *config.DataSet) map[string]interface{} {
 	features := map[string]interface{}{}
-	if providers, ok := dipper.GetMapData(APICfg, "auth-providers"); ok && providers != nil {
+	if providers, ok := dipper.GetMapData(s.Drivers, "daemon.services.api.auth-providers"); ok && providers != nil {
 		if len(providers.([]interface{})) > 0 {
 			for _, p := range providers.([]interface{}) {
 				parts := strings.Split(p.(string), ".")


### PR DESCRIPTION
#### Description
The `APIFeatures` method is in charge of discovering what drivers to
load for api service. The old way is to use dataset in `APICfg`.  With
the new staged config loading method since version 2.1.3, it doesnt work
any more because the `APICfg` is not initialized during discovery. It is
supposed to use the dataset object passed in as parameters.

Also, added some api related tests in integration test,

#### This PR fixes the following issues
N/A