### PR TITLE
ci: use correct node image for ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - run: make integration-tests
   semantic-release:
     docker:
-      - image: circleci/node:18
+      - image: cimg/node:19.6.0
     steps:
       - checkout
       - run: |


### PR DESCRIPTION
#### Description
semantic release still failing because the circleci/node images are superseded by cimg/node images.

#### This PR fixes the following issues
https://app.circleci.com/pipelines/github/honeydipper/honeydipper/2815/workflows/b8707461-32cc-4127-a22d-ae5a7bc83a71/jobs/8612