### PR TITLE
ci: install dockerize with wget

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,8 +102,12 @@ jobs:
       - run:
           name: install dependencies
           command: >
-            apk add --repository http://dl-3.alpinelinux.org/alpine/edge/testing
-            git openssh-client gcc libc-dev dockerize make
+            apk add git openssh-client gcc libc-dev make &&
+            wget "$DOCKERIZE_URL" &&
+            tar zxvf "$(basename "$DOCKERIZE_URL")" &&
+            install dockerize /usr/local/bin
+          environment:
+            DOCKERIZE_URL: https://github.com/jwilder/dockerize/releases/download/v0.7.0/dockerize-alpine-linux-amd64-v0.7.0.tar.gz
       - checkout
       - restore-mod
       - run:


### PR DESCRIPTION

<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->
Dockerizer can no longer be installed from apk

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
