### PR TITLE
fix: not reusing success messages

### DIFF
--- a/internal/workflow/execute.go
+++ b/internal/workflow/execute.go
@@ -17,10 +17,13 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-var Success = &dipper.Message{
-	Labels: map[string]string{
-		"status": SessionStatusSuccess,
-	},
+// Success returns a empty message with success status.
+func Success() *dipper.Message {
+	return &dipper.Message{
+		Labels: map[string]string{
+			"status": SessionStatusSuccess,
+		},
+	}
 }
 
 // execute is the entry point of the workflow.
@@ -73,7 +76,7 @@ func (w *Session) execute(msg *dipper.Message) {
 // noop continues the workflow as doing nothing.
 func (w *Session) noop(msg *dipper.Message) {
 	if msg.Labels["status"] != "success" {
-		msg = Success
+		msg = Success()
 	}
 	if w.ID != "" {
 		w.continueExec(msg, nil)
@@ -314,7 +317,7 @@ func (w *Session) executeAction(msg *dipper.Message) {
 				defer dipper.SafeExitOnError("Failed in execute detached workflow %+v", w.workflow.Workflow)
 				child.execute(msg)
 			})
-			w.continueExec(Success, nil)
+			w.continueExec(Success(), nil)
 		} else {
 			child.execute(msg)
 		}
@@ -343,7 +346,7 @@ func (w *Session) executeAction(msg *dipper.Message) {
 		w.performing = "switch"
 		w.executeSwitch(msg)
 	default:
-		w.continueExec(Success, nil)
+		w.continueExec(Success(), nil)
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->
The reusable Success message should be immutable, but it seems harder to maintain the immutability. There has been cases where the Success message was contaminated with failure message, which requires a restart to clear. Using a disposable success message seems safer and easier.


#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
