### PR TITLE
feat(driver): load redis option from env variable

### DIFF
--- a/drivers/pkg/redisclient/redisclient.go
+++ b/drivers/pkg/redisclient/redisclient.go
@@ -89,6 +89,10 @@ func GetRedisOpts(driver *dipper.Driver) *redis.Options {
 	}
 
 	if localRedis, ok := os.LookupEnv("LOCALREDIS"); ok && localRedis != "" {
+		if opts, e := redis.ParseURL(localRedis); e == nil {
+			return opts
+		}
+
 		return &redis.Options{
 			Addr: "127.0.0.1:6379",
 			DB:   0,


### PR DESCRIPTION

#### Description

When testing in non-local environment, such as `docker-compose`, we need a
way to override the redis config through environment variable other than using
`127.0.0.1:6379`.


#### This PR fixes the following issues
N/A