### PR TITLE
fix(dipper): driver ReadySignal chan initialization

### DIFF
--- a/pkg/dipper/driver.go
+++ b/pkg/dipper/driver.go
@@ -49,11 +49,12 @@ type Driver struct {
 // NewDriver : create a blank driver object.
 func NewDriver(service string, name string) *Driver {
 	driver := Driver{
-		Name:    name,
-		Service: service,
-		State:   "loaded",
-		In:      os.Stdin,
-		Out:     os.Stdout,
+		Name:        name,
+		Service:     service,
+		State:       "loaded",
+		In:          os.Stdin,
+		Out:         os.Stdout,
+		ReadySignal: make(chan bool),
 	}
 
 	driver.RPCProvider.Init("rpc", "return", driver.Out)
@@ -129,10 +130,7 @@ func (d *Driver) ReceiveOptions(msg *Message) {
 }
 
 func (d *Driver) start(msg *Message) {
-	select {
-	case <-d.ReadySignal:
-	case <-time.After(time.Second):
-	}
+	<-d.ReadySignal
 
 	if d.State == "alive" {
 		if d.Reload != nil {


### PR DESCRIPTION
#### Description

A `chan` needs to be initialized before first use. We are missing the
initialization part for `ReadySignal`, but for some reason `go` does not
check for it, and allow you to send to or receive from `0x0`, and
potentially corrupting memmory.

The `ReadySignal` is used for signalling the readiness of the
configuration received from the `daemon`. Originally, it was considered
to be optional, since not all driver requires a configuration from
`daemon`. So, a timeout of one second was in place to forcefully start
the driver even without the signal.  I am changing this to be mandatory
so it can be a little easier sequencing the lifecycle, and avoid race
conditions. The `Driver` is receiving an empty configuration from
`daemon` even if no configuation is needed.

#### This PR fixes the following issues
N/A