### PR TITLE
feat(workflow): sending pseudo events from workflow

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -77,16 +77,30 @@ rules:
 ```
 
 ### Simple Actions
-There are 4 types of simple actions that a workflow can perform.
+There are 5 types of simple actions that a workflow can perform.
 
  - `call_workflow`: calling out to another named workflow, taking a string specifying the name of the workflow
  - `call_function`: calling a predefined system function, taking a string in the form of `system.function`
  - `call_driver`: calling a `rawAction` offered by a driver, taking a string in the form of `driver.rawAction`
+ - `send_event`: send a message to `eventbus:message` so the engine can match it against rules and start new sessions. The value is a map containing an `events` list (event names) and an optional `data` map. A fresh `eventID` is generated automatically.
  - `wait`: wait for the specified amount of time or receive a wake-up request with a matching token. The time should be formatted according to the requirement for function [ParseDuration](https://golang.org/pkg/time/#ParseDuration). A unit suffix is required.
 
 They can not be combined.
 
 A function can also have no action at all. `{}` is a perfectly legit no-op workflow.
+
+Example of `send_event` that fires a synthetic event for the engine to pick up:
+
+```yaml
+---
+workflows:
+  fire_my_event:
+    send_event:
+      events:
+        - mySystem.myTrigger
+      data:
+        key: value
+```
 
 ### Complex Actions
 Complex actions are groups of multiple `workflows` organized together to do some complex work.

--- a/drivers/cmd/redisqueue/main.go
+++ b/drivers/cmd/redisqueue/main.go
@@ -65,6 +65,7 @@ func main() {
 		driver.MessageHandlers["eventbus:message"] = relayToRedis
 	case "engine":
 		driver.MessageHandlers["eventbus:command"] = relayToRedis
+		driver.MessageHandlers["eventbus:message"] = relayToRedis
 	case "operator":
 		driver.MessageHandlers["eventbus:command"] = relayToRedis
 		driver.MessageHandlers["eventbus:return"] = relayToRedis

--- a/drivers/cmd/redisqueue/main_test.go
+++ b/drivers/cmd/redisqueue/main_test.go
@@ -120,6 +120,58 @@ func TestOperatorRelayToRedis(t *testing.T) {
 	<-done
 }
 
+func TestEngineRelayEventToRedis(t *testing.T) {
+	db, mock := redismock.NewClientMock()
+	redisOptionsMock = &redisclient.Options{Client: db}
+
+	i, inbuf := io.Pipe()
+	outbuf, o := io.Pipe()
+
+	done := testStartDriver(t, "engine", i, o)
+	dipper.SendMessage(inbuf, &dipper.Message{
+		Channel: "command",
+		Subject: "options",
+		Payload: map[string]interface{}{
+			"data": map[string]interface{}{
+				"connection": map[string]interface{}{
+					"Addr":     "1.1.1.1:6379",
+					"Username": "nouser",
+					"Password": "123",
+					"DB":       "2",
+				},
+			},
+		},
+	})
+	dipper.SendMessage(inbuf, &dipper.Message{
+		Channel: "command",
+		Subject: "start",
+	})
+
+	reply := dipper.FetchRawMessage(outbuf)
+	assert.Equal(t, "state", reply.Channel, "reply channel should be state")
+	assert.Equal(t, "alive", reply.Subject, "reply subject should be alive")
+
+	driver.State = dipper.DriverStateCompleted
+
+	mock.MatchExpectationsInOrder(false)
+	mock.ExpectBLPop(time.Second, "honeydipper:events").SetVal([]string{})
+	mock.ExpectBLPop(time.Second, "honeydipper:return").SetVal([]string{})
+	mock.ExpectRPush("honeydipper:events", `{"data":"{\"events\":[\"demo.event\"]}","labels":{"from":"`+dipper.GetIP()+`"}}`).SetVal(1)
+
+	dipper.SendMessage(inbuf, &dipper.Message{
+		Channel: "eventbus",
+		Subject: "message",
+		Payload: map[string]interface{}{
+			"events": []string{"demo.event"},
+		},
+	})
+
+	time.Sleep(time.Millisecond * 100)
+	assert.NoError(t, mock.ExpectationsWereMet(), "mock redis expectations not met")
+	inbuf.Close()
+	<-done
+}
+
 func TestOperatorEmit(t *testing.T) {
 	db, mock := redismock.NewClientMock()
 	redisOptionsMock = &redisclient.Options{

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -99,6 +99,8 @@ type Workflow struct {
 	Detach       bool
 	Resume       string
 
+	SendEvent interface{} `json:"send_event" mapstructure:"send_event"`
+
 	Switch  string
 	Cases   map[string]interface{}
 	Default interface{}

--- a/pkg/workflow/execute.go
+++ b/pkg/workflow/execute.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/honeydipper/honeydipper/v4/internal/config"
 	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
 	"github.com/mitchellh/mapstructure"
@@ -47,6 +48,10 @@ func (w *Session) execute() {
 		w.Action++
 		w.callShorthandFunction(w.Workflow.CallFunction)
 		w.pending = true
+	case w.Workflow.SendEvent != nil:
+		w.setPerforming("sending eventbus:message")
+		w.Action++
+		w.sendEventbusMessage()
 	case w.Workflow.Steps != nil:
 		// Execute workflow steps sequentially.
 		w.setPerforming("step - " + strconv.Itoa(w.Current))
@@ -254,6 +259,26 @@ func (w *Session) callShorthandFunction(f string) {
 			Function: funcName,
 		},
 	})
+}
+
+// sendEventbusMessage emits an eventbus:message for engine rule processing.
+func (w *Session) sendEventbusMessage() {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		panic(err)
+	}
+
+	msg := &dipper.Message{
+		Channel: dipper.ChannelEventbus,
+		Subject: dipper.EventbusMessage,
+		Payload: w.Workflow.SendEvent,
+		Labels: map[string]string{
+			"eventID": id.String(),
+		},
+	}
+
+	w.store.SendMessage(msg)
+	w.CurrentMsg.Labels["status"] = SessionStatusSuccess
 }
 
 // executeSwitch selects and executes a branch based on the switch condition.

--- a/pkg/workflow/execute_test.go
+++ b/pkg/workflow/execute_test.go
@@ -351,6 +351,41 @@ func TestExecute_CallFunctionBranch(t *testing.T) {
 	}
 }
 
+func TestExecute_SendEventBranch(t *testing.T) {
+	s := makeExecuteSession()
+	es := &execTestStore{}
+	s.store = es
+	s.Workflow.SendEvent = map[string]any{
+		"events": []any{"{{.ctx.raw_event}}"},
+		"data":   map[string]any{"flag": "{{.ctx.flag}}"},
+	}
+
+	s.execute()
+
+	if len(es.lastSentMessages) != 1 {
+		t.Fatalf("expected one message sent, got %d", len(es.lastSentMessages))
+	}
+	msg := es.lastSentMessages[0]
+	if msg.Channel != dipper.ChannelEventbus || msg.Subject != dipper.EventbusMessage {
+		t.Errorf("unexpected message channel/subject: %s/%s", msg.Channel, msg.Subject)
+	}
+	pm, ok := msg.Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("payload is not map: %v", msg.Payload)
+	}
+	events, ok := pm["events"].([]any)
+	if !ok || len(events) != 1 || events[0] != "{{.ctx.raw_event}}" {
+		t.Fatalf("unexpected events payload: %+v", pm["events"])
+	}
+	data, ok := pm["data"].(map[string]any)
+	if !ok || data["flag"] != "{{.ctx.flag}}" {
+		t.Fatalf("unexpected data payload: %+v", pm["data"])
+	}
+	if s.pending {
+		t.Error("eventbus_message branch should not set pending")
+	}
+}
+
 func TestExecute_FailedWorkflowPanics(t *testing.T) {
 	s := makeExecuteSession()
 	es := &execTestStore{}

--- a/pkg/workflow/session.go
+++ b/pkg/workflow/session.go
@@ -251,6 +251,8 @@ func (w *Session) Brief() string {
 		w.brief = "system func: " + wf.CallFunction
 	case wf.CallDriver != "":
 		w.brief = "driver func: " + wf.CallDriver
+	case wf.SendEvent != nil:
+		w.brief = "send event"
 	case wf.Workflow != "":
 		w.brief = "wrapper: " + wf.Workflow
 	case len(wf.Steps) > 0:
@@ -337,6 +339,7 @@ func (w *Session) checkIsNoop() bool {
 	case w.isFunction():
 	case w.Workflow.CallDriver != "":
 	case w.Workflow.CallFunction != "":
+	case w.Workflow.SendEvent != nil:
 	case len(w.Workflow.Steps) != 0:
 	case len(w.Workflow.Threads) != 0:
 	case w.Workflow.Wait != "":

--- a/pkg/workflow/session_init.go
+++ b/pkg/workflow/session_init.go
@@ -260,6 +260,7 @@ func (w *Session) interpolateWorkflow() {
 	ret.Wait = dipper.InterpolateStr(v.Wait, envData)
 	ret.CallFunction = dipper.InterpolateStr(v.CallFunction, envData)
 	ret.CallDriver = dipper.InterpolateStr(v.CallDriver, envData)
+	ret.SendEvent = dipper.Interpolate(v.SendEvent, envData)
 	ret.Resume = dipper.InterpolateStr(v.Resume, envData)
 	ret.CacheKey = dipper.InterpolateStr(v.CacheKey, envData)
 	ret.CacheTTL = dipper.InterpolateStr(v.CacheTTL, envData)

--- a/pkg/workflow/session_init_test.go
+++ b/pkg/workflow/session_init_test.go
@@ -381,7 +381,7 @@ func TestInjectLocalCTX(t *testing.T) {
 
 func TestInterpolateWorkflow(t *testing.T) {
 	s := makeSession()
-	s.Ctx = map[string]interface{}{"name": "n", "desc": "d", "ifval": "i", "any": "a", "unless": "u", "uall": "ua", "match": "m", "umatch": "um", "retry": "r", "backoff": "b", "wait": "w", "callFunc": "cf", "callDrv": "cd", "resume": "rs", "pool": "p"}
+	s.Ctx = map[string]interface{}{"name": "n", "desc": "d", "ifval": "i", "any": "a", "unless": "u", "uall": "ua", "match": "m", "umatch": "um", "retry": "r", "backoff": "b", "wait": "w", "callFunc": "cf", "callDrv": "cd", "resume": "rs", "pool": "p", "evt": "sys.trigger"}
 	wf := &cfg.Workflow{
 		Name:            "{{.ctx.name}}",
 		Description:     "{{.ctx.desc}}",
@@ -396,6 +396,7 @@ func TestInterpolateWorkflow(t *testing.T) {
 		Wait:            "{{.ctx.wait}}",
 		CallFunction:    "{{.ctx.callFunc}}",
 		CallDriver:      "{{.ctx.callDrv}}",
+		SendEvent:       map[string]interface{}{"events": []interface{}{"{{.ctx.evt}}"}},
 		Resume:          "{{.ctx.resume}}",
 		Iterate:         []interface{}{1},
 		IterateParallel: []interface{}{2},
@@ -419,6 +420,14 @@ func TestInterpolateWorkflow(t *testing.T) {
 	}
 	if s.Workflow.CallFunction != "cf" || s.Workflow.CallDriver != "cd" {
 		t.Error("calls not interpolated")
+	}
+	msg, ok := s.Workflow.SendEvent.(map[string]interface{})
+	if !ok {
+		t.Fatalf("send_event not interpolated as map: %T", s.Workflow.SendEvent)
+	}
+	events, ok := msg["events"].([]interface{})
+	if !ok || len(events) != 1 || events[0] != "sys.trigger" {
+		t.Fatalf("send_event events not interpolated: %+v", msg)
 	}
 	if arr, ok := s.Workflow.Iterate.([]interface{}); !ok || len(arr) == 0 {
 		t.Error("iterate fields lost")

--- a/pkg/workflow/session_test.go
+++ b/pkg/workflow/session_test.go
@@ -339,6 +339,18 @@ func TestBrief_WithCallDriver(t *testing.T) {
 	}
 }
 
+// TestBrief_WithSendEvent tests the Brief method with send_event.
+func TestBrief_WithSendEvent(t *testing.T) {
+	wf := &cfg.Workflow{SendEvent: map[string]interface{}{"events": []interface{}{"a.b"}}}
+	s := newSession(wf)
+
+	brief := s.Brief()
+
+	if brief != "send event" {
+		t.Errorf("expected 'send event', got '%s'", brief)
+	}
+}
+
 // TestBrief_WithWorkflow tests the Brief method with workflow.
 func TestBrief_WithWorkflow(t *testing.T) {
 	wf := &cfg.Workflow{Workflow: "other_workflow"}
@@ -702,6 +714,18 @@ func TestCheckIsNoop_WithCallFunction(t *testing.T) {
 
 	if result {
 		t.Fatal("expected checkIsNoop to return false for callFunction")
+	}
+}
+
+// TestCheckIsNoop_WithSendEvent tests the checkIsNoop method with send_event.
+func TestCheckIsNoop_WithSendEvent(t *testing.T) {
+	wf := &cfg.Workflow{SendEvent: map[string]interface{}{"events": []interface{}{"a.b"}}}
+	s := newSession(wf)
+
+	result := s.checkIsNoop()
+
+	if result {
+		t.Fatal("expected checkIsNoop to return false for eventbus_message")
 	}
 }
 


### PR DESCRIPTION
Use the event to decouple async workflow sessions.

<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
