### PR TITLE
fix: run hooks in parallel to avoid interference

### DIFF
--- a/internal/workflow/hooks.go
+++ b/internal/workflow/hooks.go
@@ -62,7 +62,7 @@ func (w *Session) executeHook(msg *dipper.Message, hookBlock interface{}) {
 			Context: SessionContextHooks,
 		}
 		for i := 0; i < v.Len(); i++ {
-			childWf.Steps = append(childWf.Steps, config.Workflow{Workflow: v.Index(i).Interface().(string)})
+			childWf.Threads = append(childWf.Threads, config.Workflow{Workflow: v.Index(i).Interface().(string)})
 		}
 		child = w.createChildSession(&childWf, msg)
 	}

--- a/internal/workflow/session_hook_test.go
+++ b/internal/workflow/session_hook_test.go
@@ -308,6 +308,7 @@ func TestOnFailureHook(t *testing.T) {
 				},
 				"ctx": map[string]interface{}{},
 				"asserts": func() {
+					mockHelper.EXPECT().GetDaemonID().Return("")
 					mockHelper.EXPECT().SendMessage(gomock.Eq(&dipper.Message{
 						Channel: "eventbus",
 						Subject: "command",
@@ -316,10 +317,10 @@ func TestOnFailureHook(t *testing.T) {
 						},
 						Payload: map[string]interface{}{
 							"ctx": map[string]interface{}{
-								"_meta_desc":   "",
-								"_meta_name":   "foo.failure",
-								"resume_token": "//0",
-								"step_number":  int32(0),
+								"_meta_desc":    "",
+								"_meta_name":    "foo.failure",
+								"resume_token":  "//2",
+								"thread_number": 0,
 							},
 							"data":  map[string]interface{}{},
 							"event": map[string]interface{}{},


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->

The hook execution return may override the parent workflow return causing following hook to receive wrong data. Making the hook execution in parallel avoids the problem and also make it faster.

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
