### PR TITLE
feat(api): add gh-scoped workflow controls

### DIFF
--- a/.github/workflows/check-semantic-commits.yml
+++ b/.github/workflows/check-semantic-commits.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           validateSingleCommit: true
           scopes: |
+            api
             config
             core
             deps

--- a/internal/api/def.go
+++ b/internal/api/def.go
@@ -108,6 +108,34 @@ func GetDefs() map[string]map[string]Def {
 				EntitlementKey:      "gh_slug",
 			},
 		},
+		"gh/events/:sessionID/rerun/*gh_slug": {
+			http.MethodPost: {
+				Object: "gh_event", Name: "ghEventRerun", ReqType: TypeFirst, Service: "engine",
+				EntitlementProvider: "auth-github",
+				EntitlementKey:      "gh_slug",
+			},
+		},
+		"gh/events/:sessionID/pause/*gh_slug": {
+			http.MethodPost: {
+				Object: "gh_event", Name: "ghEventPause", ReqType: TypeFirst, Service: "engine",
+				EntitlementProvider: "auth-github",
+				EntitlementKey:      "gh_slug",
+			},
+		},
+		"gh/events/:sessionID/resume/*gh_slug": {
+			http.MethodPost: {
+				Object: "gh_event", Name: "ghEventResume", ReqType: TypeFirst, Service: "engine",
+				EntitlementProvider: "auth-github",
+				EntitlementKey:      "gh_slug",
+			},
+		},
+		"gh/events/:sessionID/interact/*gh_slug": {
+			http.MethodPost: {
+				Object: "gh_event", Name: "ghEventInteract", AttachPrincipalUser: true, ReqType: TypeFirst, Service: "engine",
+				EntitlementProvider: "auth-github",
+				EntitlementKey:      "gh_slug",
+			},
+		},
 		"pods/:pod_id/log/chunk": {
 			http.MethodGet: {
 				Object: "pod_log", Name: "podLogChunk", ReqType: TypeFirst, Service: "operator",

--- a/internal/service/engine_apis.go
+++ b/internal/service/engine_apis.go
@@ -25,6 +25,7 @@ var (
 	ErrSessionControlUnsupported = errors.New("session store does not support session control")
 	ErrUnknownSessionAction      = errors.New("unknown action")
 	ErrSessionStoreNoRerun       = errors.New("session store does not support rerun")
+	ErrUnauthorized              = errors.New("unauthorized: session does not belong to this repository")
 )
 
 func setupEngineAPIs() {
@@ -36,6 +37,10 @@ func setupEngineAPIs() {
 	engine.APIs["eventInteract"] = handleEventInteract
 	engine.APIs["eventCancel"] = handleEventCancel
 	engine.APIs["ghEventList"] = handleGHEventList
+	engine.APIs["ghEventRerun"] = handleGHEventRerun
+	engine.APIs["ghEventPause"] = handleGHEventPause
+	engine.APIs["ghEventResume"] = handleGHEventResume
+	engine.APIs["ghEventInteract"] = handleGHEventInteract
 }
 
 type rerunSessionStarter interface {
@@ -362,4 +367,103 @@ func getSessionGitRepo(event map[string]interface{}) string {
 	}
 
 	return ""
+}
+
+func verifySessionBelongsToGHSlug(sessionID string, ghSlug string) error {
+	if sessionStore == nil {
+		return ErrSessionNotFound
+	}
+
+	session := workflow.GetStoredSession(sessionStore, sessionID)
+	if session == nil {
+		return ErrSessionNotFound
+	}
+
+	// Extract git_repo from session's EventCtx
+	var repo string
+	if session.EventCtx != nil {
+		if r, ok := session.EventCtx["git_repo"].(string); ok {
+			repo = r
+		}
+	}
+
+	if strings.TrimSpace(repo) == "" {
+		return ErrUnauthorized
+	}
+
+	normalizedSlug := strings.ToLower(strings.Trim(strings.TrimSpace(ghSlug), "/"))
+	normalizedRepo := strings.ToLower(strings.Trim(strings.TrimSpace(repo), "/"))
+
+	if normalizedSlug == "" {
+		return ErrUnauthorized
+	}
+
+	isRepo := strings.Contains(normalizedSlug, "/")
+	if (isRepo && normalizedRepo == normalizedSlug) || (!isRepo && strings.HasPrefix(normalizedRepo, normalizedSlug+"/")) {
+		return nil
+	}
+
+	return ErrUnauthorized
+}
+
+func handleGHEventRerun(resp *api.Response) {
+	defer func() {
+		if r := recover(); r != nil {
+			resp.ReturnError(r.(error))
+		}
+	}()
+
+	resp.Request = dipper.DeserializePayload(resp.Request)
+	sessionID := dipper.MustGetMapDataStr(resp.Request.Payload, "sessionID")
+	ghSlug, _ := dipper.GetMapDataStr(resp.Request.Payload, "gh_slug")
+
+	if err := verifySessionBelongsToGHSlug(sessionID, ghSlug); err != nil {
+		resp.ReturnError(err)
+
+		return
+	}
+
+	resp.Return(dipper.Must(rerunSession(sessionID)).(map[string]interface{}))
+}
+
+func handleGHEventPause(resp *api.Response) {
+	resp.Request = dipper.DeserializePayload(resp.Request)
+	ghSlug, _ := dipper.GetMapDataStr(resp.Request.Payload, "gh_slug")
+	sessionID := dipper.MustGetMapDataStr(resp.Request.Payload, "sessionID")
+
+	if err := verifySessionBelongsToGHSlug(sessionID, ghSlug); err != nil {
+		resp.ReturnError(err)
+
+		return
+	}
+
+	handleSessionControl(resp, "pause")
+}
+
+func handleGHEventResume(resp *api.Response) {
+	resp.Request = dipper.DeserializePayload(resp.Request)
+	ghSlug, _ := dipper.GetMapDataStr(resp.Request.Payload, "gh_slug")
+	sessionID := dipper.MustGetMapDataStr(resp.Request.Payload, "sessionID")
+
+	if err := verifySessionBelongsToGHSlug(sessionID, ghSlug); err != nil {
+		resp.ReturnError(err)
+
+		return
+	}
+
+	handleSessionControl(resp, "resume")
+}
+
+func handleGHEventInteract(resp *api.Response) {
+	resp.Request = dipper.DeserializePayload(resp.Request)
+	ghSlug, _ := dipper.GetMapDataStr(resp.Request.Payload, "gh_slug")
+	sessionID := dipper.MustGetMapDataStr(resp.Request.Payload, "sessionID")
+
+	if err := verifySessionBelongsToGHSlug(sessionID, ghSlug); err != nil {
+		resp.ReturnError(err)
+
+		return
+	}
+
+	handleSessionControl(resp, "interact")
 }


### PR DESCRIPTION
Add ghEvent rerun, pause, resume, and interact handlers with repository ownership checks so GH-scoped workflow actions are enforced server-side.

<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
