### PR TITLE
build: go version and CI updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ---
 defaults: &defaults
   docker:
-    - image: golang:1.17.8-alpine
+    - image: golang:1.17.10-alpine
       environment:
         - GO111MODULE=on
   working_directory: /go/src/github.com/honeydipper/honeydipper
@@ -21,10 +21,13 @@ jobs:
   golangci-lint:
     <<: *defaults
     docker:
-      - image: golangci/golangci-lint:v1.42.1-alpine
+      - image: golangci/golangci-lint:v1.43-alpine
     steps:
       - checkout
       - run: golangci-lint run
+      # Since golangci is ignoring test files, make sure gofmt gets run on
+      # everything
+      - run: golangci-lint run --tests=true --disable-all --enable=gofmt --enable=gofumpt --no-config
   license_finder:
     <<: *defaults
     steps:
@@ -61,7 +64,7 @@ jobs:
   integration:
     <<: *defaults
     docker:
-      - image: golang:1.17.8-alpine
+      - image: golang:1.17.10-alpine
       - image: redis:5.0.14-alpine
     steps:
       - run:
@@ -79,7 +82,7 @@ jobs:
       - run: make integration-tests
   semantic-release:
     docker:
-      - image: circleci/node:14
+      - image: circleci/node:16
     steps:
       - checkout
       - run: |

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,9 +1,0 @@
-# https://github.com/probot/semantic-pull-requests#configuration
-
-# Always validate the PR title AND all the commits
-titleAndCommits: true
-
-# Allow use of Merge commits (eg on github: "Merge branch 'main' into
-# feature/ride-unicorns") this is only relevant when using commitsOnly: true
-# (or titleAndCommits: true)
-allowMergeCommits: true

--- a/.github/workflows/check-semantic-commits.yml
+++ b/.github/workflows/check-semantic-commits.yml
@@ -1,0 +1,27 @@
+---
+name: 'Check Title and Commits'
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: check_pr_title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: true
+          scopes: |
+            core
+            database
+            deps
+            error
+            release
+            util

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.8-alpine AS build
+FROM golang:1.17.10-alpine AS build
 
 ARG GOINSTALLOPTS
 ARG GOGC
@@ -21,7 +21,7 @@ RUN go install -v ./drivers/cmd/redispubsub
 RUN go install -v ./cmd/...
 RUN go install -v ./drivers/...
 
-FROM alpine:3.14
+FROM alpine:3.15
 
 LABEL description="Honeydipper - an event-driven orchestration framework" \
       org.label-schema.vcs-url=https://github.com/honeydipper/honeydipper \

--- a/build/docker/Dockerfile-dev
+++ b/build/docker/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM golang:1.15.7-alpine
+FROM golang:1.17.10-alpine
 
 # Enable module mode (see https://github.com/golang/go/wiki/Modules)
 ENV GO111MODULE=auto


### PR DESCRIPTION
#### Description
- Update to latest 1.17 version of go in Docker and CI
- Update to Alpine 3.15
- Update golangci-lint to v1.43
- Run go fmt on test files in CI
- Update node for semantic-release step to 16

#### This PR fixes the following issues