### PR TITLE
feat: truncate the labels before displaying in logs

### DIFF
--- a/internal/workflow/continue.go
+++ b/internal/workflow/continue.go
@@ -1,4 +1,4 @@
-// Copyright 2022 PayPal Inc.
+// Copyright 2023 PayPal Inc.
 
 // This Source Code Form is subject to the terms of the MIT License.
 // If a copy of the MIT License was not distributed with this file,
@@ -223,7 +223,7 @@ func (w *Session) complete(msg *dipper.Message) {
 		msg.Labels["performing"] = w.performing
 	}
 
-	dipper.Logger.Infof("[workflow] session [%s] completing with msg labels %+v", w.ID, msg.Labels)
+	dipper.Logger.Infof("[workflow] session [%s] completing with msg labels %+v", w.ID, dipper.SanitizedLabels(msg.Labels))
 	if w.ID != "" && dipper.IDMapGet(&w.store.sessions, w.ID) != nil {
 		if w.currentHook == "" {
 			w.processExport(msg)

--- a/pkg/dipper/security.go
+++ b/pkg/dipper/security.go
@@ -1,0 +1,25 @@
+// Copyright 2023 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+// Package dipper is a library used for developing drivers for Honeydipper.
+package dipper
+
+import (
+	util "github.com/Masterminds/goutils"
+)
+
+const MaxLabelLen = 256
+
+func SanitizedLabels(l map[string]string) map[string]string {
+	sl := map[string]string{}
+
+	for k, v := range l {
+		sl[k] = Must(util.AbbreviateFull(v, len(v), MaxLabelLen)).(string)
+		// more sanitization in the future
+	}
+
+	return sl
+}

--- a/pkg/dipper/security_test.go
+++ b/pkg/dipper/security_test.go
@@ -1,0 +1,31 @@
+// Copyright 2023 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package dipper
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizedLabels(t *testing.T) {
+	src := map[string]string{
+		"str1": "foo",
+		"str2": strings.Repeat("x", MaxLabelLen),
+		"str3": strings.Repeat("x", 999) + "123",
+	}
+
+	dst := SanitizedLabels(src)
+
+	assert.Equal(t, src["str1"], dst["str1"], "short string should not change")
+	assert.Equal(t, src["str2"], dst["str2"], "max length string should not change")
+	assert.Equal(t, "..."+strings.Repeat("x", MaxLabelLen-6)+"123", dst["str3"], "long string should be abbreviated")
+}


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->
The label value could be the complete output of a job. Better to shrink it before showing in the logs


#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
