### PR TITLE
fix: stay with golang 1.25

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine AS build
+FROM golang:1.25.10-alpine AS build
 
 ARG GOINSTALLOPTS=""
 ARG GOGC=""


### PR DESCRIPTION
golang 1.26 uses a feature called MADV_DONTNEED in its GC scavenger. But it is not well supported in older version of QEMU hypervisor (<7.1.0), such as what rancher desktop uses. The tool chain and resulting binary frequently crashes with memory related errors. Stay with 1.25 for now, until it is well addressed by QEMU or other vendors.

<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
