### PR TITLE
fix: secret lookup should return raw message with bytes

### DIFF
--- a/drivers/cmd/hd-driver-vault/main.go
+++ b/drivers/cmd/hd-driver-vault/main.go
@@ -96,7 +96,7 @@ func lookup(msg *dipper.Message) {
 	}
 
 	msg.Reply <- dipper.Message{
-		Payload: value,
+		Payload: []byte(value.(string)),
 		IsRaw:   true,
 	}
 }

--- a/internal/config/collapsed_trigger.go
+++ b/internal/config/collapsed_trigger.go
@@ -44,6 +44,12 @@ func CollapseTrigger(t *Trigger, c *DataSet) (*Trigger, *CollapsedTrigger) {
 		params = dipper.MergeMap(params, dipper.MustDeepCopyMap(trigger.Parameters))
 		match = dipper.MergeMap(match, dipper.MustDeepCopyMap(trigger.Match))
 		exports = append(exports, trigger.Export)
+
+		if current.Driver == "webhook" {
+			if sigsec, ok := sourceSys.Data["signatureSecret"]; ok && sigsec.(string) != "" {
+				match["verifiedSystem"] = trigger.Source.System
+			}
+		}
 	}
 
 	if len(sysData) > 0 {
@@ -52,10 +58,6 @@ func CollapseTrigger(t *Trigger, c *DataSet) (*Trigger, *CollapsedTrigger) {
 		}
 		match = dipper.Interpolate(match, envData).(map[string]interface{})
 		params = dipper.Interpolate(params, envData).(map[string]interface{})
-	}
-
-	if flag, ok := params["verifySystem"]; ok && dipper.IsTruthy(flag) {
-		match["verifiedSystem"] = t.Source.System
 	}
 
 	return current, &CollapsedTrigger{


### PR DESCRIPTION
#### Description
secret lookup in hd-driver-vault should return byte array instead of a string.

Also, ensure all webhook events for systems with signatureSecrets are verified.

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
