### PR TITLE
fix: sync creating parallel childs to avoid concurrent map access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,4 +175,6 @@ workflows:
           context: honeydipper
           filters:
             branches:
-              only: main
+              only:
+                - main
+                - v3

--- a/internal/workflow/continue.go
+++ b/internal/workflow/continue.go
@@ -369,11 +369,13 @@ func (w *Session) continueExec(msg *dipper.Message, exports []map[string]interfa
 					// Create the child session synchronously under ctxLock to avoid
 					// concurrent read/write on w.ctx during deep-copy in createParallelIteration.
 					w.ctxLock.Lock()
+					defer w.ctxLock.Unlock()
 					child := w.createParallelIteration(i)
-					w.ctxLock.Unlock()
 
 					go func(child *Session) {
 						defer daemon.Children.Done()
+						defer dipper.SafeExitOnError("Failed in execute child thread with %+v", child.workflow)
+						defer w.onError()
 						child.execute(w.origMsg)
 					}(child)
 				}

--- a/internal/workflow/continue.go
+++ b/internal/workflow/continue.go
@@ -366,10 +366,16 @@ func (w *Session) continueExec(msg *dipper.Message, exports []map[string]interfa
 				i := poolCount + int(w.iteration)
 				if i < w.lenOfIterate() {
 					daemon.Children.Add(1)
-					go func() {
+					// Create the child session synchronously under ctxLock to avoid
+					// concurrent read/write on w.ctx during deep-copy in createParallelIteration.
+					w.ctxLock.Lock()
+					child := w.createParallelIteration(i)
+					w.ctxLock.Unlock()
+
+					go func(child *Session) {
 						defer daemon.Children.Done()
-						w.createParallelIteration(i).execute(w.origMsg)
-					}()
+						child.execute(w.origMsg)
+					}(child)
 				}
 			}
 		}

--- a/internal/workflow/continue.go
+++ b/internal/workflow/continue.go
@@ -366,7 +366,10 @@ func (w *Session) continueExec(msg *dipper.Message, exports []map[string]interfa
 				i := poolCount + int(w.iteration)
 				if i < w.lenOfIterate() {
 					daemon.Children.Add(1)
-					go w.launchParallelIteration(i)
+					go func() {
+						defer daemon.Children.Done()
+						w.createParallelIteration(i).execute(w.origMsg)
+					}()
 				}
 			}
 		}

--- a/internal/workflow/execute.go
+++ b/internal/workflow/execute.go
@@ -151,16 +151,22 @@ func (w *Session) launchParallelIterations(msg *dipper.Message) {
 	}
 
 	w.origMsg = msg
+	children := make([]*Session, poolCount)
+	for i := 0; i < poolCount; i++ {
+		children[i] = w.createParallelIteration(i)
+	}
+
 	for i := 0; i < poolCount; i++ {
 		daemon.Children.Add(1)
-		go w.launchParallelIteration(i)
+		go func(i int) {
+			defer daemon.Children.Done()
+			children[i].execute(w.origMsg)
+		}(i)
 	}
 }
 
-// launchParallelIteration starts one of the iteration.
-func (w *Session) launchParallelIteration(i int) {
-	defer daemon.Children.Done()
-
+// createParallelIteration starts one of the iteration.
+func (w *Session) createParallelIteration(i int) *Session {
 	single := config.Workflow{
 		Workflow:     w.workflow.Workflow,
 		Function:     w.workflow.Function,
@@ -184,7 +190,7 @@ func (w *Session) launchParallelIteration(i int) {
 	}
 	delete(child.ctx, "resume_token")
 
-	child.execute(w.origMsg)
+	return child
 }
 
 // executeIteration takes actions for items in iteration list.

--- a/internal/workflow/execute.go
+++ b/internal/workflow/execute.go
@@ -165,7 +165,7 @@ func (w *Session) launchParallelIterations(msg *dipper.Message) {
 	}
 }
 
-// createParallelIteration starts one of the iteration.
+// createParallelIteration creates and prepares a child Session for one parallel iteration.
 func (w *Session) createParallelIteration(i int) *Session {
 	single := config.Workflow{
 		Workflow:     w.workflow.Workflow,

--- a/internal/workflow/execute.go
+++ b/internal/workflow/execute.go
@@ -160,6 +160,8 @@ func (w *Session) launchParallelIterations(msg *dipper.Message) {
 		daemon.Children.Add(1)
 		go func(i int) {
 			defer daemon.Children.Done()
+			defer dipper.SafeExitOnError("Failed in execute child thread with %+v", children[i].workflow)
+			defer w.onError()
 			children[i].execute(w.origMsg)
 		}(i)
 	}

--- a/internal/workflow/execute.go
+++ b/internal/workflow/execute.go
@@ -152,6 +152,8 @@ func (w *Session) launchParallelIterations(msg *dipper.Message) {
 
 	w.origMsg = msg
 	children := make([]*Session, poolCount)
+	w.ctxLock.Lock()
+	defer w.ctxLock.Unlock()
 	for i := 0; i < poolCount; i++ {
 		children[i] = w.createParallelIteration(i)
 	}


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->
A few crashes have been detected due to concurrent map read iterations. Making this synchronized to avoid the crashes.


#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
