### PR TITLE
feat(drivers): fetch secrets from google secret manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ RESET := \033[0m
 files_require_mocking = internal/workflow/session.go \
 						internal/workflow/store.go \
 						pkg/dipper/rpc.go \
-						internal/api/request_context.go
+						internal/api/request_context.go \
+						drivers/cmd/gcloud-secret/main.go
 
 .PHONY: build lint run_mockgen unit-tests integration-tests test all clean
 

--- a/drivers/cmd/gcloud-secret/main.go
+++ b/drivers/cmd/gcloud-secret/main.go
@@ -74,13 +74,13 @@ func main() {
 	flag.Parse()
 
 	driver = dipper.NewDriver(os.Args[1], "google-secret")
-	driver.RPCHandlers["decrypt"] = decrypt
+	driver.RPCHandlers["lookup"] = lookup
 	driver.Reload = loadOptions
 	driver.Start = loadOptions
 	driver.Run()
 }
 
-func decrypt(msg *dipper.Message) {
+func lookup(msg *dipper.Message) {
 	nameBytes, ok := msg.Payload.([]byte)
 	if !ok {
 		panic(ErrSecretNameMissing)

--- a/drivers/cmd/gcloud-secret/main.go
+++ b/drivers/cmd/gcloud-secret/main.go
@@ -1,0 +1,110 @@
+// Copyright 2021 Honey Science Corporation
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package gcloud-secret enables Honeydipper to use secrets stored in gcloud secret manager.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"github.com/gogf/gf/container/gpool"
+	"github.com/googleapis/gax-go/v2"
+	"github.com/honeydipper/honeydipper/pkg/dipper"
+	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
+)
+
+// DefaultClientTTLSeconds specifies the TTL for reusable google clients.
+const DefaultClientTTLSeconds = 60
+
+// ErrSecretNameMissing means the secret name is not supplied.
+var ErrSecretNameMissing = errors.New("secret name not supplied")
+
+// SecretManagerClient is an interface with a subset of method used for mocking.
+type SecretManagerClient interface {
+	AccessSecretVersion(
+		ctx context.Context,
+		req *secretmanagerpb.AccessSecretVersionRequest,
+		opts ...gax.CallOption,
+	) (*secretmanagerpb.AccessSecretVersionResponse, error)
+	Close() error
+}
+
+func initFlags() {
+	flag.Usage = func() {
+		fmt.Printf("%s [ -h ] <service name>\n", os.Args[0])
+		fmt.Printf("    This driver supports all services including engine, receiver, workflow, operator etc")
+		fmt.Printf("  This program provides honeydipper with capability of decrypting with gcloud secret manager")
+	}
+}
+
+var (
+	driver      *dipper.Driver
+	_clientPool *gpool.Pool
+)
+
+func loadOptions(msg *dipper.Message) {
+	var clientTTL time.Duration
+	if clientTTLStr, ok := driver.GetOptionStr("data.clientTTL"); ok {
+		clientTTL = dipper.Must(time.ParseDuration(clientTTLStr)).(time.Duration)
+	} else {
+		clientTTL = time.Second * DefaultClientTTLSeconds
+	}
+	if _clientPool != nil {
+		_clientPool.Close()
+		dipper.Logger.Infof("[%s] _clientPool re-created", driver.Service)
+	}
+	_clientPool = gpool.New(
+		clientTTL, // TTL
+		func() (interface{}, error) { return secretmanager.NewClient(context.Background()) }, // NewFunc
+		func(o interface{}) { _ = o.(SecretManagerClient).Close() },                          // ExpireFunc
+	)
+}
+
+func main() {
+	initFlags()
+	flag.Parse()
+
+	driver = dipper.NewDriver(os.Args[1], "google-secret")
+	driver.RPCHandlers["decrypt"] = decrypt
+	driver.Reload = loadOptions
+	driver.Start = loadOptions
+	driver.Run()
+}
+
+func decrypt(msg *dipper.Message) {
+	nameBytes, ok := msg.Payload.([]byte)
+	if !ok {
+		panic(ErrSecretNameMissing)
+	}
+	name := string(nameBytes)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*driver.APITimeout)
+	defer cancel()
+	req := &secretmanagerpb.AccessSecretVersionRequest{
+		Name: name,
+	}
+	client, err := _clientPool.Get()
+	if err != nil {
+		dipper.Logger.Warning("failed to google secret manager client")
+		panic(err)
+	}
+	defer func() { _ = _clientPool.Put(client) }()
+	resp, err := client.(SecretManagerClient).AccessSecretVersion(ctx, req)
+	if err != nil {
+		dipper.Logger.Warning("failed to access the secret version")
+		panic(err)
+	}
+
+	msg.Reply <- dipper.Message{
+		Payload: resp.Payload.Data,
+		IsRaw:   true,
+	}
+}

--- a/drivers/cmd/gcloud-secret/main_test.go
+++ b/drivers/cmd/gcloud-secret/main_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestDecryptWithoutName(t *testing.T) {
+func TestLookupWithoutName(t *testing.T) {
 	driver = dipper.NewDriver(os.Args[1], "secretmanager")
 	ctrl := gomock.NewController(t)
 	client := mock_driver.NewMockSecretManagerClient(ctrl)
@@ -38,10 +38,10 @@ func TestDecryptWithoutName(t *testing.T) {
 
 	client.EXPECT().Close().Times(1).Return(nil)
 
-	assert.PanicsWithValue(t, ErrSecretNameMissing, func() { decrypt(&dipper.Message{}) }, "should panic without the secret name")
+	assert.PanicsWithValue(t, ErrSecretNameMissing, func() { lookup(&dipper.Message{}) }, "should panic without the secret name")
 }
 
-func TestDecryptWithName(t *testing.T) {
+func TestLookupWithName(t *testing.T) {
 	driver = dipper.NewDriver(os.Args[1], "secretmanager")
 	ctrl := gomock.NewController(t)
 	client := mock_driver.NewMockSecretManagerClient(ctrl)
@@ -69,7 +69,7 @@ func TestDecryptWithName(t *testing.T) {
 		Reply:   make(chan dipper.Message, 1),
 	}
 
-	assert.NotPanics(t, func() { decrypt(msg) }, "should not panic when decrypting.")
+	assert.NotPanics(t, func() { lookup(msg) }, "should not panic when looking up.")
 	select {
 	case ret := <-msg.Reply:
 		assert.Equal(t, []byte("plaintext"), ret.Payload, "return value should be 'plaintext'.")

--- a/drivers/cmd/gcloud-secret/main_test.go
+++ b/drivers/cmd/gcloud-secret/main_test.go
@@ -1,0 +1,79 @@
+// Copyright 2021 Honey Science Corporation
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build !integration
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	mock_driver "github.com/honeydipper/honeydipper/drivers/cmd/gcloud-secret/mock_gcloud-secret"
+	"github.com/honeydipper/honeydipper/pkg/dipper"
+	"github.com/stretchr/testify/assert"
+	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
+)
+
+func TestMain(m *testing.M) {
+	if dipper.Logger == nil {
+		f, _ := os.Create("test.log")
+		defer f.Close()
+		dipper.GetLogger("test service", "DEBUG", f, f)
+	}
+	os.Exit(m.Run())
+}
+
+func TestDecryptWithoutName(t *testing.T) {
+	driver = dipper.NewDriver(os.Args[1], "secretmanager")
+	ctrl := gomock.NewController(t)
+	client := mock_driver.NewMockSecretManagerClient(ctrl)
+	loadOptions(&dipper.Message{})
+	_clientPool.Put(client)
+	defer _clientPool.Close()
+
+	client.EXPECT().Close().Times(1).Return(nil)
+
+	assert.PanicsWithValue(t, ErrSecretNameMissing, func() { decrypt(&dipper.Message{}) }, "should panic without the secret name")
+}
+
+func TestDecryptWithName(t *testing.T) {
+	driver = dipper.NewDriver(os.Args[1], "secretmanager")
+	ctrl := gomock.NewController(t)
+	client := mock_driver.NewMockSecretManagerClient(ctrl)
+	loadOptions(&dipper.Message{})
+	_clientPool.Put(client)
+	defer _clientPool.Close()
+
+	client.EXPECT().Close().Times(1).Return(nil)
+	client.EXPECT().AccessSecretVersion(
+		gomock.Any(),
+		gomock.Eq(&secretmanagerpb.AccessSecretVersionRequest{
+			Name: "secretname",
+		}),
+	).Times(1).Return(
+		&secretmanagerpb.AccessSecretVersionResponse{
+			Payload: &secretmanagerpb.SecretPayload{
+				Data: []byte("plaintext"),
+			},
+		},
+		nil,
+	)
+
+	msg := &dipper.Message{
+		Payload: []byte("secretname"),
+		Reply:   make(chan dipper.Message, 1),
+	}
+
+	assert.NotPanics(t, func() { decrypt(msg) }, "should not panic when decrypting.")
+	select {
+	case ret := <-msg.Reply:
+		assert.Equal(t, []byte("plaintext"), ret.Payload, "return value should be 'plaintext'.")
+	default:
+		assert.Fail(t, "should receive plain text in reply chan.")
+	}
+}


### PR DESCRIPTION
#### Description

The new driver should provide the capability to fetch secrets from
google secret manager.

The daemon code is updated to support passing non-base64 string to the
driver for lookup instead of decryption.

#### This PR fixes the following issues
N/A