### PR TITLE
fix: k8s job only fail if succeeded is 0

### DIFF
--- a/drivers/cmd/kubernetes/main.go
+++ b/drivers/cmd/kubernetes/main.go
@@ -213,7 +213,7 @@ func waitForJob(m *dipper.Message) {
 			jobStatus = StatusSuccess
 			reason    []string
 		)
-		if job.Status.Failed > 0 {
+		if job.Status.Succeeded == 0 {
 			jobStatus = StatusFailure
 			for _, condition := range job.Status.Conditions {
 				reason = append(reason, condition.Reason)


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
