### PR TITLE
fix: patch method require body in the request

### DIFF
--- a/drivers/cmd/web/main.go
+++ b/drivers/cmd/web/main.go
@@ -120,6 +120,8 @@ func createRequest(method, rurl string, header http.Header, form url.Values, m *
 	var req *http.Request
 
 	switch method {
+	case "PATCH":
+		fallthrough
 	case "POST":
 		fallthrough
 	case "PUT":


### PR DESCRIPTION
#### Description
The web driver does not create a request body for a PATCH request, which fails on API calls using PATCH method.

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
