### PR TITLE
fix(drivers): web and webhook recognize more json content types

### DIFF
--- a/drivers/cmd/web/main.go
+++ b/drivers/cmd/web/main.go
@@ -189,7 +189,7 @@ func extractHTTPResponseData(r *http.Response) map[string]interface{} {
 	}
 
 	contentType := r.Header.Get("Content-type")
-	if len(contentType) > 0 && strings.HasPrefix(contentType, "application/json") {
+	if len(contentType) > 0 && strings.Contains(contentType, "json") {
 		var bodyObj interface{}
 		err := json.Unmarshal(bodyBytes, &bodyObj)
 		if err != nil {

--- a/pkg/dipper/web.go
+++ b/pkg/dipper/web.go
@@ -44,7 +44,7 @@ func ExtractWebRequest(r *http.Request) map[string]interface{} {
 
 	if len(body) > 0 {
 		req["body"] = body
-		if strings.HasPrefix(r.Header.Get("content-type"), "application/json") {
+		if strings.Contains(r.Header.Get("content-type"), "json") {
 			j := map[string]interface{}{}
 			Must(json.Unmarshal(body, &j))
 			req["json"] = j


### PR DESCRIPTION


#### Description
The drivers should not rely on an exact match of `application/json` content type.

#### This PR fixes the following issues
N/A