### PR TITLE
fix: correct web driver token_sources missing headers

### DIFF
--- a/drivers/cmd/web/token_test.go
+++ b/drivers/cmd/web/token_test.go
@@ -25,7 +25,7 @@ func TestGetToken(t *testing.T) {
 
 	gock.New("https://api.github.com").
 		Post("/app/installations/123/access_token").
-		Reply(200).
+		Reply(201).
 		JSON(map[string]string{"token": "foobar"})
 
 	keyb64 := dipper.Must(ioutil.ReadFile("test_fixtures/testkey")).([]byte)
@@ -42,8 +42,10 @@ func TestGetToken(t *testing.T) {
 	}
 
 	driver.Options = map[string]interface{}{
-		"token_sources": map[string]interface{}{
-			"test1": githubSource,
+		"data": map[string]interface{}{
+			"token_sources": map[string]interface{}{
+				"test1": githubSource,
+			},
 		},
 	}
 
@@ -60,7 +62,7 @@ func TestGetToken(t *testing.T) {
 
 	gock.New("https://api.github.com").
 		Post("/app/installations/123/access_token").
-		Reply(200).
+		Reply(201).
 		JSON(map[string]string{"token": "foobar2"})
 
 	githubSource["_expiresAt"] = time.Now().Add(-time.Minute * 15)
@@ -69,7 +71,7 @@ func TestGetToken(t *testing.T) {
 
 	gock.New("https://api.github.com").
 		Post("/app/installations/123/access_token").
-		Reply(200).
+		Reply(201).
 		JSON(map[string]string{"token": "foobar3"})
 
 	githubSource["_expiresAt"] = time.Now().Add(-time.Minute * 15)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/spanner v1.45.0
 	cloud.google.com/go/storage v1.29.0
 	github.com/DataDog/datadog-go v4.8.3+incompatible
-	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/goutils v1.1.1
 	github.com/casbin/casbin/v2 v2.41.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-gonic/gin v1.9.1


### PR DESCRIPTION
#### Description
* add headers to the access_token request
* longest allowed token expiration time is 10 min
* token_sources should be under data in driver.Options

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
