### PR TITLE
fix: add RequestHeaderTimeout to http servers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
     <<: *defaults
     resource_class: medium+
     docker:
-      - image: golangci/golangci-lint:v1.46-alpine
+      - image: golangci/golangci-lint:v1.47-alpine
     steps:
       - checkout
       - restore_cache:

--- a/drivers/cmd/webhook/main.go
+++ b/drivers/cmd/webhook/main.go
@@ -26,6 +26,11 @@ import (
 	"github.com/op/go-logging"
 )
 
+const (
+	// Timeout (in seconds) for RequestHeaderTimeout.
+	RequestHeaderTimeoutSecs = 20
+)
+
 var log *logging.Logger
 
 // ErrCalcHash is raised when unable to calculate the hash for validating the webhook request.
@@ -112,8 +117,9 @@ func loadOptions(m *dipper.Message) {
 func startWebhook(m *dipper.Message) {
 	loadOptions(m)
 	server = &http.Server{
-		Addr:    Addr,
-		Handler: http.HandlerFunc(hookHandler),
+		Addr:              Addr,
+		Handler:           http.HandlerFunc(hookHandler),
+		ReadHeaderTimeout: RequestHeaderTimeoutSecs * time.Second,
 	}
 	go func() {
 		log.Infof("[%s] start listening for webhook requests", driver.Service)

--- a/internal/service/api.go
+++ b/internal/service/api.go
@@ -23,6 +23,9 @@ import (
 const (
 	// APIServerGracefulTimeout is the timeout in seconds for waiting for a http.Server to shutdown gracefully.
 	APIServerGracefulTimeout time.Duration = 10
+
+	// Timeout (in seconds) for RequestHeaderTimeout.
+	RequestHeaderTimeoutSecs = 20
 )
 
 var (
@@ -83,8 +86,9 @@ func startAPIListener() {
 		}
 	})
 	APIServer = &http.Server{
-		Addr:    addr,
-		Handler: mux,
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: RequestHeaderTimeoutSecs * time.Second,
 	}
 	go func() {
 		dipper.Logger.Infof("[api] start listening for webhook requests")


### PR DESCRIPTION
#### Description
Set RequestHeaderTimeout to 20s on instances of `http.Server`. Resolves a `gosec` warning, and potentially mitigates the risk of a Slowloris attack

https://pkg.go.dev/net/http#Server


#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
