### PR TITLE
fix: API default timeout use store writeTimeout

### DIFF
--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -366,5 +366,5 @@ func (l *Store) getTimeout(d Def) time.Duration {
 		return dipper.Must(time.ParseDuration(timeoutStr)).(time.Duration)
 	}
 
-	return DefaultAPIWriteTimeout * time.Second
+	return l.writeTimeout
 }

--- a/internal/api/test_fixtures/TypeMatchAPI.yaml
+++ b/internal/api/test_fixtures/TypeMatchAPI.yaml
@@ -8,6 +8,7 @@ def:
   reqType: 2
   service: foo
   object: event
+  ackTimeout: 1000
 
 
 # mock incoming call

--- a/internal/api/test_fixtures/TypeMatchAPI.yaml
+++ b/internal/api/test_fixtures/TypeMatchAPI.yaml
@@ -10,6 +10,9 @@ def:
   object: event
   ackTimeout: 1000
 
+# store config
+config:
+  writeTimeout: 2000
 
 # mock incoming call
 path: /test_type_match

--- a/internal/api/test_fixtures/TypeMatchAPILongRequest.yaml
+++ b/internal/api/test_fixtures/TypeMatchAPILongRequest.yaml
@@ -8,7 +8,7 @@ def:
   reqType: 2
   service: foo
   object: event
-  timeout: 0
+  timeout: 500
 
 # test config
 config:


### PR DESCRIPTION
#### Description

When building an API request, the default timeout should match the store
configured `writeTimeout`. When using the constant value as default, it causes
the API has a longer timeout, and confuses the store yielding 202s instead of
500 timeouts.

Also include a test fix:

This is the only test seems still constantly timing out for the last couple of
months. Increasing the actTimeout should improve this as it did for the type all test.
The better resource class since last PR also helps.

#### This PR fixes the following issues
N/A