### PR TITLE
chore(ci): update image for semantic-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
       - run: make integration-tests
   semantic-release:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:14
     steps:
       - checkout
       - run: |


### PR DESCRIPTION

#### Description

semantic-release is failing due to requiring a node version upgrade.

#### This PR fixes the following issues
N/A
