### PR TITLE
ci: upgrade node for semantic release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - run: make integration-tests
   semantic-release:
     docker:
-      - image: circleci/node:16
+      - image: circleci/node:18
     steps:
       - checkout
       - run: |


### PR DESCRIPTION
#### Description
Looks like semantic release now requires node 18 and above.

#### This PR fixes the following issues
https://app.circleci.com/pipelines/github/honeydipper/honeydipper/2810/workflows/5d7c03b6-9d4a-479c-a5fb-4469d6550a24/jobs/8584
