### PR TITLE
fix: delayed regex compiling for conditions

### DIFF
--- a/pkg/dipper/condition.go
+++ b/pkg/dipper/condition.go
@@ -20,7 +20,10 @@ func Compare(actual string, criteria interface{}) bool {
 
 	strVal, ok := criteria.(string)
 	if ok {
-		return (strVal == actual)
+		if !strings.HasPrefix(strVal, ":regex:") {
+			return (strVal == actual)
+		}
+		criteria = Must(regexp.Compile(strVal[7:])).(*regexp.Regexp)
 	}
 
 	re, ok := criteria.(*regexp.Regexp)

--- a/pkg/dipper/interpolation.go
+++ b/pkg/dipper/interpolation.go
@@ -124,7 +124,6 @@ func ParseYaml(pattern string) interface{} {
 	if err != nil {
 		panic(err)
 	}
-	Recursive(data, RegexParser)
 
 	return data
 }


### PR DESCRIPTION
The regex in contexts dont survive persistence and loading. Have to keep it in the string form and compile it during compare time.

<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
