### PR TITLE
fix: file reference path correction

### DIFF
--- a/internal/config/file_reference.go
+++ b/internal/config/file_reference.go
@@ -20,7 +20,7 @@ import (
 var ErrFileError = errors.New("file error")
 
 func (c *Repo) normalizeFilePath(cwd string, file string) string {
-	fullpath := path.Clean(path.Join(c.root, cwd, file))
+	fullpath := path.Clean(path.Join(cwd, file))
 	if !strings.HasPrefix(fullpath, c.root+"/") {
 		panic(fmt.Errorf("%w: invalid path: %s", ErrFileError, fullpath))
 	}


### PR DESCRIPTION

<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
Since we are using full path in loadFile, the file reference path can now be found without using the c.root.

<!--
Add a description of your pull request.
-->

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
