### PR TITLE
fix: commandHandler protecting the return labels

### DIFF
--- a/pkg/dipper/commandHandler.go
+++ b/pkg/dipper/commandHandler.go
@@ -103,6 +103,12 @@ func (p *CommandProvider) Router(msg *Message) {
 	attempt = func(replyChannel chan Message) {
 		msg.Reply = replyChannel
 		m := *msg
+		// make a copy of Labels so the function call won't
+		// tamper with the original one.
+		m.Labels = map[string]string{}
+		for k, v := range msg.Labels {
+			m.Labels[k] = v
+		}
 
 		go func() {
 			defer func() {


### PR DESCRIPTION
#### Description

commandHandler uses the source msg labels to create the return msg, so if the labels are updated in the function call, the return message will have dirty labels. This causes function returns get send to a wrong recipient in cluster environments. An example is when a workflow calls broadcast method of the redispubsub driver, the source labels were reused to send the broadcast message, and `from` label was updated to local node IP. The function never returns to the caller. By making a copy in the commandHandler, this can be avoid.

#### This PR fixes the following issues
