### PR TITLE
feat(core): graceful shutdown by draining drivers

### DIFF
--- a/.github/workflows/check-semantic-commits.yml
+++ b/.github/workflows/check-semantic-commits.yml
@@ -20,7 +20,8 @@ jobs:
           validateSingleCommit: true
           scopes: |
             core
-            database
+            drivers
+            pkg
             deps
             error
             release

--- a/drivers/cmd/webhook/main.go
+++ b/drivers/cmd/webhook/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	// Timeout (in seconds) for RequestHeaderTimeout.
+	// RequestHeaderTimeoutSecs is the timeout (in seconds) for accepting incoming requests.
 	RequestHeaderTimeoutSecs = 20
 )
 
@@ -124,7 +124,7 @@ func startWebhook(m *dipper.Message) {
 	go func() {
 		log.Infof("[%s] start listening for webhook requests", driver.Service)
 		log.Infof("[%s] listener stopped: %+v", driver.Service, server.ListenAndServe())
-		if driver.State != "exit" && driver.State != "cold" {
+		if driver.State != "stopped" && driver.State != "cold" {
 			startWebhook(m)
 		}
 	}()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,8 @@ const (
 	StageDiscovering
 	// StageServing means all config should be processed and serving.
 	StageServing
+	// StageDrained means that the service has finished all in-fly requests and no longer accepts new requests.
+	StageDrained
 )
 
 var (
@@ -39,6 +41,7 @@ var (
 		"Booting",
 		"Discovering",
 		"Serving",
+		"Drained",
 	}
 
 	// ErrConfigRollback happens when daemon decides to rollback during reload.
@@ -96,13 +99,15 @@ func (c *Config) ResetStage() {
 		}
 	}
 	//nolint:gomnd
-	c.StageWG = make([]*sync.WaitGroup, 3)
+	c.StageWG = make([]*sync.WaitGroup, 4)
 	c.StageWG[StageLoading] = &sync.WaitGroup{}
 	c.StageWG[StageLoading].Add(len(c.Services))
 	c.StageWG[StageBooting] = &sync.WaitGroup{}
 	c.StageWG[StageBooting].Add(len(c.Services))
 	c.StageWG[StageDiscovering] = &sync.WaitGroup{}
 	c.StageWG[StageDiscovering].Add(len(c.Services))
+	c.StageWG[StageServing] = &sync.WaitGroup{}
+	c.StageWG[StageServing].Add(len(c.Services))
 }
 
 // Bootstrap loads the configuration during daemon bootstrap.

--- a/internal/config/gitssh.go
+++ b/internal/config/gitssh.go
@@ -15,7 +15,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
 )
 
-var currentSSHAuth map[string]transport.AuthMethod = map[string]transport.AuthMethod{}
+var currentSSHAuth = map[string]transport.AuthMethod{}
 
 // GetGitSSHAuth creates an AuthMethod to be used for various git operations.
 func GetGitSSHAuth(keyfile, keypassEnv string) transport.AuthMethod {

--- a/internal/driver/schema.go
+++ b/internal/driver/schema.go
@@ -21,4 +21,5 @@ const (
 	DriverReloading
 	DriverAlive
 	DriverFailed
+	DriverStopped
 )

--- a/internal/service/api.go
+++ b/internal/service/api.go
@@ -24,7 +24,7 @@ const (
 	// APIServerGracefulTimeout is the timeout in seconds for waiting for a http.Server to shutdown gracefully.
 	APIServerGracefulTimeout time.Duration = 10
 
-	// Timeout (in seconds) for RequestHeaderTimeout.
+	// RequestHeaderTimeoutSecs is the timeout (in seconds) for accepting incoming requests.
 	RequestHeaderTimeoutSecs = 20
 )
 
@@ -45,7 +45,6 @@ func StartAPI(cfg *config.Config) {
 	API.ServiceReload = reloadAPI
 	API.DiscoverFeatures = APIFeatures
 	API.addResponder("eventbus:api", handleAPIMessage)
-	Services["api"] = API
 	APIRequestStore = api.NewStore(API)
 	API.start()
 }

--- a/internal/service/engine.go
+++ b/internal/service/engine.go
@@ -51,7 +51,6 @@ func (h *WorkflowHelper) GetConfig() *config.Config {
 // StartEngine Starts the engine service.
 func StartEngine(cfg *config.Config) {
 	engine = NewService(cfg, "engine")
-	Services["engine"] = engine
 	helper := &WorkflowHelper{engine: engine}
 	sessionStore = workflow.NewSessionStore(helper)
 

--- a/internal/service/operator.go
+++ b/internal/service/operator.go
@@ -28,7 +28,6 @@ var (
 func StartOperator(cfg *config.Config) {
 	operator = NewService(cfg, "operator")
 	operator.Route = operatorRoute
-	Services["operator"] = operator
 	operator.start()
 }
 

--- a/internal/service/receiver.go
+++ b/internal/service/receiver.go
@@ -25,7 +25,6 @@ func StartReceiver(cfg *config.Config) {
 	receiver.Route = receiverRoute
 	receiver.DiscoverFeatures = ReceiverFeatures
 	receiver.EmitMetrics = receiverMetrics
-	Services["receiver"] = receiver
 	setupReceiverAPIs()
 	receiver.start()
 }

--- a/pkg/dipper/driver.go
+++ b/pkg/dipper/driver.go
@@ -148,12 +148,12 @@ func (d *Driver) start(msg *Message) {
 }
 
 func (d *Driver) stop(msg *Message) {
-	d.State = "exit"
+	d.State = "stopped"
 	if d.Stop != nil {
 		d.Stop(msg)
 	}
 	d.Ping(msg)
-	Logger.Fatalf("[%s] quiting on daemon request", d.Service)
+	Logger.Warningf("[%s] quiting on daemon request", d.Service)
 }
 
 // SendMessage : send a prepared message to daemon.

--- a/pkg/dipper/sync.go
+++ b/pkg/dipper/sync.go
@@ -7,7 +7,10 @@
 // Package dipper is a library used for developing drivers for Honeydipper.
 package dipper
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
 
 // WaitGroupDone is a way to safely decrement the counter for a WaitGroup.
 func WaitGroupDone(wg *sync.WaitGroup) (ok bool) {
@@ -41,4 +44,19 @@ func WaitGroupWait(wg *sync.WaitGroup) {
 	}()
 
 	wg.Wait()
+}
+
+// WaitGroupWaitTimeout is a wrapper for safely waiting for a WaitGroup with a timeout.
+func WaitGroupWaitTimeout(wg *sync.WaitGroup, t time.Duration) {
+	allDone := make(chan interface{})
+	go func() {
+		WaitGroupWait(wg)
+		close(allDone)
+	}()
+
+	select {
+	case <-time.After(t):
+		WaitGroupDoneAll(wg)
+	case <-allDone:
+	}
 }

--- a/pkg/dipper/sync_test.go
+++ b/pkg/dipper/sync_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package dipper
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaitGroupWaitTimeout(t *testing.T) {
+	subj := &sync.WaitGroup{}
+	subj.Add(3)
+	done := false
+	go func() {
+		WaitGroupWaitTimeout(subj, time.Millisecond*10)
+		done = true
+	}()
+	assert.Eventually(t, func() bool { return done }, time.Second, time.Millisecond*5, "WaitGroupWaitTimeout should eventually quit.")
+}
+
+func TestWaitGroupWait(t *testing.T) {
+	subj := &sync.WaitGroup{}
+	subj.Add(3)
+	done := false
+	go func() {
+		WaitGroupDone(subj)
+		WaitGroupWait(subj)
+		done = true
+	}()
+	assert.Never(t, func() bool { return done }, time.Second, time.Millisecond*5, "WaitGroupWait should never quit until the wait group is done.")
+	WaitGroupDoneAll(subj)
+}


### PR DESCRIPTION
#### Description
Upon forceful reload, gracefully stop all drivers before shutdown the
daemon process. Adding a stage in config named `Drained`.

This is useful when we migrate the work from one node to another to allow daemon restarting.

#### This PR fixes the following issues
N/A
