### PR TITLE
ci: update golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
     <<: *defaults
     resource_class: medium+
     docker:
-      - image: golangci/golangci-lint:v1.50-alpine
+      - image: golangci/golangci-lint:v1.59-alpine
     steps:
       - checkout
       - restore_cache:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,9 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
     - dogsled
     - dupl
+    - err113
     - errorlint
     - exportloopref
     - funlen
@@ -17,17 +17,16 @@ linters:
     - gocyclo
     - godot
     - godox
-    - goerr113
     - gofmt
     - gofumpt
     - goheader
     - goimports
-    - gomnd
     - gomodguard
     - goprintffuncname
     - gosec
     - lll
     - misspell
+    # - mnd
     - nakedret
     - nestif
     - nlreturn
@@ -35,7 +34,7 @@ linters:
     - nolintlint
     - paralleltest
     - prealloc
-    - revive
+    # - revive
     - rowserrcheck
     - sqlclosecheck
     - stylecheck
@@ -57,13 +56,13 @@ linters-settings:
 
 issues:
   exclude-rules:
-    - path: (.+)_test.go
+    - path: _test\.go
       linters:
         - dupl
+        - err113
         - errcheck
         - funlen
         - gocritic
-        - goerr113
         - gosec
         - lll
         - nestif


### PR DESCRIPTION
#### Description
Try to get golangci-lint to a passing baseline.

- Update golangci-lint to v1.59
- Update test file ignore regex
- Resolve deprecation warning from linter package renames, but comment out `mnd`, and `revive` for now - these can be re-enabled as separate PRs if desired, but create a number of warnings with the existing code.

Note: `depguard` was enabled in config, but doesn't seem to have a configured set of allowed dependencies, and as such, was failing.

It looks like things like the failures in #598 etc. have more to do with the large # of deps that are also getting updated there.

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
