### PR TITLE
fix: sync creating parallel childs to avoid concurrent map access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# [3.10.0](https://github.com/honeydipper/honeydipper/compare/v3.9.2...v3.10.0) (2026-02-15)
+
+
+### Bug Fixes
+
+* **deps:** update module github.com/go-git/go-git/v5 to v5.16.5 [security] ([#680](https://github.com/honeydipper/honeydipper/issues/680)) ([0bdc406](https://github.com/honeydipper/honeydipper/commit/0bdc4060c71d0ff2a45da9bbaba12612595b7f38))
+* **deps:** update module golang.org/x/crypto to v0.45.0 [security] ([8cab2d7](https://github.com/honeydipper/honeydipper/commit/8cab2d7b6c1255ab32342f3017ca46d01ef37f7d))
+* openai in non-streaming mode ([aca7e40](https://github.com/honeydipper/honeydipper/commit/aca7e40461adbcba3cf8bf385bb76d79156a6089))
+* tested successfully ([d37a79a](https://github.com/honeydipper/honeydipper/commit/d37a79a63149893fe1b0c8bab20bbd3e8c1d8575))
+* tests and changes to support tests ([a0ea244](https://github.com/honeydipper/honeydipper/commit/a0ea244c90b4d3cf35c2ad88e07aa2f22dd26d1c))
+
+
+### Features
+
+* add openai driver ([6ff362d](https://github.com/honeydipper/honeydipper/commit/6ff362dde6a4db7255fb6ffa480afad5fb1cb9ec))
+
 # [3.10.0](https://github.com/honeydipper/honeydipper/compare/v3.9.2...v3.10.0) (2026-02-13)
 
 

--- a/internal/workflow/continue.go
+++ b/internal/workflow/continue.go
@@ -366,7 +366,10 @@ func (w *Session) continueExec(msg *dipper.Message, exports []map[string]interfa
 				i := poolCount + int(w.iteration)
 				if i < w.lenOfIterate() {
 					daemon.Children.Add(1)
-					go w.launchParallelIteration(i)
+					go func() {
+						defer daemon.Children.Done()
+						w.createParallelIteration(i).execute(w.origMsg)
+					}()
 				}
 			}
 		}

--- a/internal/workflow/execute.go
+++ b/internal/workflow/execute.go
@@ -151,16 +151,22 @@ func (w *Session) launchParallelIterations(msg *dipper.Message) {
 	}
 
 	w.origMsg = msg
+	children := make([]*Session, poolCount)
+	for i := 0; i < poolCount; i++ {
+		children[i] = w.createParallelIteration(i)
+	}
+
 	for i := 0; i < poolCount; i++ {
 		daemon.Children.Add(1)
-		go w.launchParallelIteration(i)
+		go func(i int) {
+			children[i].execute(w.origMsg)
+			defer daemon.Children.Done()
+		}(i)
 	}
 }
 
-// launchParallelIteration starts one of the iteration.
-func (w *Session) launchParallelIteration(i int) {
-	defer daemon.Children.Done()
-
+// createParallelIteration starts one of the iteration.
+func (w *Session) createParallelIteration(i int) *Session {
 	single := config.Workflow{
 		Workflow:     w.workflow.Workflow,
 		Function:     w.workflow.Function,
@@ -184,7 +190,7 @@ func (w *Session) launchParallelIteration(i int) {
 	}
 	delete(child.ctx, "resume_token")
 
-	child.execute(w.origMsg)
+	return child
 }
 
 // executeIteration takes actions for items in iteration list.


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->
Synchroize the parallel child session creation to avoid concurrent map iterations, which could lead to crashes.
#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
