### PR TITLE
feat: add conversation tracking for multiple agent sessions

### DIFF
--- a/cmd/honeydipper/main.go
+++ b/cmd/honeydipper/main.go
@@ -33,7 +33,7 @@ Usage:  %v [ -h ] service1 service2 ...
 
   -h            print this help message and quit
 
-Supported services include engine, receiver, operator, docgen and configcheck.
+Supported services include engine, receiver, operator, agent, docgen and configcheck.
 Docgen and configcheck are auxiliary services used for helping users managing their
 Honeydipper configurations. They can not be combined, and Honeydipper exits after
 completing the desired auxiliary tasks instead of running as a daemon.
@@ -76,7 +76,7 @@ func initEnv() {
 	config.SetVersion(_honeydipperVersion)
 	cfg = config.Config{InitRepo: config.RepoInfo{}, Services: flag.Args()}
 	if len(cfg.Services) == 0 {
-		cfg.Services = []string{"engine", "receiver", "operator", "api"}
+		cfg.Services = []string{"engine", "receiver", "operator", "api", "agent"}
 	}
 
 loop:
@@ -167,6 +167,8 @@ func start() {
 			service.StartOperator(&cfg)
 		case "api":
 			service.StartAPI(&cfg)
+		case "agent":
+			service.StartAgent(&cfg)
 		default:
 			dipper.Logger.Fatalf("'%v' service is not implemented", s)
 		}

--- a/drivers/cmd/redislock/main.go
+++ b/drivers/cmd/redislock/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -27,6 +28,8 @@ var (
 	ErrFailToLock = errors.New("fail to lock")
 	// ErrFailToUnlock means not being able to unlock.
 	ErrFailToUnlock = errors.New("fail to unlock")
+	// ErrOutOfSync means the given sequence number is lower than the current lock serial.
+	ErrOutOfSync = errors.New("out of sync")
 )
 
 // Locker holds the driver, configurations and runtime information.
@@ -71,10 +74,38 @@ func main() {
 	l.nodeID = dipper.GetIP()
 }
 
+func waitForSeq(ctx context.Context, client redisclient.Options, seqKey string, sq int, strict bool) bool {
+	for {
+		currentSeq, _ := strconv.ParseInt(dipper.Must(client.Get(ctx, seqKey).Result()).(string), 10, 64)
+		if strict {
+			if currentSeq > int64(sq) {
+				panic(ErrOutOfSync)
+			}
+			if currentSeq == int64(sq) {
+				return true
+			}
+		} else if currentSeq >= int64(sq) {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
 func (l *Locker) lock(msg *dipper.Message) {
 	msg = dipper.DeserializePayload(msg)
 	expire := dipper.Must(time.ParseDuration(dipper.MustGetMapDataStr(msg.Payload, "expire"))).(time.Duration)
 	name := dipper.MustGetMapDataStr(msg.Payload, "name")
+	sq, hasSq := dipper.GetMapDataInt(msg.Payload, "sq")
+	strict, _ := dipper.GetMapDataBool(msg.Payload, "strict")
+
+	seqExpire := 24 * time.Hour
+	if seqExpireStr, ok := dipper.GetMapDataStr(msg.Payload, "seq_expire"); ok {
+		seqExpire = dipper.Must(time.ParseDuration(seqExpireStr)).(time.Duration)
+	}
 
 	ctx, cancel := l.driver.GetContext(msg)
 	defer cancel()
@@ -82,12 +113,25 @@ func (l *Locker) lock(msg *dipper.Message) {
 	client := redisclient.NewClient(l.redisOptions)
 	defer client.Close()
 
+	var seqKey string
+	if hasSq {
+		seqKey = l.prefix + name + ":seq"
+		dipper.Must(client.SetNX(ctx, seqKey, "1", seqExpire).Result())
+		if !waitForSeq(ctx, client, seqKey, sq, strict) {
+			return
+		}
+	}
+
 	for !dipper.Must(client.SetNX(ctx, l.prefix+name, l.nodeID, expire).Result()).(bool) {
 		select {
 		case <-ctx.Done():
 			return
 		case <-time.After(100 * time.Millisecond):
 		}
+	}
+
+	if hasSq {
+		dipper.Must(client.Incr(ctx, seqKey).Result())
 	}
 
 	msg.Reply <- dipper.Message{}

--- a/drivers/cmd/redisqueue/main.go
+++ b/drivers/cmd/redisqueue/main.go
@@ -39,6 +39,7 @@ type EventBusOptions struct {
 	AgentWorkflowTopic string
 	AgentResponseTopic string
 	AgentRecoverTopic  string
+	AgentPollTopic     string
 }
 
 var (
@@ -73,6 +74,7 @@ func main() {
 		driver.MessageHandlers["eventbus:command"] = relayToRedis
 		driver.MessageHandlers["eventbus:message"] = relayToRedis
 		driver.MessageHandlers["eventbus:agent_start"] = relayToRedis
+		driver.MessageHandlers["eventbus:agent_poll"] = relayToRedis
 		driver.MessageHandlers["eventbus:agent_continue"] = relayToRedis
 	case "operator":
 		driver.MessageHandlers["eventbus:agent_command"] = relayToRedis
@@ -109,6 +111,7 @@ func loadOptions() {
 		AgentCommandTopic:  "honeydipper:agent_command",
 		AgentWorkflowTopic: "honeydipper:agent_workflow",
 		AgentResponseTopic: "honeydipper:agent_response",
+		AgentPollTopic:     "honeydipper:agent_poll",
 		AgentRecoverTopic:  "honeydipper:agent_recover",
 	}
 	if commandTopic, ok := driver.GetOptionStr("data.topics.command"); ok {
@@ -141,6 +144,9 @@ func loadOptions() {
 	if v, ok := driver.GetOptionStr("data.topics.agent_recover"); ok {
 		eb.AgentRecoverTopic = v
 	}
+	if v, ok := driver.GetOptionStr("data.topics.agent_poll"); ok {
+		eb.AgentPollTopic = v
+	}
 	eventbus = eb
 }
 
@@ -159,6 +165,7 @@ func start(msg *dipper.Message) {
 		go subscribe(eventbus.AgentStartTopic, "agent_start")
 		go subscribe(eventbus.AgentContinueTopic, "agent_continue")
 		go subscribe(eventbus.AgentRecoverTopic, "agent_recover")
+		go subscribe(eventbus.AgentPollTopic, "agent_poll")
 	case "api":
 		go subscribe(eventbus.APITopic, "api")
 	case "receiver":
@@ -199,6 +206,8 @@ func relayToRedis(msg *dipper.Message) {
 		topic = eventbus.AgentResponseTopic
 	case "agent_recover":
 		topic = eventbus.AgentRecoverTopic
+	case "agent_poll":
+		topic = eventbus.AgentPollTopic
 	}
 
 	payload := map[string]interface{}{

--- a/drivers/cmd/redisqueue/main.go
+++ b/drivers/cmd/redisqueue/main.go
@@ -29,10 +29,16 @@ const (
 
 // EventBusOptions : stores all the redis key names used by honeydipper.
 type EventBusOptions struct {
-	EventTopic   string
-	CommandTopic string
-	ReturnTopic  string
-	APITopic     string
+	EventTopic         string
+	CommandTopic       string
+	ReturnTopic        string
+	APITopic           string
+	AgentStartTopic    string
+	AgentContinueTopic string
+	AgentCommandTopic  string
+	AgentWorkflowTopic string
+	AgentResponseTopic string
+	AgentRecoverTopic  string
 }
 
 var (
@@ -66,10 +72,19 @@ func main() {
 	case "engine":
 		driver.MessageHandlers["eventbus:command"] = relayToRedis
 		driver.MessageHandlers["eventbus:message"] = relayToRedis
+		driver.MessageHandlers["eventbus:agent_start"] = relayToRedis
+		driver.MessageHandlers["eventbus:agent_continue"] = relayToRedis
 	case "operator":
+		driver.MessageHandlers["eventbus:agent_command"] = relayToRedis
 		driver.MessageHandlers["eventbus:command"] = relayToRedis
 		driver.MessageHandlers["eventbus:return"] = relayToRedis
 		driver.MessageHandlers["eventbus:message"] = relayToRedis
+		driver.MessageHandlers["eventbus:agent_continue"] = relayToRedis
+	case "agent":
+		driver.MessageHandlers["eventbus:agent_command"] = relayToRedis
+		driver.MessageHandlers["eventbus:agent_workflow"] = relayToRedis
+		driver.MessageHandlers["eventbus:agent_response"] = relayToRedis
+		driver.MessageHandlers["eventbus:agent_recover"] = relayToRedis
 	}
 	driver.MessageHandlers["eventbus:api"] = relayToRedis
 	driver.Run()
@@ -85,10 +100,16 @@ func loadOptions() {
 	log.Infof("[%s] receiving driver data %+v", driver.Service, driver.Options)
 
 	eb := &EventBusOptions{
-		CommandTopic: "honeydipper:commands",
-		EventTopic:   "honeydipper:events",
-		ReturnTopic:  "honeydipper:return",
-		APITopic:     "honeydipper:api:",
+		CommandTopic:       "honeydipper:commands",
+		EventTopic:         "honeydipper:events",
+		ReturnTopic:        "honeydipper:return",
+		APITopic:           "honeydipper:api:",
+		AgentStartTopic:    "honeydipper:agent_start",
+		AgentContinueTopic: "honeydipper:agent_continue",
+		AgentCommandTopic:  "honeydipper:agent_command",
+		AgentWorkflowTopic: "honeydipper:agent_workflow",
+		AgentResponseTopic: "honeydipper:agent_response",
+		AgentRecoverTopic:  "honeydipper:agent_recover",
 	}
 	if commandTopic, ok := driver.GetOptionStr("data.topics.command"); ok {
 		eb.CommandTopic = commandTopic
@@ -102,6 +123,24 @@ func loadOptions() {
 	if apiTopic, ok := driver.GetOptionStr("data.topics.api"); ok {
 		eb.APITopic = apiTopic
 	}
+	if v, ok := driver.GetOptionStr("data.topics.agent_start"); ok {
+		eb.AgentStartTopic = v
+	}
+	if v, ok := driver.GetOptionStr("data.topics.agent_continue"); ok {
+		eb.AgentContinueTopic = v
+	}
+	if v, ok := driver.GetOptionStr("data.topics.agent_command"); ok {
+		eb.AgentCommandTopic = v
+	}
+	if v, ok := driver.GetOptionStr("data.topics.agent_workflow"); ok {
+		eb.AgentWorkflowTopic = v
+	}
+	if v, ok := driver.GetOptionStr("data.topics.agent_response"); ok {
+		eb.AgentResponseTopic = v
+	}
+	if v, ok := driver.GetOptionStr("data.topics.agent_recover"); ok {
+		eb.AgentRecoverTopic = v
+	}
 	eventbus = eb
 }
 
@@ -111,8 +150,15 @@ func start(msg *dipper.Message) {
 	case "engine":
 		go subscribe(eventbus.EventTopic, "message")
 		go subscribe(eventbus.ReturnTopic, "return")
+		go subscribe(eventbus.AgentWorkflowTopic, "agent_workflow")
+		go subscribe(eventbus.AgentResponseTopic, "agent_response")
 	case "operator":
 		go subscribe(eventbus.CommandTopic, "command")
+		go subscribe(eventbus.AgentCommandTopic, "agent_command")
+	case "agent":
+		go subscribe(eventbus.AgentStartTopic, "agent_start")
+		go subscribe(eventbus.AgentContinueTopic, "agent_continue")
+		go subscribe(eventbus.AgentRecoverTopic, "agent_recover")
 	case "api":
 		go subscribe(eventbus.APITopic, "api")
 	case "receiver":
@@ -141,6 +187,18 @@ func relayToRedis(msg *dipper.Message) {
 		}
 	case "return":
 		topic = eventbus.ReturnTopic
+	case "agent_start":
+		topic = eventbus.AgentStartTopic
+	case "agent_continue":
+		topic = eventbus.AgentContinueTopic
+	case "agent_command":
+		topic = eventbus.AgentCommandTopic
+	case "agent_workflow":
+		topic = eventbus.AgentWorkflowTopic
+	case "agent_response":
+		topic = eventbus.AgentResponseTopic
+	case "agent_recover":
+		topic = eventbus.AgentRecoverTopic
 	}
 
 	payload := map[string]interface{}{

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -183,17 +183,6 @@ func (s *AgentSession) appendConvoHistory(msg AgentMessage) {
 
 // run appends the current user message and dispatches the conversation to the AI driver.
 func (s *AgentSession) run() {
-	if len(s.history) == 0 {
-		systemPrompt := s.Agent.SystemPrompt
-		if s.Type == AgentSessionTypeInference && len(s.Agent.InferencePrompt) > 0 {
-			systemPrompt = s.Agent.InferencePrompt
-		}
-		s.appendConvoHistory(AgentMessage{
-			Role:    RoleSystem,
-			Content: systemPrompt,
-		})
-	}
-
 	text := dipper.MustGetMapDataStr(s.CurrentMsg.Payload, "text")
 	user, _ := dipper.GetMapDataStr(s.CurrentMsg.Payload, "user")
 	s.appendConvoHistory(AgentMessage{
@@ -220,13 +209,30 @@ func (s *AgentSession) sendToDriver() {
 	if timeout == "" {
 		timeout = AgentSessionDefaultTimeout
 	}
+
+	// Build the system prompt from the current agent config (inference vs chat).
+	systemPrompt := s.Agent.SystemPrompt
+	if s.Type == AgentSessionTypeInference && len(s.Agent.InferencePrompt) > 0 {
+		systemPrompt = s.Agent.InferencePrompt
+	}
+
+	// Prepend the system prompt ephemerally; filter any legacy persisted system
+	// messages so the driver always sees exactly one, up-to-date system entry.
+	history := make([]AgentMessage, 0, len(s.history)+1)
+	history = append(history, AgentMessage{Role: RoleSystem, Content: systemPrompt})
+	for _, m := range s.history {
+		if m.Role != RoleSystem {
+			history = append(history, m)
+		}
+	}
+
 	if log := s.log(); log != nil {
 		log.Infof("[agent] session [%s] sending to driver=%s engine=%s history_len=%d tools=%d",
-			s.ID, s.Agent.Driver, s.Agent.Engine, len(s.history), len(tools))
+			s.ID, s.Agent.Driver, s.Agent.Engine, len(history), len(tools))
 	}
 	dipper.Must(s.store.CallNoWait("driver:"+s.Agent.Driver, "send_to_model", map[string]interface{}{
 		"engine":        s.Agent.Engine,
-		"history":       s.history,
+		"history":       history,
 		"tools":         tools,
 		"type":          s.Type,
 		"model_data":    s.Agent.ModelData,

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -1,9 +1,11 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/honeydipper/honeydipper/v4/internal/config"
 	agentpkg "github.com/honeydipper/honeydipper/v4/pkg/agent"
@@ -14,11 +16,14 @@ import (
 
 // Session type constants, cache key prefixes, default TTL, and role labels.
 const (
-	AgentSessionTypeInference = agentpkg.SessionTypeInference
-	AgentSessionTypeChatTurn  = agentpkg.SessionTypeChatTurn
-	AgentKeyPrefix            = "agent_session:"
-	ConvoHistoryKeyPrefix     = "convo_history:"
-	AgentSessionDefaultTTL    = "1h"
+	AgentSessionTypeInference      = agentpkg.SessionTypeInference
+	AgentSessionTypeChatTurn       = agentpkg.SessionTypeChatTurn
+	AgentKeyPrefix                 = "agent_session:"
+	ConvoHistoryKeyPrefix          = "convo_history:"
+	AgentSessionDefaultTTL         = "72h"
+	AgentSessionDefaultTimeout     = "1h"
+	AgentSessionDefaultPollTimeout = time.Second * 9
+	MinPollInterval                = time.Second * 2
 
 	RoleSystem     = agentpkg.RoleSystem
 	RoleUser       = agentpkg.RoleUser
@@ -29,20 +34,19 @@ const (
 
 // AgentSession holds the runtime state of a single agent inference or chat-turn session.
 type AgentSession struct {
-	ID          string
-	CallerID    string
-	CallerType  string
-	ConvoID     string
-	Agent       *config.Agent
-	History     []AgentMessage
-	CurrentMsg  *dipper.Message
-	Type        string
-	TTL         string
-	CurrentCall int
-	SessionSeq  int
-	ChunkSeq    int
-	ToolCalls   []AgentToolCall
-	ToolResults []map[string]interface{}
+	ID           string
+	ConvoID      string
+	Agent        *config.Agent
+	history      []AgentMessage
+	CurrentMsg   *dipper.Message
+	Type         string
+	TTL          string
+	CurrentCall  int
+	ToolCalls    []AgentToolCall
+	ToolResults  []map[string]interface{}
+	LastPoll     int
+	LastPollTime time.Time
+	ErrorReason  string
 
 	store AgentStore
 }
@@ -60,7 +64,7 @@ func (s *AgentSession) log() *logging.Logger {
 }
 
 // persist serialises the session and writes it to the cache.
-func (s *AgentSession) persist() {
+func (s *AgentSession) persist(unlocking bool) {
 	if log := s.log(); log != nil {
 		log.Debugf("[agent] session [%s] persisting to cache", s.ID)
 	}
@@ -70,14 +74,20 @@ func (s *AgentSession) persist() {
 		"value": string(dipper.SerializeContent(s)),
 		"ttl":   s.TTL,
 	}))
+
+	if unlocking {
+		dipper.Must(s.store.Call("locker", "unlock", map[string]interface{}{
+			"name": AgentKeyPrefix + s.ID,
+		}))
+	}
 }
 
 // load reads and deserialises a previously persisted session from the cache.
-func (s *AgentSession) load(id string) {
-	if log := s.log(); log != nil {
+func (s *AgentSession) load(id string, store AgentStore) {
+	if log := store.GetLogger(); log != nil {
 		log.Debugf("[agent] session [%s] loading from cache", id)
 	}
-	ret := dipper.Must(s.store.Call("cache", "load", map[string]interface{}{
+	ret := dipper.Must(store.Call("cache", "load", map[string]interface{}{
 		"key": AgentKeyPrefix + id,
 	})).([]byte)
 
@@ -86,22 +96,46 @@ func (s *AgentSession) load(id string) {
 
 // setup initialises a new session or restores an existing one from cache.
 // Returns the conversation ID.
-func (s *AgentSession) setup(msg *dipper.Message, store AgentStore) {
-	s.store = store
-	if id, ok := msg.Labels["agent_session_id"]; ok && id != "" {
-		s.load(id)
-		s.CurrentMsg = msg
-
-		return
+func (s *AgentSession) setup(msg *dipper.Message, store AgentStore, locking bool) {
+	id, ok := msg.Labels["agent_session_id"]
+	if !ok || id == "" {
+		id = dipper.NewUUID()
 	}
 
-	s.ID = dipper.NewUUID()
-	s.CallerID = msg.Labels["caller_id"]
-	s.CallerType = msg.Labels["caller_type"]
+	if locking {
+		dipper.Must(store.Call("locker", "lock", map[string]interface{}{
+			"name":   AgentKeyPrefix + id,
+			"expire": "600s",
+		}))
+	}
 
+	if ok && id != "" {
+		s.load(id, store)
+		s.store = store
+		s.loadConvoHistory()
+	} else {
+		s.initNewSession(id, msg, store)
+	}
+
+	if log := s.log(); log != nil {
+		log.Infof("[agent] session [%s] created type=%s agent=%s", s.ID, s.Type, msg.Labels["agent_name"])
+	}
+}
+
+// initNewSession populates a freshly created session from the incoming message.
+func (s *AgentSession) initNewSession(id string, msg *dipper.Message, store AgentStore) {
+	s.store = store
+	s.CurrentMsg = msg
+	s.ID = id
 	s.Type, _ = dipper.GetMapDataStr(msg.Payload, "type")
 	if s.Type == "" {
 		s.Type = agentpkg.SessionTypeChatTurn
+	}
+
+	s.Agent = s.store.GetAgent(msg.Labels["agent_name"])
+	s.TTL = AgentSessionDefaultTTL
+	if ttl, ok := dipper.GetMapDataStr(msg.Payload, "ttl"); ok && ttl != "" {
+		s.TTL = ttl
 	}
 
 	if convoID, ok := dipper.GetMapDataStr(msg.Payload, "convo_id"); ok && convoID != "" {
@@ -110,21 +144,14 @@ func (s *AgentSession) setup(msg *dipper.Message, store AgentStore) {
 	} else {
 		s.ConvoID = dipper.NewUUID()
 	}
-
-	s.Agent = s.store.GetAgent(msg.Labels["agent_name"])
-	s.CurrentMsg = msg
-
-	s.TTL = AgentSessionDefaultTTL
-	if ttl, ok := dipper.GetMapDataStr(msg.Payload, "ttl"); ok {
-		s.TTL = ttl
-	}
-	if log := s.log(); log != nil {
-		log.Infof("[agent] session [%s] created type=%s agent=%s", s.ID, s.Type, msg.Labels["agent_name"])
-	}
 }
 
 // loadConvoHistory fetches the multi-turn conversation history from the cache.
 func (s *AgentSession) loadConvoHistory() {
+	if s.ConvoID == "" {
+		return
+	}
+
 	ret := dipper.Must(s.store.Call("cache", "lrange", map[string]interface{}{
 		"key": ConvoHistoryKeyPrefix + s.ConvoID,
 	})).([]byte)
@@ -132,12 +159,12 @@ func (s *AgentSession) loadConvoHistory() {
 	var history []AgentMessage
 	dipper.Must(json.Unmarshal(ret, &history))
 
-	s.History = history
+	s.history = history
 }
 
 // appendConvoHistory appends a message to the in-memory history and the cache.
 func (s *AgentSession) appendConvoHistory(msg AgentMessage) {
-	s.History = append(s.History, msg)
+	s.history = append(s.history, msg)
 
 	if s.ConvoID != "" {
 		dipper.Must(s.store.Call("cache", "rpush", map[string]interface{}{
@@ -151,7 +178,7 @@ func (s *AgentSession) appendConvoHistory(msg AgentMessage) {
 func (s *AgentSession) run() {
 	tools := s.BuildTools()
 
-	if len(s.History) == 0 {
+	if len(s.history) == 0 {
 		systemPrompt := s.Agent.SystemPrompt
 		if s.Type == AgentSessionTypeInference && len(s.Agent.InferencePrompt) > 0 {
 			systemPrompt = s.Agent.InferencePrompt
@@ -164,25 +191,30 @@ func (s *AgentSession) run() {
 
 	text := dipper.MustGetMapDataStr(s.CurrentMsg.Payload, "text")
 	user, _ := dipper.GetMapDataStr(s.CurrentMsg.Payload, "user")
+	timeout := s.CurrentMsg.Labels["timeout"]
+	if timeout == "" {
+		timeout = AgentSessionDefaultTimeout
+	}
 	s.appendConvoHistory(AgentMessage{
 		Role:    RoleUser,
 		User:    user,
 		Content: text,
 	})
+	s.LastPoll = len(s.history)
 
-	s.persist()
+	s.persist(true)
 	if log := s.log(); log != nil {
 		log.Infof("[agent] session [%s] sending to driver=%s engine=%s history_len=%d tools=%d",
-			s.ID, s.Agent.Driver, s.Agent.Engine, len(s.History), len(tools))
+			s.ID, s.Agent.Driver, s.Agent.Engine, len(s.history), len(tools))
 	}
 	dipper.Must(s.store.CallNoWait("driver:"+s.Agent.Driver, "send_to_model", map[string]interface{}{
 		"engine":        s.Agent.Engine,
-		"history":       s.History,
+		"history":       s.history,
 		"tools":         tools,
 		"type":          s.Type,
 		"model_data":    s.Agent.ModelData,
 		"should_stream": s.Agent.ShouldStream,
-	}, "agent_session_id", s.ID, "chunk_sq", strconv.Itoa(s.ChunkSeq), "timeout", s.TTL))
+	}, "agent_session_id", s.ID, "timeout", timeout))
 }
 
 func (s *AgentSession) recover() {
@@ -191,14 +223,21 @@ func (s *AgentSession) recover() {
 	}
 
 	tools := s.BuildTools()
+	var timeout string
+	if s.CurrentMsg != nil {
+		timeout = s.CurrentMsg.Labels["timeout"]
+	}
+	if timeout == "" {
+		timeout = AgentSessionDefaultTimeout
+	}
 	dipper.Must(s.store.CallNoWait("driver:"+s.Agent.Driver, "send_to_model", map[string]interface{}{
 		"engine":        s.Agent.Engine,
-		"history":       s.History,
+		"history":       s.history,
 		"tools":         tools,
 		"type":          s.Type,
 		"model_data":    s.Agent.ModelData,
 		"should_stream": s.Agent.ShouldStream,
-	}, "agent_session_id", s.ID, "chunk_sq", strconv.Itoa(s.ChunkSeq), "timeout", s.TTL))
+	}, "agent_session_id", s.ID, "timeout", timeout))
 }
 
 // BuildTools assembles the tool map from the agent's configured system and workflow tools.
@@ -304,51 +343,13 @@ func (s *AgentSession) addWorkflowTool(tools map[string]AgentTool, toolDef confi
 func (s *AgentSession) processAgentResponse(msg *dipper.Message) {
 	s.CurrentMsg = msg
 	m := dipper.MustGetMapData(msg.Payload, "message").(map[string]interface{})
-
-	if msg.Labels["status"] != "" && msg.Labels["status"] != "success" {
-		errRet := dipper.Message{
-			Channel: "eventbus",
-			Subject: "agent_response",
-			Labels: map[string]string{
-				"agent_session_id": s.ID,
-				"convo_id":         s.ConvoID,
-				"caller_id":        s.CallerID,
-				"caller_type":      s.CallerType,
-				"session_seq":      strconv.Itoa(s.SessionSeq),
-				"status":           msg.Labels["status"],
-				"reason":           msg.Labels["reason"],
-			},
-		}
-		if s.SessionSeq > 0 {
-			s.SessionSeq++
-			errRet.Labels["session_seq"] = strconv.Itoa(s.SessionSeq)
-		}
-		s.store.EmitMessage(errRet)
-
-		return
-	}
-
 	var agentMsg AgentMessage
 	dipper.Must(mapstructure.Decode(m, &agentMsg))
 	if log := s.log(); log != nil {
 		log.Debugf("[agent] session [%s] response received role=%s thinking=%v tool_calls=%d",
 			s.ID, agentMsg.Role, agentMsg.IsThinking, len(agentMsg.ToolCalls))
 	}
-	if agentMsg.ChunkSeq > 0 {
-		dipper.Must(s.store.Call("locker", "lock", map[string]interface{}{
-			"name":   AgentKeyPrefix + "lock:" + s.ID,
-			"expire": "30s",
-			"sq":     agentMsg.ChunkSeq,
-		}))
-		s.setup(msg, s.store) // refresh session data in case of updates during streaming
-		s.ChunkSeq = agentMsg.ChunkSeq
-	}
 	s.processAgentMessage(&agentMsg)
-	if agentMsg.ChunkSeq > 0 {
-		dipper.Must(s.store.Call("locker", "unlock", map[string]interface{}{
-			"name": AgentKeyPrefix + "lock:" + s.ID,
-		}))
-	}
 }
 
 // processAgentMessage routes a decoded model message: triggers tool calls, handles thinking
@@ -363,34 +364,10 @@ func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 		return
 	}
 
-	if !agentMsg.IsThinking || s.Agent.ShouldEmitThoughts {
-		msg := dipper.Message{
-			Channel: "eventbus",
-			Subject: "agent_response",
-			Labels: map[string]string{
-				"agent_session_id": s.ID,
-				"convo_id":         s.ConvoID,
-				"caller_id":        s.CallerID,
-				"caller_type":      s.CallerType,
-			},
-			Payload: map[string]interface{}{
-				"message": agentMsg,
-			},
-		}
-		if agentMsg.ChunkSeq > 0 {
-			s.SessionSeq++
-			msg.Labels["session_seq"] = strconv.Itoa(s.SessionSeq)
-			s.persist()
-		}
-		s.store.EmitMessage(msg)
-	}
-
-	if agentMsg.IsThinking {
-		return
-	}
-
 	if agentMsg.Role != RoleAgent {
 		s.run()
+	} else {
+		s.persist(true)
 	}
 }
 
@@ -400,7 +377,7 @@ func (s *AgentSession) nextToolCall() {
 		return
 	}
 
-	s.persist()
+	s.persist(true)
 
 	c := s.ToolCalls[s.CurrentCall]
 	if log := s.log(); log != nil {
@@ -418,7 +395,7 @@ func (s *AgentSession) nextToolCall() {
 			Subject: "agent_command",
 			Labels: map[string]string{
 				"agent_session_id": s.ID,
-				"turn_id":          strconv.Itoa(len(s.History)),
+				"turn_id":          strconv.Itoa(len(s.history)),
 				"tool_call_id":     strconv.Itoa(s.CurrentCall),
 			},
 			Payload: map[string]interface{}{
@@ -440,7 +417,7 @@ func (s *AgentSession) nextToolCall() {
 				"message": map[string]interface{}{
 					"labels": map[string]string{
 						"agent_session_id": s.ID,
-						"turn_id":          strconv.Itoa(len(s.History)),
+						"turn_id":          strconv.Itoa(len(s.history)),
 						"tool_call_id":     strconv.Itoa(s.CurrentCall),
 					},
 				},
@@ -459,10 +436,10 @@ func (s *AgentSession) processToolResult(msg *dipper.Message) {
 
 	turn_id, _ := strconv.Atoi(msg.Labels["turn_id"])
 
-	if turn_id != len(s.History) {
+	if turn_id != len(s.history) {
 		if log := s.log(); log != nil {
 			log.Warningf("[agent] session [%s] received out-of-order tool result for turn %d (current turn is %d)",
-				s.ID, turn_id, len(s.History))
+				s.ID, turn_id, len(s.history))
 		}
 
 		return
@@ -479,7 +456,7 @@ func (s *AgentSession) processToolResult(msg *dipper.Message) {
 	}
 
 	var data interface{}
-	c := s.History[len(s.History)-1].ToolCalls[s.CurrentCall]
+	c := s.history[len(s.history)-1].ToolCalls[s.CurrentCall]
 	switch {
 	case strings.HasPrefix(c.FuncName, "sys_"):
 		sysName := c.FuncName[len("sys_"):strings.LastIndex(c.FuncName, "__")]
@@ -516,4 +493,115 @@ func (s *AgentSession) processToolResult(msg *dipper.Message) {
 
 		s.processAgentMessage(&agentMsg)
 	}
+}
+
+func (s *AgentSession) processAgentPoll(msg *dipper.Message) {
+	log := s.log()
+	if log == nil {
+		log = dipper.GetLogger("agent", "INFO")
+	}
+
+	if s.LastPoll == len(s.history) {
+		if s.LastPoll > 0 && s.history[s.LastPoll-1].IsComplete {
+			log.Panicf("[agent] session [%s] poll after completion", s.ID)
+		}
+	}
+	log.Infof("[agent] session [%s] poll received lastpoll=%d resume_key %s", s.ID, s.LastPoll, msg.Labels["resume_key"])
+
+	timeout := AgentSessionDefaultPollTimeout
+	if t, ok := msg.Labels["timeout"]; ok {
+		timeout = dipper.Must(time.ParseDuration(t)).(time.Duration)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	for {
+		for (s.LastPoll == len(s.history) && s.ErrorReason == "") || (!s.LastPollTime.IsZero() && time.Since(s.LastPollTime) < MinPollInterval) {
+			select {
+			case <-ctx.Done():
+				log.Warningf("[agent] session [%s] poll timeout after %s", s.ID, timeout)
+				labels := msg.Labels
+				labels["status"] = "failure"
+				labels["reason"] = "poll timeout after " + timeout.String()
+				dipper.Must(s.store.Call("locker", "unlock", map[string]interface{}{
+					"name": AgentKeyPrefix + s.ID,
+				}))
+				s.store.EmitMessage(dipper.Message{
+					Channel: dipper.ChannelEventbus,
+					Subject: "agent_response",
+					Labels:  labels,
+				})
+
+				return
+			default:
+			}
+			dipper.Must(s.store.Call("locker", "unlock", map[string]interface{}{
+				"name": AgentKeyPrefix + s.ID,
+			}))
+
+			time.Sleep(time.Second)
+			s.setup(msg, s.store, true)
+		}
+
+		if s.emitPollResponse(msg) {
+			return
+		}
+	}
+}
+
+func (s *AgentSession) emitPollResponse(msg *dipper.Message) bool {
+	buf := strings.Builder{}
+	if marker, ok := msg.Labels["last_poll"]; ok {
+		s.LastPoll = dipper.Must(strconv.Atoi(marker)).(int)
+	}
+	for i := s.LastPoll; i < len(s.history); i++ {
+		am := s.history[i]
+		if am.Role != RoleAgent {
+			continue
+		}
+
+		if am.IsThinking && !s.Agent.ShouldStream {
+			continue
+		}
+
+		buf.WriteString(am.Content)
+	}
+
+	labels := msg.Labels
+	am := AgentMessage{
+		Role:    RoleAgent,
+		Content: buf.String(),
+	}
+
+	if h := len(s.history); h > 0 {
+		am.IsComplete = s.history[h-1].IsComplete
+	}
+
+	if s.ErrorReason != "" {
+		am.IsComplete = true
+		labels["status"] = "error"
+		labels["reason"] = s.ErrorReason
+	} else {
+		labels["status"] = "ok"
+	}
+
+	s.LastPoll = len(s.history)
+	labels["last_poll"] = strconv.Itoa(s.LastPoll)
+	if am.Content == "" && s.ErrorReason == "" {
+		s.persist(false)
+
+		return false
+	}
+
+	s.store.EmitMessage(dipper.Message{
+		Channel: dipper.ChannelEventbus,
+		Subject: "agent_response",
+		Labels:  labels,
+		Payload: map[string]interface{}{
+			"message": am,
+		},
+	})
+	s.LastPollTime = time.Now()
+	s.persist(true)
+
+	return true
 }

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -489,6 +489,15 @@ func (s *AgentSession) nextToolCall() {
 		log.Infof("[agent] session [%s] dispatching tool call %d/%d: %s",
 			s.ID, s.CurrentCall+1, len(s.ToolCalls), c.FuncName)
 	}
+
+	unifiedConvoID := s.CurrentMsg.Labels["unified_convo_id"]
+	if unifiedConvoID == "" {
+		unifiedConvoID, _ = dipper.GetMapDataStr(s.CurrentMsg.Payload, "convo_id")
+	}
+	if unifiedConvoID == "" {
+		unifiedConvoID = s.ConvoID
+	}
+
 	switch {
 	case strings.HasPrefix(c.FuncName, "sys_"):
 		sysName := c.FuncName[len("sys_"):strings.LastIndex(c.FuncName, "__")]
@@ -501,6 +510,7 @@ func (s *AgentSession) nextToolCall() {
 				"agent_session_id": s.ID,
 				"turn_id":          strconv.Itoa(len(s.history)),
 				"tool_call_id":     strconv.Itoa(s.CurrentCall),
+				"unified_convo_id": unifiedConvoID, // for unified history access in workflows
 			},
 			Payload: map[string]interface{}{
 				"ctx": c.Params,
@@ -523,12 +533,19 @@ func (s *AgentSession) nextToolCall() {
 				"do": map[string]interface{}{
 					"call_workflow": wfName,
 					"context":       "_agent_tool_call",
+					"with": map[string]interface{}{
+						"agent_session_id": s.ID,
+						"turn_id":          strconv.Itoa(len(s.history)),
+						"convo_id":         s.ConvoID,
+						"unified_convo_id": unifiedConvoID, // for unified history access in workflows
+					},
 				},
 				"message": map[string]interface{}{
 					"labels": map[string]string{
 						"agent_session_id": s.ID,
 						"turn_id":          strconv.Itoa(len(s.history)),
 						"tool_call_id":     strconv.Itoa(s.CurrentCall),
+						"unified_convo_id": unifiedConvoID, // for unified history access in workflows
 					},
 				},
 			},
@@ -545,6 +562,8 @@ func (s *AgentSession) nextToolCall() {
 				"turn_id":          strconv.Itoa(len(s.history)),
 				"tool_call_id":     strconv.Itoa(s.CurrentCall),
 				"sub_agent_name":   subAgentName,
+				"convo_id":         s.ConvoID,
+				"unified_convo_id": unifiedConvoID, // for unified history access in sub-agents
 			},
 			Payload: map[string]interface{}{
 				"input": input,

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -1,0 +1,519 @@
+package agent
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	agentpkg "github.com/honeydipper/honeydipper/v4/pkg/agent"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+	"github.com/mitchellh/mapstructure"
+	"github.com/op/go-logging"
+)
+
+// Session type constants, cache key prefixes, default TTL, and role labels.
+const (
+	AgentSessionTypeInference = agentpkg.SessionTypeInference
+	AgentSessionTypeChatTurn  = agentpkg.SessionTypeChatTurn
+	AgentKeyPrefix            = "agent_session:"
+	ConvoHistoryKeyPrefix     = "convo_history:"
+	AgentSessionDefaultTTL    = "1h"
+
+	RoleSystem     = agentpkg.RoleSystem
+	RoleUser       = agentpkg.RoleUser
+	RoleAgent      = agentpkg.RoleAgent
+	RoleTool       = agentpkg.RoleTool
+	RoleToolResult = agentpkg.RoleToolResult
+)
+
+// AgentSession holds the runtime state of a single agent inference or chat-turn session.
+type AgentSession struct {
+	ID          string
+	CallerID    string
+	CallerType  string
+	ConvoID     string
+	Agent       *config.Agent
+	History     []AgentMessage
+	CurrentMsg  *dipper.Message
+	Type        string
+	TTL         string
+	CurrentCall int
+	SessionSeq  int
+	ChunkSeq    int
+	ToolCalls   []AgentToolCall
+	ToolResults []map[string]interface{}
+
+	store AgentStore
+}
+
+// Type aliases so internal code can use the short names unchanged.
+type (
+	AgentMessage  = agentpkg.Message
+	AgentTool     = agentpkg.Tool
+	AgentToolCall = agentpkg.ToolCall
+)
+
+// log returns the logger from the store, or nil if unavailable.
+func (s *AgentSession) log() *logging.Logger {
+	return s.store.GetLogger()
+}
+
+// persist serialises the session and writes it to the cache.
+func (s *AgentSession) persist() {
+	if log := s.log(); log != nil {
+		log.Debugf("[agent] session [%s] persisting to cache", s.ID)
+	}
+	// add locking when parallel access is expected
+	dipper.Must(s.store.Call("cache", "save", map[string]interface{}{
+		"key":   AgentKeyPrefix + s.ID,
+		"value": string(dipper.SerializeContent(s)),
+		"ttl":   s.TTL,
+	}))
+}
+
+// load reads and deserialises a previously persisted session from the cache.
+func (s *AgentSession) load(id string) {
+	if log := s.log(); log != nil {
+		log.Debugf("[agent] session [%s] loading from cache", id)
+	}
+	ret := dipper.Must(s.store.Call("cache", "load", map[string]interface{}{
+		"key": AgentKeyPrefix + id,
+	})).([]byte)
+
+	dipper.Must(json.Unmarshal(ret, s))
+}
+
+// setup initialises a new session or restores an existing one from cache.
+// Returns the conversation ID.
+func (s *AgentSession) setup(msg *dipper.Message, store AgentStore) {
+	s.store = store
+	if id, ok := msg.Labels["agent_session_id"]; ok && id != "" {
+		s.load(id)
+		s.CurrentMsg = msg
+
+		return
+	}
+
+	s.ID = dipper.NewUUID()
+	s.CallerID = msg.Labels["caller_id"]
+	s.CallerType = msg.Labels["caller_type"]
+
+	s.Type, _ = dipper.GetMapDataStr(msg.Payload, "type")
+	if s.Type == "" {
+		s.Type = agentpkg.SessionTypeChatTurn
+	}
+
+	if convoID, ok := dipper.GetMapDataStr(msg.Payload, "convo_id"); ok && convoID != "" {
+		s.ConvoID = convoID
+		s.loadConvoHistory()
+	} else {
+		s.ConvoID = dipper.NewUUID()
+	}
+
+	s.Agent = s.store.GetAgent(msg.Labels["agent_name"])
+	s.CurrentMsg = msg
+
+	s.TTL = AgentSessionDefaultTTL
+	if ttl, ok := dipper.GetMapDataStr(msg.Payload, "ttl"); ok {
+		s.TTL = ttl
+	}
+	if log := s.log(); log != nil {
+		log.Infof("[agent] session [%s] created type=%s agent=%s", s.ID, s.Type, msg.Labels["agent_name"])
+	}
+}
+
+// loadConvoHistory fetches the multi-turn conversation history from the cache.
+func (s *AgentSession) loadConvoHistory() {
+	ret := dipper.Must(s.store.Call("cache", "lrange", map[string]interface{}{
+		"key": ConvoHistoryKeyPrefix + s.ConvoID,
+	})).([]byte)
+
+	var history []AgentMessage
+	dipper.Must(json.Unmarshal(ret, &history))
+
+	s.History = history
+}
+
+// appendConvoHistory appends a message to the in-memory history and the cache.
+func (s *AgentSession) appendConvoHistory(msg AgentMessage) {
+	s.History = append(s.History, msg)
+
+	if s.ConvoID != "" {
+		dipper.Must(s.store.Call("cache", "rpush", map[string]interface{}{
+			"key":   ConvoHistoryKeyPrefix + s.ConvoID,
+			"value": string(dipper.SerializeContent(msg)),
+		}))
+	}
+}
+
+// run appends the current user message and dispatches the conversation to the AI driver.
+func (s *AgentSession) run() {
+	tools := s.BuildTools()
+
+	if len(s.History) == 0 {
+		systemPrompt := s.Agent.SystemPrompt
+		if s.Type == AgentSessionTypeInference && len(s.Agent.InferencePrompt) > 0 {
+			systemPrompt = s.Agent.InferencePrompt
+		}
+		s.appendConvoHistory(AgentMessage{
+			Role:    RoleSystem,
+			Content: systemPrompt,
+		})
+	}
+
+	text := dipper.MustGetMapDataStr(s.CurrentMsg.Payload, "text")
+	user, _ := dipper.GetMapDataStr(s.CurrentMsg.Payload, "user")
+	s.appendConvoHistory(AgentMessage{
+		Role:    RoleUser,
+		User:    user,
+		Content: text,
+	})
+
+	s.persist()
+	if log := s.log(); log != nil {
+		log.Infof("[agent] session [%s] sending to driver=%s engine=%s history_len=%d tools=%d",
+			s.ID, s.Agent.Driver, s.Agent.Engine, len(s.History), len(tools))
+	}
+	dipper.Must(s.store.CallNoWait("driver:"+s.Agent.Driver, "send_to_model", map[string]interface{}{
+		"engine":        s.Agent.Engine,
+		"history":       s.History,
+		"tools":         tools,
+		"type":          s.Type,
+		"model_data":    s.Agent.ModelData,
+		"should_stream": s.Agent.ShouldStream,
+	}, "agent_session_id", s.ID, "chunk_sq", strconv.Itoa(s.ChunkSeq), "timeout", s.TTL))
+}
+
+func (s *AgentSession) recover() {
+	if log := s.log(); log != nil {
+		log.Infof("[agent] session [%s] recovering from cache after restart", s.ID)
+	}
+
+	tools := s.BuildTools()
+	dipper.Must(s.store.CallNoWait("driver:"+s.Agent.Driver, "send_to_model", map[string]interface{}{
+		"engine":        s.Agent.Engine,
+		"history":       s.History,
+		"tools":         tools,
+		"type":          s.Type,
+		"model_data":    s.Agent.ModelData,
+		"should_stream": s.Agent.ShouldStream,
+	}, "agent_session_id", s.ID, "chunk_sq", strconv.Itoa(s.ChunkSeq), "timeout", s.TTL))
+}
+
+// BuildTools assembles the tool map from the agent's configured system and workflow tools.
+func (s *AgentSession) BuildTools() map[string]AgentTool {
+	tools := map[string]AgentTool{}
+
+	for _, toolDef := range s.Agent.Tools {
+		switch toolDef.Type {
+		case "system":
+			s.addSystemTool(tools, toolDef)
+		case "workflow":
+			s.addWorkflowTool(tools, toolDef)
+		}
+	}
+
+	return tools
+}
+
+// addSystemTool exposes each function of a named system as a callable tool.
+func (s *AgentSession) addSystemTool(tools map[string]AgentTool, toolDef config.AgentToolDef) {
+	prefix := "sys_" + toolDef.Name + "__"
+
+	sys := s.store.GetSystem(toolDef.Name)
+	for k, f := range sys.Functions {
+		fname := prefix + k
+		if _, exists := tools[fname]; exists {
+			continue
+		}
+
+		meta := f.Meta.(map[string]interface{})
+		desc := ""
+		if d, ok := meta["description"]; ok {
+			desc = d.(string)
+		}
+
+		params := map[string]interface{}{}
+		inputs := meta["inputs"].([]interface{})
+		for _, v := range inputs {
+			def := v.(map[string]interface{})
+
+			pname := def["name"].(string)
+			ptype := "string"
+			if t, ok := def["type"]; ok {
+				ptype = t.(string)
+			}
+
+			params[pname] = map[string]interface{}{
+				"name":        pname,
+				"type":        ptype,
+				"description": def["description"],
+			}
+		}
+
+		tools[fname] = AgentTool{
+			Name:        fname,
+			Description: desc,
+			Params:      params,
+		}
+	}
+}
+
+// addWorkflowTool registers a named workflow as a callable tool.
+func (s *AgentSession) addWorkflowTool(tools map[string]AgentTool, toolDef config.AgentToolDef) {
+	fname := "wf__" + toolDef.Name
+	if _, exists := tools[fname]; exists {
+		return
+	}
+
+	wf := s.store.GetWorkflow(toolDef.Name)
+	meta := wf.Meta.(map[string]interface{})
+	desc := wf.Description
+	if desc == "" {
+		if d, ok := meta["description"]; ok {
+			desc = d.(string)
+		}
+	}
+	params := map[string]interface{}{}
+	inputs := meta["inputs"].([]interface{})
+	for _, v := range inputs {
+		def := v.(map[string]interface{})
+
+		pname := def["name"].(string)
+		ptype := "string"
+		if t, ok := def["type"]; ok {
+			ptype = t.(string)
+		}
+
+		params[pname] = map[string]interface{}{
+			"name":        pname,
+			"type":        ptype,
+			"description": def["description"],
+		}
+	}
+
+	tools[fname] = AgentTool{
+		Name:        fname,
+		Description: desc,
+		Params:      params,
+	}
+}
+
+// processAgentResponse decodes the model's response message and hands it to processAgentMessage.
+func (s *AgentSession) processAgentResponse(msg *dipper.Message) {
+	s.CurrentMsg = msg
+	m := dipper.MustGetMapData(msg.Payload, "message").(map[string]interface{})
+
+	if msg.Labels["status"] != "" && msg.Labels["status"] != "success" {
+		errRet := dipper.Message{
+			Channel: "eventbus",
+			Subject: "agent_response",
+			Labels: map[string]string{
+				"agent_session_id": s.ID,
+				"convo_id":         s.ConvoID,
+				"caller_id":        s.CallerID,
+				"caller_type":      s.CallerType,
+				"session_seq":      strconv.Itoa(s.SessionSeq),
+				"status":           msg.Labels["status"],
+				"reason":           msg.Labels["reason"],
+			},
+		}
+		if s.SessionSeq > 0 {
+			s.SessionSeq++
+			errRet.Labels["session_seq"] = strconv.Itoa(s.SessionSeq)
+		}
+		s.store.EmitMessage(errRet)
+
+		return
+	}
+
+	var agentMsg AgentMessage
+	dipper.Must(mapstructure.Decode(m, &agentMsg))
+	if log := s.log(); log != nil {
+		log.Debugf("[agent] session [%s] response received role=%s thinking=%v tool_calls=%d",
+			s.ID, agentMsg.Role, agentMsg.IsThinking, len(agentMsg.ToolCalls))
+	}
+	if agentMsg.ChunkSeq > 0 {
+		dipper.Must(s.store.Call("locker", "lock", map[string]interface{}{
+			"name":   AgentKeyPrefix + "lock:" + s.ID,
+			"expire": "30s",
+			"sq":     agentMsg.ChunkSeq,
+		}))
+		s.setup(msg, s.store) // refresh session data in case of updates during streaming
+		s.ChunkSeq = agentMsg.ChunkSeq
+	}
+	s.processAgentMessage(&agentMsg)
+	if agentMsg.ChunkSeq > 0 {
+		dipper.Must(s.store.Call("locker", "unlock", map[string]interface{}{
+			"name": AgentKeyPrefix + "lock:" + s.ID,
+		}))
+	}
+}
+
+// processAgentMessage routes a decoded model message: triggers tool calls, handles thinking
+// tokens, or re-runs the session when the model produces a final user-facing reply.
+func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
+	s.appendConvoHistory(*agentMsg)
+	if len(agentMsg.ToolCalls) > 0 {
+		s.CurrentCall = 0
+		s.ToolCalls = agentMsg.ToolCalls
+		s.nextToolCall()
+
+		return
+	}
+
+	if !agentMsg.IsThinking || s.Agent.ShouldEmitThoughts {
+		msg := dipper.Message{
+			Channel: "eventbus",
+			Subject: "agent_response",
+			Labels: map[string]string{
+				"agent_session_id": s.ID,
+				"convo_id":         s.ConvoID,
+				"caller_id":        s.CallerID,
+				"caller_type":      s.CallerType,
+			},
+			Payload: map[string]interface{}{
+				"message": agentMsg,
+			},
+		}
+		if agentMsg.ChunkSeq > 0 {
+			s.SessionSeq++
+			msg.Labels["session_seq"] = strconv.Itoa(s.SessionSeq)
+			s.persist()
+		}
+		s.store.EmitMessage(msg)
+	}
+
+	if agentMsg.IsThinking {
+		return
+	}
+
+	if agentMsg.Role != RoleAgent {
+		s.run()
+	}
+}
+
+// nextToolCall dispatches the next pending tool call to the appropriate system or workflow.
+func (s *AgentSession) nextToolCall() {
+	if s.CurrentCall >= len(s.ToolCalls) {
+		return
+	}
+
+	s.persist()
+
+	c := s.ToolCalls[s.CurrentCall]
+	if log := s.log(); log != nil {
+		log.Infof("[agent] session [%s] dispatching tool call %d/%d: %s",
+			s.ID, s.CurrentCall+1, len(s.ToolCalls), c.FuncName)
+	}
+	if strings.HasPrefix(c.FuncName, "sys_") {
+		sysName := c.FuncName[len("sys_"):strings.LastIndex(c.FuncName, "__")]
+		fName := c.FuncName[strings.LastIndex(c.FuncName, "__")+2:]
+		sys := s.store.GetSystem(sysName)
+		f := sys.Functions[fName]
+
+		s.store.EmitMessage(dipper.Message{
+			Channel: "eventbus",
+			Subject: "agent_command",
+			Labels: map[string]string{
+				"agent_session_id": s.ID,
+				"turn_id":          strconv.Itoa(len(s.History)),
+				"tool_call_id":     strconv.Itoa(s.CurrentCall),
+			},
+			Payload: map[string]interface{}{
+				"ctx":      c.Params,
+				"function": f,
+			},
+		})
+	} else if strings.HasPrefix(c.FuncName, "wf__") {
+		wfName := c.FuncName[len("wf__"):]
+
+		s.store.EmitMessage(dipper.Message{
+			Channel: "eventbus",
+			Subject: "agent_workflow",
+			Payload: map[string]interface{}{
+				"data": c.Params,
+				"do": map[string]interface{}{
+					"call_workflow": wfName,
+				},
+				"message": map[string]interface{}{
+					"labels": map[string]string{
+						"agent_session_id": s.ID,
+						"turn_id":          strconv.Itoa(len(s.History)),
+						"tool_call_id":     strconv.Itoa(s.CurrentCall),
+					},
+				},
+			},
+		})
+	}
+}
+
+// processToolResult collects the result of a completed tool call and either advances to the
+// next pending call or feeds all results back to the model.
+func (s *AgentSession) processToolResult(msg *dipper.Message) {
+	if log := s.log(); log != nil {
+		log.Debugf("[agent] session [%s] tool result received call=%d subject=%s",
+			s.ID, s.CurrentCall, msg.Subject)
+	}
+
+	turn_id, _ := strconv.Atoi(msg.Labels["turn_id"])
+
+	if turn_id != len(s.History) {
+		if log := s.log(); log != nil {
+			log.Warningf("[agent] session [%s] received out-of-order tool result for turn %d (current turn is %d)",
+				s.ID, turn_id, len(s.History))
+		}
+
+		return
+	}
+
+	tool_call_id, _ := strconv.Atoi(msg.Labels["tool_call_id"])
+	if tool_call_id != s.CurrentCall {
+		if log := s.log(); log != nil {
+			log.Warningf("[agent] session [%s] received out-of-order tool result for call %d (current call is %d)",
+				s.ID, tool_call_id, s.CurrentCall)
+		}
+
+		return
+	}
+
+	var data interface{}
+	c := s.History[len(s.History)-1].ToolCalls[s.CurrentCall]
+	switch {
+	case strings.HasPrefix(c.FuncName, "sys_"):
+		sysName := c.FuncName[len("sys_"):strings.LastIndex(c.FuncName, "__")]
+		fName := c.FuncName[strings.LastIndex(c.FuncName, "__")+2:]
+		sys := s.store.GetSystem(sysName)
+		f := sys.Functions[fName]
+
+		data = config.ExportFunctionContext(&f, map[string]interface{}{
+			"data":   msg.Payload,
+			"ctx":    c.Params,
+			"labels": msg.Labels,
+		}, s.store.GetConfig())
+
+	case strings.HasPrefix(c.FuncName, "wf__"):
+		data, _ = dipper.GetMapData(msg.Payload, "data.output")
+	}
+
+	result := map[string]interface{}{
+		"status": msg.Labels["status"],
+		"reason": msg.Labels["reason"],
+		"data":   data,
+	}
+
+	s.ToolResults = append(s.ToolResults, result)
+	s.CurrentCall++
+
+	if s.CurrentCall < len(s.ToolCalls) {
+		s.nextToolCall()
+	} else {
+		agentMsg := AgentMessage{
+			Role:       RoleToolResult,
+			ToolResult: s.ToolResults,
+		}
+
+		s.processAgentMessage(&agentMsg)
+	}
+}

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -49,6 +49,7 @@ type AgentSession struct {
 	PendingContent string
 	PendingOffset  int
 	ErrorReason    string
+	TotalTokens    int
 
 	store AgentStore
 }
@@ -58,6 +59,7 @@ type (
 	AgentMessage  = agentpkg.Message
 	AgentTool     = agentpkg.Tool
 	AgentToolCall = agentpkg.ToolCall
+	AgentState    = agentpkg.State
 )
 
 // log returns the logger from the store, or nil if unavailable.
@@ -379,6 +381,7 @@ func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 	if agentMsg.Role == RoleAgent && agentMsg.IsComplete {
 		agentMsg.Content = s.PendingContent + agentMsg.Content
 		s.PendingContent = ""
+		s.TotalTokens += agentMsg.InputTokens + agentMsg.OutputTokens
 		s.appendConvoHistory(*agentMsg)
 
 		return
@@ -642,6 +645,11 @@ func (s *AgentSession) emitPollResponse(msg *dipper.Message) bool {
 		Labels:  labels,
 		Payload: map[string]interface{}{
 			"message": am,
+			"state": AgentState{
+				HistoryLen:  len(s.history),
+				TotalTokens: s.TotalTokens,
+				ConvoID:     s.ConvoID,
+			},
 		},
 	})
 	s.LastPollTime = time.Now()

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -34,19 +34,21 @@ const (
 
 // AgentSession holds the runtime state of a single agent inference or chat-turn session.
 type AgentSession struct {
-	ID           string
-	ConvoID      string
-	Agent        *config.Agent
-	history      []AgentMessage
-	CurrentMsg   *dipper.Message
-	Type         string
-	TTL          string
-	CurrentCall  int
-	ToolCalls    []AgentToolCall
-	ToolResults  []map[string]interface{}
-	LastPoll     int
-	LastPollTime time.Time
-	ErrorReason  string
+	ID             string
+	ConvoID        string
+	Agent          *config.Agent
+	history        []AgentMessage
+	CurrentMsg     *dipper.Message
+	Type           string
+	TTL            string
+	CurrentCall    int
+	ToolCalls      []AgentToolCall
+	ToolResults    []map[string]interface{}
+	LastPoll       int
+	LastPollTime   time.Time
+	PendingContent string
+	PendingOffset  int
+	ErrorReason    string
 
 	store AgentStore
 }
@@ -355,6 +357,28 @@ func (s *AgentSession) processAgentResponse(msg *dipper.Message) {
 // processAgentMessage routes a decoded model message: triggers tool calls, handles thinking
 // tokens, or re-runs the session when the model produces a final user-facing reply.
 func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
+	// Streaming chunk: non-complete agent content with no tool calls and not a thinking token.
+	// Accumulate in PendingContent to avoid one Redis rpush per chunk.
+	if agentMsg.Role == RoleAgent && !agentMsg.IsComplete && !agentMsg.IsThinking && len(agentMsg.ToolCalls) == 0 {
+		s.PendingContent += agentMsg.Content
+		s.persist(true)
+
+		return
+	}
+
+	// Final agent message: merge PendingContent into a single history entry.
+	// PendingOffset is intentionally NOT reset here so that emitPollResponse
+	// does not re-send content that was already streamed to the engine.
+	if agentMsg.Role == RoleAgent && agentMsg.IsComplete {
+		agentMsg.Content = s.PendingContent + agentMsg.Content
+		s.PendingContent = ""
+		s.appendConvoHistory(*agentMsg)
+		s.persist(true)
+
+		return
+	}
+
+	// Everything else: thinking tokens, tool calls, non-agent messages.
 	s.appendConvoHistory(*agentMsg)
 	if len(agentMsg.ToolCalls) > 0 {
 		s.CurrentCall = 0
@@ -515,7 +539,9 @@ func (s *AgentSession) processAgentPoll(msg *dipper.Message) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	for {
-		for (s.LastPoll == len(s.history) && s.ErrorReason == "") || (!s.LastPollTime.IsZero() && time.Since(s.LastPollTime) < MinPollInterval) {
+		noNewContent := s.LastPoll == len(s.history) && len(s.PendingContent) <= s.PendingOffset
+		rateLimited := !s.LastPollTime.IsZero() && time.Since(s.LastPollTime) < MinPollInterval
+		for (noNewContent && s.ErrorReason == "") || rateLimited {
 			select {
 			case <-ctx.Done():
 				log.Warningf("[agent] session [%s] poll timeout after %s", s.ID, timeout)
@@ -540,6 +566,8 @@ func (s *AgentSession) processAgentPoll(msg *dipper.Message) {
 
 			time.Sleep(time.Second)
 			s.setup(msg, s.store, true)
+			noNewContent = s.LastPoll == len(s.history) && len(s.PendingContent) <= s.PendingOffset
+			rateLimited = !s.LastPollTime.IsZero() && time.Since(s.LastPollTime) < MinPollInterval
 		}
 
 		if s.emitPollResponse(msg) {
@@ -549,10 +577,10 @@ func (s *AgentSession) processAgentPoll(msg *dipper.Message) {
 }
 
 func (s *AgentSession) emitPollResponse(msg *dipper.Message) bool {
-	buf := strings.Builder{}
-	if marker, ok := msg.Labels["last_poll"]; ok {
-		s.LastPoll = dipper.Must(strconv.Atoi(marker)).(int)
-	}
+	// Build the full content available since LastPoll:
+	// PendingContent (not-yet-committed streaming chunks) plus any agent entries
+	// that have already been committed to history.
+	fullContent := s.PendingContent
 	for i := s.LastPoll; i < len(s.history); i++ {
 		am := s.history[i]
 		if am.Role != RoleAgent {
@@ -563,13 +591,20 @@ func (s *AgentSession) emitPollResponse(msg *dipper.Message) bool {
 			continue
 		}
 
-		buf.WriteString(am.Content)
+		fullContent += am.Content
+	}
+
+	// PendingOffset tracks how much of fullContent has already been sent to
+	// the engine in previous poll responses.
+	newContent := ""
+	if len(fullContent) > s.PendingOffset {
+		newContent = fullContent[s.PendingOffset:]
 	}
 
 	labels := msg.Labels
 	am := AgentMessage{
 		Role:    RoleAgent,
-		Content: buf.String(),
+		Content: newContent,
 	}
 
 	if h := len(s.history); h > 0 {
@@ -584,14 +619,21 @@ func (s *AgentSession) emitPollResponse(msg *dipper.Message) bool {
 		labels["status"] = "ok"
 	}
 
-	s.LastPoll = len(s.history)
-	labels["last_poll"] = strconv.Itoa(s.LastPoll)
-	if am.Content == "" && s.ErrorReason == "" {
+	if newContent == "" && s.ErrorReason == "" && !am.IsComplete {
 		s.persist(false)
 
 		return false
 	}
 
+	s.PendingOffset += len(newContent)
+	if am.IsComplete || s.ErrorReason != "" {
+		// Final poll response: reset tracking state.
+		s.LastPoll = len(s.history)
+		s.PendingOffset = 0
+		s.PendingContent = ""
+	}
+
+	labels["last_poll"] = strconv.Itoa(s.LastPoll)
 	s.store.EmitMessage(dipper.Message{
 		Channel: dipper.ChannelEventbus,
 		Subject: "agent_response",

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -34,22 +34,25 @@ const (
 
 // AgentSession holds the runtime state of a single agent inference or chat-turn session.
 type AgentSession struct {
-	ID             string
-	ConvoID        string
-	Agent          *config.Agent
-	history        []AgentMessage
-	CurrentMsg     *dipper.Message
-	Type           string
-	TTL            string
-	CurrentCall    int
-	ToolCalls      []AgentToolCall
-	ToolResults    []map[string]interface{}
-	LastPoll       int
-	LastPollTime   time.Time
-	PendingContent string
-	PendingOffset  int
-	ErrorReason    string
-	TotalTokens    int
+	ID               string
+	ConvoID          string
+	Agent            *config.Agent
+	history          []AgentMessage
+	CurrentMsg       *dipper.Message
+	Type             string
+	TTL              string
+	CurrentCall      int
+	ToolCalls        []AgentToolCall
+	ToolResults      []map[string]interface{}
+	LastPoll         int
+	LastPollTime     time.Time
+	PendingContent   string
+	PendingOffset    int
+	ErrorReason      string
+	TotalTokens      int
+	ParentSessionID  string
+	ParentTurnID     string
+	ParentToolCallID string
 
 	store AgentStore
 }
@@ -252,6 +255,8 @@ func (s *AgentSession) BuildTools() map[string]AgentTool {
 			s.addSystemTool(tools, toolDef)
 		case "workflow":
 			s.addWorkflowTool(tools, toolDef)
+		case "agent":
+			s.addAgentTool(tools, toolDef)
 		}
 	}
 
@@ -348,6 +353,52 @@ func (s *AgentSession) addWorkflowTool(tools map[string]AgentTool, toolDef confi
 	}
 }
 
+// addAgentTool registers a named agent as a callable tool.
+func (s *AgentSession) addAgentTool(tools map[string]AgentTool, toolDef config.AgentToolDef) {
+	fname := "ag__" + toolDef.Name
+	if _, exists := tools[fname]; exists {
+		return
+	}
+
+	ag := s.store.GetAgent(toolDef.Name)
+	desc := ag.Description
+	if desc == "" {
+		desc = "Call the " + toolDef.Name + " agent"
+	}
+
+	tools[fname] = AgentTool{
+		Name:        fname,
+		Description: desc,
+		Params: map[string]interface{}{
+			"input": map[string]interface{}{
+				"name":        "input",
+				"type":        "string",
+				"description": "The input text to send to the agent",
+			},
+		},
+	}
+}
+
+// notifyParent emits an agent_continue message to the parent session when a sub-agent
+// session completes as a tool call.
+func (s *AgentSession) notifyParent(agentMsg AgentMessage) {
+	s.store.EmitMessage(dipper.Message{
+		Channel: dipper.ChannelEventbus,
+		Subject: dipper.EventbusAgentContinue,
+		Labels: map[string]string{
+			"agent_session_id": s.ParentSessionID,
+			"turn_id":          s.ParentTurnID,
+			"tool_call_id":     s.ParentToolCallID,
+			"status":           "success",
+		},
+		Payload: map[string]interface{}{
+			"data": map[string]interface{}{
+				"output": agentMsg.Content,
+			},
+		},
+	})
+}
+
 // processAgentResponse decodes the model's response message and hands it to processAgentMessage.
 func (s *AgentSession) processAgentResponse(msg *dipper.Message) {
 	m := dipper.MustGetMapData(msg.Payload, "message").(map[string]interface{})
@@ -383,6 +434,9 @@ func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 		s.PendingContent = ""
 		s.TotalTokens += agentMsg.InputTokens + agentMsg.OutputTokens
 		s.appendConvoHistory(*agentMsg)
+		if s.ParentSessionID != "" {
+			s.notifyParent(*agentMsg)
+		}
 
 		return
 	}
@@ -413,7 +467,8 @@ func (s *AgentSession) nextToolCall() {
 		log.Infof("[agent] session [%s] dispatching tool call %d/%d: %s",
 			s.ID, s.CurrentCall+1, len(s.ToolCalls), c.FuncName)
 	}
-	if strings.HasPrefix(c.FuncName, "sys_") {
+	switch {
+	case strings.HasPrefix(c.FuncName, "sys_"):
 		sysName := c.FuncName[len("sys_"):strings.LastIndex(c.FuncName, "__")]
 		fName := c.FuncName[strings.LastIndex(c.FuncName, "__")+2:]
 
@@ -435,7 +490,7 @@ func (s *AgentSession) nextToolCall() {
 				},
 			},
 		})
-	} else if strings.HasPrefix(c.FuncName, "wf__") {
+	case strings.HasPrefix(c.FuncName, "wf__"):
 		wfName := c.FuncName[len("wf__"):]
 
 		s.store.EmitMessage(dipper.Message{
@@ -454,6 +509,23 @@ func (s *AgentSession) nextToolCall() {
 						"tool_call_id":     strconv.Itoa(s.CurrentCall),
 					},
 				},
+			},
+		})
+	case strings.HasPrefix(c.FuncName, "ag__"):
+		subAgentName := c.FuncName[len("ag__"):]
+		input := c.Params["input"]
+
+		s.store.EmitMessage(dipper.Message{
+			Channel: dipper.ChannelEventbus,
+			Subject: "agent_call",
+			Labels: map[string]string{
+				"agent_session_id": s.ID,
+				"turn_id":          strconv.Itoa(len(s.history)),
+				"tool_call_id":     strconv.Itoa(s.CurrentCall),
+				"sub_agent_name":   subAgentName,
+			},
+			Payload: map[string]interface{}{
+				"input": input,
 			},
 		})
 	}
@@ -504,6 +576,9 @@ func (s *AgentSession) processToolResult(msg *dipper.Message) {
 		}, s.store.GetConfig())
 
 	case strings.HasPrefix(c.FuncName, "wf__"):
+		data, _ = dipper.GetMapData(msg.Payload, "data.output")
+
+	case strings.HasPrefix(c.FuncName, "ag__"):
 		data, _ = dipper.GetMapData(msg.Payload, "data.output")
 	}
 

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -65,6 +65,13 @@ func (s *AgentSession) log() *logging.Logger {
 	return s.store.GetLogger()
 }
 
+// unlock releases the session lock in the store.
+func (s *AgentSession) unlock() {
+	dipper.Must(s.store.Call("locker", "unlock", map[string]interface{}{
+		"name": AgentKeyPrefix + s.ID,
+	}))
+}
+
 // persist serialises the session and writes it to the cache.
 func (s *AgentSession) persist(unlocking bool) {
 	if log := s.log(); log != nil {
@@ -78,9 +85,7 @@ func (s *AgentSession) persist(unlocking bool) {
 	}))
 
 	if unlocking {
-		dipper.Must(s.store.Call("locker", "unlock", map[string]interface{}{
-			"name": AgentKeyPrefix + s.ID,
-		}))
+		s.unlock()
 	}
 }
 
@@ -178,8 +183,6 @@ func (s *AgentSession) appendConvoHistory(msg AgentMessage) {
 
 // run appends the current user message and dispatches the conversation to the AI driver.
 func (s *AgentSession) run() {
-	tools := s.BuildTools()
-
 	if len(s.history) == 0 {
 		systemPrompt := s.Agent.SystemPrompt
 		if s.Type == AgentSessionTypeInference && len(s.Agent.InferencePrompt) > 0 {
@@ -193,10 +196,6 @@ func (s *AgentSession) run() {
 
 	text := dipper.MustGetMapDataStr(s.CurrentMsg.Payload, "text")
 	user, _ := dipper.GetMapDataStr(s.CurrentMsg.Payload, "user")
-	timeout := s.CurrentMsg.Labels["timeout"]
-	if timeout == "" {
-		timeout = AgentSessionDefaultTimeout
-	}
 	s.appendConvoHistory(AgentMessage{
 		Role:    RoleUser,
 		User:    user,
@@ -204,19 +203,7 @@ func (s *AgentSession) run() {
 	})
 	s.LastPoll = len(s.history)
 
-	s.persist(true)
-	if log := s.log(); log != nil {
-		log.Infof("[agent] session [%s] sending to driver=%s engine=%s history_len=%d tools=%d",
-			s.ID, s.Agent.Driver, s.Agent.Engine, len(s.history), len(tools))
-	}
-	dipper.Must(s.store.CallNoWait("driver:"+s.Agent.Driver, "send_to_model", map[string]interface{}{
-		"engine":        s.Agent.Engine,
-		"history":       s.history,
-		"tools":         tools,
-		"type":          s.Type,
-		"model_data":    s.Agent.ModelData,
-		"should_stream": s.Agent.ShouldStream,
-	}, "agent_session_id", s.ID, "timeout", timeout))
+	s.sendToDriver()
 }
 
 func (s *AgentSession) recover() {
@@ -224,13 +211,18 @@ func (s *AgentSession) recover() {
 		log.Infof("[agent] session [%s] recovering from cache after restart", s.ID)
 	}
 
+	s.sendToDriver()
+}
+
+func (s *AgentSession) sendToDriver() {
 	tools := s.BuildTools()
-	var timeout string
-	if s.CurrentMsg != nil {
-		timeout = s.CurrentMsg.Labels["timeout"]
-	}
+	timeout := s.CurrentMsg.Labels["timeout"]
 	if timeout == "" {
 		timeout = AgentSessionDefaultTimeout
+	}
+	if log := s.log(); log != nil {
+		log.Infof("[agent] session [%s] sending to driver=%s engine=%s history_len=%d tools=%d",
+			s.ID, s.Agent.Driver, s.Agent.Engine, len(s.history), len(tools))
 	}
 	dipper.Must(s.store.CallNoWait("driver:"+s.Agent.Driver, "send_to_model", map[string]interface{}{
 		"engine":        s.Agent.Engine,
@@ -269,7 +261,14 @@ func (s *AgentSession) addSystemTool(tools map[string]AgentTool, toolDef config.
 			continue
 		}
 
+		if f.Meta == nil {
+			continue
+		}
 		meta := f.Meta.(map[string]interface{})
+		if skip, ok := dipper.GetMapData(meta, "skip_agent"); ok && dipper.IsTruthy(skip) {
+			continue
+		}
+
 		desc := ""
 		if d, ok := meta["description"]; ok {
 			desc = d.(string)
@@ -343,13 +342,16 @@ func (s *AgentSession) addWorkflowTool(tools map[string]AgentTool, toolDef confi
 
 // processAgentResponse decodes the model's response message and hands it to processAgentMessage.
 func (s *AgentSession) processAgentResponse(msg *dipper.Message) {
-	s.CurrentMsg = msg
 	m := dipper.MustGetMapData(msg.Payload, "message").(map[string]interface{})
 	var agentMsg AgentMessage
 	dipper.Must(mapstructure.Decode(m, &agentMsg))
 	if log := s.log(); log != nil {
 		log.Debugf("[agent] session [%s] response received role=%s thinking=%v tool_calls=%d",
 			s.ID, agentMsg.Role, agentMsg.IsThinking, len(agentMsg.ToolCalls))
+	}
+
+	if msg.Labels["status"] != "success" && msg.Labels["status"] != "" {
+		s.ErrorReason = msg.Labels["reason"]
 	}
 	s.processAgentMessage(&agentMsg)
 }
@@ -361,7 +363,6 @@ func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 	// Accumulate in PendingContent to avoid one Redis rpush per chunk.
 	if agentMsg.Role == RoleAgent && !agentMsg.IsComplete && !agentMsg.IsThinking && len(agentMsg.ToolCalls) == 0 {
 		s.PendingContent += agentMsg.Content
-		s.persist(true)
 
 		return
 	}
@@ -373,7 +374,6 @@ func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 		agentMsg.Content = s.PendingContent + agentMsg.Content
 		s.PendingContent = ""
 		s.appendConvoHistory(*agentMsg)
-		s.persist(true)
 
 		return
 	}
@@ -389,9 +389,7 @@ func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 	}
 
 	if agentMsg.Role != RoleAgent {
-		s.run()
-	} else {
-		s.persist(true)
+		s.sendToDriver()
 	}
 }
 
@@ -401,8 +399,6 @@ func (s *AgentSession) nextToolCall() {
 		return
 	}
 
-	s.persist(true)
-
 	c := s.ToolCalls[s.CurrentCall]
 	if log := s.log(); log != nil {
 		log.Infof("[agent] session [%s] dispatching tool call %d/%d: %s",
@@ -411,8 +407,6 @@ func (s *AgentSession) nextToolCall() {
 	if strings.HasPrefix(c.FuncName, "sys_") {
 		sysName := c.FuncName[len("sys_"):strings.LastIndex(c.FuncName, "__")]
 		fName := c.FuncName[strings.LastIndex(c.FuncName, "__")+2:]
-		sys := s.store.GetSystem(sysName)
-		f := sys.Functions[fName]
 
 		s.store.EmitMessage(dipper.Message{
 			Channel: "eventbus",
@@ -423,8 +417,13 @@ func (s *AgentSession) nextToolCall() {
 				"tool_call_id":     strconv.Itoa(s.CurrentCall),
 			},
 			Payload: map[string]interface{}{
-				"ctx":      c.Params,
-				"function": f,
+				"ctx": c.Params,
+				"function": map[string]interface{}{
+					"target": map[string]interface{}{
+						"system":   sysName,
+						"function": fName,
+					},
+				},
 			},
 		})
 	} else if strings.HasPrefix(c.FuncName, "wf__") {
@@ -437,6 +436,7 @@ func (s *AgentSession) nextToolCall() {
 				"data": c.Params,
 				"do": map[string]interface{}{
 					"call_workflow": wfName,
+					"context":       "_agent_tool_call",
 				},
 				"message": map[string]interface{}{
 					"labels": map[string]string{
@@ -514,6 +514,7 @@ func (s *AgentSession) processToolResult(msg *dipper.Message) {
 			Role:       RoleToolResult,
 			ToolResult: s.ToolResults,
 		}
+		s.ToolResults = nil
 
 		s.processAgentMessage(&agentMsg)
 	}
@@ -548,9 +549,6 @@ func (s *AgentSession) processAgentPoll(msg *dipper.Message) {
 				labels := msg.Labels
 				labels["status"] = "failure"
 				labels["reason"] = "poll timeout after " + timeout.String()
-				dipper.Must(s.store.Call("locker", "unlock", map[string]interface{}{
-					"name": AgentKeyPrefix + s.ID,
-				}))
 				s.store.EmitMessage(dipper.Message{
 					Channel: dipper.ChannelEventbus,
 					Subject: "agent_response",
@@ -560,9 +558,7 @@ func (s *AgentSession) processAgentPoll(msg *dipper.Message) {
 				return
 			default:
 			}
-			dipper.Must(s.store.Call("locker", "unlock", map[string]interface{}{
-				"name": AgentKeyPrefix + s.ID,
-			}))
+			s.unlock()
 
 			time.Sleep(time.Second)
 			s.setup(msg, s.store, true)
@@ -619,6 +615,7 @@ func (s *AgentSession) emitPollResponse(msg *dipper.Message) bool {
 		labels["status"] = "ok"
 	}
 
+	s.LastPoll = len(s.history)
 	if newContent == "" && s.ErrorReason == "" && !am.IsComplete {
 		s.persist(false)
 
@@ -628,7 +625,6 @@ func (s *AgentSession) emitPollResponse(msg *dipper.Message) bool {
 	s.PendingOffset += len(newContent)
 	if am.IsComplete || s.ErrorReason != "" {
 		// Final poll response: reset tracking state.
-		s.LastPoll = len(s.history)
 		s.PendingOffset = 0
 		s.PendingContent = ""
 	}
@@ -643,7 +639,6 @@ func (s *AgentSession) emitPollResponse(msg *dipper.Message) bool {
 		},
 	})
 	s.LastPollTime = time.Now()
-	s.persist(true)
 
 	return true
 }

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -379,6 +379,25 @@ func (s *AgentSession) addAgentTool(tools map[string]AgentTool, toolDef config.A
 	}
 }
 
+// notifyParentFailure emits an agent_continue failure message to the parent session.
+// It is a no-op when ParentSessionID is empty.
+func (s *AgentSession) notifyParentFailure(reason string) {
+	if s.ParentSessionID == "" {
+		return
+	}
+	s.store.EmitMessage(dipper.Message{
+		Channel: dipper.ChannelEventbus,
+		Subject: dipper.EventbusAgentContinue,
+		Labels: map[string]string{
+			"agent_session_id": s.ParentSessionID,
+			"turn_id":          s.ParentTurnID,
+			"tool_call_id":     s.ParentToolCallID,
+			"status":           "failure",
+			"reason":           reason,
+		},
+	})
+}
+
 // notifyParent emits an agent_continue message to the parent session when a sub-agent
 // session completes as a tool call.
 func (s *AgentSession) notifyParent(agentMsg AgentMessage) {
@@ -411,6 +430,9 @@ func (s *AgentSession) processAgentResponse(msg *dipper.Message) {
 
 	if msg.Labels["status"] != "success" && msg.Labels["status"] != "" {
 		s.ErrorReason = msg.Labels["reason"]
+		s.notifyParentFailure(s.ErrorReason)
+
+		return
 	}
 	s.processAgentMessage(&agentMsg)
 }

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -89,6 +89,13 @@ func (s *AgentSession) persist(unlocking bool) {
 		"ttl":   s.TTL,
 	}))
 
+	// TRACK CONVERSATION
+	err := trackSessionInConversation(s.store, s.ConvoID, s.ID)
+	if err != nil {
+		s.log().Errorf("[agent] failed to track session %s in convo %s: %v", s.ID, s.ConvoID, err)
+	}
+
+
 	if unlocking {
 		s.unlock()
 	}

--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -1,10 +1,12 @@
 package agent
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 
 	"github.com/honeydipper/honeydipper/v4/internal/config"
+	agentpkg "github.com/honeydipper/honeydipper/v4/pkg/agent"
 	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
 	"github.com/op/go-logging"
 )
@@ -15,6 +17,7 @@ type AgentStore interface {
 	PollInference(msg *dipper.Message)
 	ContinueInference(msg *dipper.Message)
 	ReceiveInference(msg *dipper.Message)
+	StartAgentCall(msg *dipper.Message)
 
 	GetAgent(name string) *config.Agent
 	GetSystem(name string) *config.System
@@ -184,6 +187,50 @@ func NewAgentStore(helper StoreHelper) AgentStore {
 	}
 }
 
+// StartAgentCall handles an eventbus:agent_call dispatched by a parent session's tool call.
+// It creates a new inference session for the named sub-agent, initiates its first driver call,
+// and persists it. The sub-agent session will notify the parent via eventbus:agent_continue
+// when it produces its final complete message.
+func (p *PersistentAgentStore) StartAgentCall(msg *dipper.Message) {
+	p.wg.Add(1)
+	defer p.wg.Done()
+	defer dipper.SafeExitOnError("[agent] error in StartAgentCall", func(r interface{}) {
+		p.EmitMessage(dipper.Message{
+			Channel: dipper.ChannelEventbus,
+			Subject: dipper.EventbusAgentContinue,
+			Labels: map[string]string{
+				"agent_session_id": msg.Labels["agent_session_id"],
+				"turn_id":          msg.Labels["turn_id"],
+				"tool_call_id":     msg.Labels["tool_call_id"],
+				"status":           "failure",
+				"reason":           fmt.Sprintf("%v", r),
+			},
+		})
+	})
+	p.Infof("[agent] StartAgentCall sub_agent=%s parent=%s", msg.Labels["sub_agent_name"], msg.Labels["agent_session_id"])
+
+	// Build a synthetic start message for the sub-agent session.
+	subMsg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name": msg.Labels["sub_agent_name"],
+		},
+		Payload: map[string]interface{}{
+			"text": dipper.MustGetMapDataStr(msg.Payload, "input"),
+			"type": agentpkg.SessionTypeInference,
+		},
+	}
+
+	s := &AgentSession{}
+	s.setup(subMsg, p, false)
+	s.ParentSessionID = msg.Labels["agent_session_id"]
+	s.ParentTurnID = msg.Labels["turn_id"]
+	s.ParentToolCallID = msg.Labels["tool_call_id"]
+
+	defer s.persist(false)
+	s.run()
+}
+
+// PollInference handles an incoming poll request for an inference session.
 func (p *PersistentAgentStore) PollInference(msg *dipper.Message) {
 	p.wg.Add(1)
 	defer p.wg.Done()

--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -12,6 +12,7 @@ import (
 // AgentStore is the interface used by agent sessions to interact with the store.
 type AgentStore interface {
 	StartInference(msg *dipper.Message)
+	PollInference(msg *dipper.Message)
 	ContinueInference(msg *dipper.Message)
 	ReceiveInference(msg *dipper.Message)
 
@@ -57,18 +58,20 @@ func (p *PersistentAgentStore) GetLogger() *logging.Logger {
 
 // emitErrorResponse sends an agent_response with status=error back to the workflow
 // session identified by callerID. It is a no-op when callerID is empty.
-func (p *PersistentAgentStore) emitErrorResponse(callerID, callerType, reason string) {
-	if callerID == "" {
+func (p *PersistentAgentStore) emitErrorResponse(msg *dipper.Message, reason string) {
+	resumeKey := msg.Labels["resume_key"]
+	if resumeKey == "" {
+		p.Warningf("[agent] cannot emit error response without resume key in message %+v", msg.Labels)
+
 		return
 	}
 	p.EmitMessage(dipper.Message{
 		Channel: dipper.ChannelEventbus,
 		Subject: "agent_response",
 		Labels: map[string]string{
-			"caller_id":   callerID,
-			"caller_type": callerType,
-			"status":      "error",
-			"reason":      reason,
+			"resume_key": resumeKey,
+			"status":     "error",
+			"reason":     reason,
 		},
 	})
 }
@@ -77,14 +80,26 @@ func (p *PersistentAgentStore) emitErrorResponse(callerID, callerType, reason st
 func (p *PersistentAgentStore) StartInference(msg *dipper.Message) {
 	p.wg.Add(1)
 	defer p.wg.Done()
-	callerID := msg.Labels["caller_id"]
-	callerType := msg.Labels["caller_type"]
-	defer dipper.SafeExitOnError("[agent] error in StartInference", func(r error) {
-		p.emitErrorResponse(callerID, callerType, r.Error())
+	resumeKey := msg.Labels["resume_key"]
+	defer dipper.SafeExitOnError("[agent] error in handleAgentStart", func(r interface{}) {
+		p.emitErrorResponse(msg, r.(error).Error())
 	})
 	p.Infof("[agent] StartInference agent=%s", msg.Labels["agent_name"])
 	s := &AgentSession{}
-	s.setup(msg, p)
+	s.setup(msg, p, true)
+	p.EmitMessage(dipper.Message{
+		Channel: dipper.ChannelEventbus,
+		Subject: "agent_response",
+		Labels: map[string]string{
+			"resume_key":       resumeKey,
+			"agent_session_id": s.ID,
+		},
+	})
+	defer dipper.SafeExitOnError("[agent] error in running inference %", func(r interface{}) {
+		if s.ErrorReason == "" {
+			s.ErrorReason = r.(error).Error()
+		}
+	})
 	s.run()
 }
 
@@ -92,12 +107,15 @@ func (p *PersistentAgentStore) StartInference(msg *dipper.Message) {
 func (p *PersistentAgentStore) ContinueInference(msg *dipper.Message) {
 	p.wg.Add(1)
 	defer p.wg.Done()
+	defer dipper.SafeExitOnError("[agent] error in ContinueInference")
 	p.Infof("[agent] ContinueInference session=%s subject=%s", msg.Labels["agent_session_id"], msg.Subject)
 	s := &AgentSession{}
-	defer dipper.SafeExitOnError("[agent] error in ContinueInference", func(r error) {
-		p.emitErrorResponse(s.CallerID, s.CallerType, r.Error())
+	defer dipper.SafeExitOnError("[agent] error in ContinueInference", func(r interface{}) {
+		if s.ErrorReason == "" {
+			s.ErrorReason = r.(error).Error()
+		}
 	})
-	s.setup(msg, p)
+	s.setup(msg, p, true)
 	if msg.Labels["recover"] == "true" {
 		s.recover()
 	} else {
@@ -113,7 +131,12 @@ func (p *PersistentAgentStore) ReceiveInference(msg *dipper.Message) {
 	defer dipper.SafeExitOnError("[agent] error in ReceiveInference")
 	p.Infof("[agent] ReceiveInference session=%s", msg.Labels["agent_session_id"])
 	s := &AgentSession{}
-	s.setup(msg, p)
+	s.setup(msg, p, true)
+	defer dipper.SafeExitOnError("[agent] error in process agent response", func(r interface{}) {
+		if s.ErrorReason == "" {
+			s.ErrorReason = r.(error).Error()
+		}
+	})
 	s.processAgentResponse(msg)
 }
 
@@ -155,4 +178,17 @@ func NewAgentStore(helper StoreHelper) AgentStore {
 		StoreHelper: helper,
 		Logger:      dipper.GetLogger("agent", "INFO"),
 	}
+}
+
+func (p *PersistentAgentStore) PollInference(msg *dipper.Message) {
+	p.wg.Add(1)
+	defer p.wg.Done()
+	defer dipper.SafeExitOnError("[agent] error in handleAgentPoll", func(r interface{}) {
+		p.emitErrorResponse(msg, r.(error).Error())
+	})
+	p.Infof("[agent] PollInference session=%s", msg.Labels["agent_session_id"])
+
+	s := &AgentSession{}
+	s.setup(msg, p, true)
+	s.processAgentPoll(msg)
 }

--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -120,6 +120,7 @@ func (p *PersistentAgentStore) ContinueInference(msg *dipper.Message) {
 		if s.ErrorReason == "" {
 			s.ErrorReason = r.(error).Error()
 		}
+		s.notifyParentFailure(s.ErrorReason)
 	})
 
 	if msg.Labels["recover"] == "true" {
@@ -143,6 +144,7 @@ func (p *PersistentAgentStore) ReceiveInference(msg *dipper.Message) {
 		if s.ErrorReason == "" {
 			s.ErrorReason = r.(error).Error()
 		}
+		s.notifyParentFailure(s.ErrorReason)
 	})
 	s.processAgentResponse(msg)
 }

--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -95,7 +95,8 @@ func (p *PersistentAgentStore) StartInference(msg *dipper.Message) {
 			"agent_session_id": s.ID,
 		},
 	})
-	defer dipper.SafeExitOnError("[agent] error in running inference %", func(r interface{}) {
+	defer s.persist(true)
+	defer dipper.SafeExitOnError("[agent] error in running inference for %s", resumeKey, func(r interface{}) {
 		if s.ErrorReason == "" {
 			s.ErrorReason = r.(error).Error()
 		}
@@ -110,12 +111,14 @@ func (p *PersistentAgentStore) ContinueInference(msg *dipper.Message) {
 	defer dipper.SafeExitOnError("[agent] error in ContinueInference")
 	p.Infof("[agent] ContinueInference session=%s subject=%s", msg.Labels["agent_session_id"], msg.Subject)
 	s := &AgentSession{}
+	s.setup(msg, p, true)
+	defer s.persist(true)
 	defer dipper.SafeExitOnError("[agent] error in ContinueInference", func(r interface{}) {
 		if s.ErrorReason == "" {
 			s.ErrorReason = r.(error).Error()
 		}
 	})
-	s.setup(msg, p, true)
+
 	if msg.Labels["recover"] == "true" {
 		s.recover()
 	} else {
@@ -132,6 +135,7 @@ func (p *PersistentAgentStore) ReceiveInference(msg *dipper.Message) {
 	p.Infof("[agent] ReceiveInference session=%s", msg.Labels["agent_session_id"])
 	s := &AgentSession{}
 	s.setup(msg, p, true)
+	defer s.persist(true)
 	defer dipper.SafeExitOnError("[agent] error in process agent response", func(r interface{}) {
 		if s.ErrorReason == "" {
 			s.ErrorReason = r.(error).Error()
@@ -190,5 +194,6 @@ func (p *PersistentAgentStore) PollInference(msg *dipper.Message) {
 
 	s := &AgentSession{}
 	s.setup(msg, p, true)
+	defer s.persist(true)
 	s.processAgentPoll(msg)
 }

--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -215,11 +215,14 @@ func (p *PersistentAgentStore) StartAgentCall(msg *dipper.Message) {
 	// Build a synthetic start message for the sub-agent session.
 	subMsg := &dipper.Message{
 		Labels: map[string]string{
-			"agent_name": msg.Labels["sub_agent_name"],
+			"agent_name":       msg.Labels["sub_agent_name"],
+			"unified_convo_id": msg.Labels["unified_convo_id"],
 		},
 		Payload: map[string]interface{}{
-			"text": dipper.MustGetMapDataStr(msg.Payload, "input"),
-			"type": agentpkg.SessionTypeInference,
+			"text":             dipper.MustGetMapDataStr(msg.Payload, "input"),
+			"type":             agentpkg.SessionTypeInference,
+			"convo_id":         fmt.Sprintf("%s-%s", msg.Labels["convo_id"], msg.Labels["sub_agent_name"]),
+			"unified_convo_id": msg.Labels["unified_convo_id"],
 		},
 	}
 

--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -85,7 +85,7 @@ func (p *PersistentAgentStore) StartInference(msg *dipper.Message) {
 	defer p.wg.Done()
 	resumeKey := msg.Labels["resume_key"]
 	defer dipper.SafeExitOnError("[agent] error in handleAgentStart", func(r interface{}) {
-		p.emitErrorResponse(msg, r.(error).Error())
+		p.emitErrorResponse(msg, fmt.Sprintf("%v", r))
 	})
 	p.Infof("[agent] StartInference agent=%s", msg.Labels["agent_name"])
 	s := &AgentSession{}
@@ -101,8 +101,9 @@ func (p *PersistentAgentStore) StartInference(msg *dipper.Message) {
 	defer s.persist(true)
 	defer dipper.SafeExitOnError("[agent] error in running inference for %s", resumeKey, func(r interface{}) {
 		if s.ErrorReason == "" {
-			s.ErrorReason = r.(error).Error()
+			s.ErrorReason = fmt.Sprintf("%v", r)
 		}
+		s.notifyParentFailure(s.ErrorReason)
 	})
 	s.run()
 }
@@ -118,7 +119,7 @@ func (p *PersistentAgentStore) ContinueInference(msg *dipper.Message) {
 	defer s.persist(true)
 	defer dipper.SafeExitOnError("[agent] error in ContinueInference", func(r interface{}) {
 		if s.ErrorReason == "" {
-			s.ErrorReason = r.(error).Error()
+			s.ErrorReason = fmt.Sprintf("%v", r)
 		}
 		s.notifyParentFailure(s.ErrorReason)
 	})
@@ -142,7 +143,7 @@ func (p *PersistentAgentStore) ReceiveInference(msg *dipper.Message) {
 	defer s.persist(true)
 	defer dipper.SafeExitOnError("[agent] error in process agent response", func(r interface{}) {
 		if s.ErrorReason == "" {
-			s.ErrorReason = r.(error).Error()
+			s.ErrorReason = fmt.Sprintf("%v", r)
 		}
 		s.notifyParentFailure(s.ErrorReason)
 	})
@@ -237,7 +238,7 @@ func (p *PersistentAgentStore) PollInference(msg *dipper.Message) {
 	p.wg.Add(1)
 	defer p.wg.Done()
 	defer dipper.SafeExitOnError("[agent] error in handleAgentPoll", func(r interface{}) {
-		p.emitErrorResponse(msg, r.(error).Error())
+		p.emitErrorResponse(msg, fmt.Sprintf("%v", r))
 	})
 	p.Infof("[agent] PollInference session=%s", msg.Labels["agent_session_id"])
 

--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -1,0 +1,158 @@
+package agent
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+	"github.com/op/go-logging"
+)
+
+// AgentStore is the interface used by agent sessions to interact with the store.
+type AgentStore interface {
+	StartInference(msg *dipper.Message)
+	ContinueInference(msg *dipper.Message)
+	ReceiveInference(msg *dipper.Message)
+
+	GetAgent(name string) *config.Agent
+	GetSystem(name string) *config.System
+	GetWorkflow(name string) *config.Workflow
+	EmitMessage(msg dipper.Message)
+	GetConfig() *config.Config
+
+	// Stop signals the store to stop accepting new sessions and returns immediately.
+	// Call Wait to block until all in-flight sessions have drained.
+	Stop()
+	// Wait blocks until all in-flight sessions are done.
+	Wait()
+
+	// GetLogger returns the logger used by the agent store and sessions.
+	GetLogger() *logging.Logger
+
+	dipper.RPCCaller
+}
+
+// StoreHelper defines the methods PersistentAgentStore requires from the service layer.
+// internal/service.Service satisfies this interface, keeping the agent package free of
+// any dependency on internal/service.
+type StoreHelper interface {
+	dipper.RPCCaller
+	GetConfig() *config.Config
+	EmitMessage(msg dipper.Message)
+}
+
+// PersistentAgentStore implements AgentStore by delegating to a StoreHelper.
+type PersistentAgentStore struct {
+	StoreHelper
+	*logging.Logger
+	wg      sync.WaitGroup
+	stopped atomic.Bool
+}
+
+// GetLogger returns the logger used by the agent store and sessions.
+func (p *PersistentAgentStore) GetLogger() *logging.Logger {
+	return p.Logger
+}
+
+// emitErrorResponse sends an agent_response with status=error back to the workflow
+// session identified by callerID. It is a no-op when callerID is empty.
+func (p *PersistentAgentStore) emitErrorResponse(callerID, callerType, reason string) {
+	if callerID == "" {
+		return
+	}
+	p.EmitMessage(dipper.Message{
+		Channel: dipper.ChannelEventbus,
+		Subject: "agent_response",
+		Labels: map[string]string{
+			"caller_id":   callerID,
+			"caller_type": callerType,
+			"status":      "error",
+			"reason":      reason,
+		},
+	})
+}
+
+// StartInference handles an incoming inference request by creating and running a new agent session.
+func (p *PersistentAgentStore) StartInference(msg *dipper.Message) {
+	p.wg.Add(1)
+	defer p.wg.Done()
+	callerID := msg.Labels["caller_id"]
+	callerType := msg.Labels["caller_type"]
+	defer dipper.SafeExitOnError("[agent] error in StartInference", func(r error) {
+		p.emitErrorResponse(callerID, callerType, r.Error())
+	})
+	p.Infof("[agent] StartInference agent=%s", msg.Labels["agent_name"])
+	s := &AgentSession{}
+	s.setup(msg, p)
+	s.run()
+}
+
+// ContinueInference handles an incoming inference continuation request by creating and running a new agent session.
+func (p *PersistentAgentStore) ContinueInference(msg *dipper.Message) {
+	p.wg.Add(1)
+	defer p.wg.Done()
+	p.Infof("[agent] ContinueInference session=%s subject=%s", msg.Labels["agent_session_id"], msg.Subject)
+	s := &AgentSession{}
+	defer dipper.SafeExitOnError("[agent] error in ContinueInference", func(r error) {
+		p.emitErrorResponse(s.CallerID, s.CallerType, r.Error())
+	})
+	s.setup(msg, p)
+	if msg.Labels["recover"] == "true" {
+		s.recover()
+	} else {
+		s.processToolResult(msg)
+	}
+}
+
+// ReceiveInference handles an incoming inference message by loading the corresponding agent session and appending
+// the message to the conversation history.
+func (p *PersistentAgentStore) ReceiveInference(msg *dipper.Message) {
+	p.wg.Add(1)
+	defer p.wg.Done()
+	defer dipper.SafeExitOnError("[agent] error in ReceiveInference")
+	p.Infof("[agent] ReceiveInference session=%s", msg.Labels["agent_session_id"])
+	s := &AgentSession{}
+	s.setup(msg, p)
+	s.processAgentResponse(msg)
+}
+
+// GetAgent returns the named agent from the current configuration.
+func (p *PersistentAgentStore) GetAgent(name string) *config.Agent {
+	agent := p.GetConfig().DataSet.Agents[name]
+
+	return &agent
+}
+
+// GetSystem returns the named system from the current configuration.
+func (p *PersistentAgentStore) GetSystem(name string) *config.System {
+	system := p.GetConfig().DataSet.Systems[name]
+
+	return &system
+}
+
+// GetWorkflow returns the named workflow from the current configuration.
+func (p *PersistentAgentStore) GetWorkflow(name string) *config.Workflow {
+	workflow := p.GetConfig().DataSet.Workflows[name]
+
+	return &workflow
+}
+
+// Wait blocks until all in-flight agent sessions have completed.
+func (p *PersistentAgentStore) Wait() {
+	p.wg.Wait()
+}
+
+// Stop signals the store to reject new sessions and returns immediately.
+// Call Wait to block until all in-flight sessions have drained.
+func (p *PersistentAgentStore) Stop() {
+	p.stopped.Store(true)
+}
+
+// NewAgentStore creates an AgentStore backed by the provided StoreHelper.
+func NewAgentStore(helper StoreHelper) AgentStore {
+	return &PersistentAgentStore{
+		StoreHelper: helper,
+		Logger:      dipper.GetLogger("agent", "INFO"),
+	}
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -154,6 +154,7 @@ func (m *mockStore) StartInference(msg *dipper.Message)    {}
 func (m *mockStore) ContinueInference(msg *dipper.Message) {}
 func (m *mockStore) ReceiveInference(msg *dipper.Message)  {}
 func (m *mockStore) PollInference(msg *dipper.Message)     {}
+func (m *mockStore) StartAgentCall(msg *dipper.Message)    {}
 
 func (m *mockStore) GetAgent(name string) *config.Agent {
 	a := m.cfg.DataSet.Agents[name]

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -757,8 +757,9 @@ func TestProcessAgentMessage_FinalReply(t *testing.T) {
 	s := newSessionForMsgProcessing(t, store)
 
 	agentMsg := &AgentMessage{
-		Role:    RoleAgent,
-		Content: "Here is the answer.",
+		Role:       RoleAgent,
+		Content:    "Here is the answer.",
+		IsComplete: true,
 	}
 
 	s.processAgentMessage(agentMsg)
@@ -767,6 +768,37 @@ func TestProcessAgentMessage_FinalReply(t *testing.T) {
 	assert.True(t, store.hasCall("cache:save"))
 	require.Len(t, s.history, 1)
 	assert.Equal(t, "Here is the answer.", s.history[0].Content)
+}
+
+func TestProcessAgentMessage_StreamingChunk(t *testing.T) {
+	store := newMockStore(nil)
+	s := newSessionForMsgProcessing(t, store)
+
+	// Non-complete streaming chunks must be accumulated in PendingContent,
+	// not written to convo history, to avoid one Redis rpush per chunk.
+	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: "Hello"})
+	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: ", world"})
+
+	assert.Equal(t, "Hello, world", s.PendingContent)
+	assert.Empty(t, s.history, "streaming chunks must not appear in history")
+	assert.True(t, store.hasCall("cache:save"))
+}
+
+func TestProcessAgentMessage_StreamingComplete(t *testing.T) {
+	store := newMockStore(nil)
+	s := newSessionForMsgProcessing(t, store)
+
+	// Simulate two chunks followed by a final IsComplete=true message.
+	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: "Chunk1"})
+	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: "Chunk2"})
+	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: "", IsComplete: true})
+
+	// PendingContent should be cleared after the complete message.
+	assert.Empty(t, s.PendingContent)
+	// History should contain exactly one entry with all content merged.
+	require.Len(t, s.history, 1)
+	assert.Equal(t, "Chunk1Chunk2", s.history[0].Content)
+	assert.True(t, s.history[0].IsComplete)
 }
 
 func TestProcessAgentMessage_Thinking_NotEmittedByDefault(t *testing.T) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -40,12 +40,13 @@ func TestMain(m *testing.M) {
 // ---------------------------------------------------------------------------
 
 type mockStore struct {
-	mu      sync.Mutex
-	calls   []string
-	resp    map[string][]byte
-	emitted []*dipper.Message
-	cfg     *config.Config
-	logger  *logging.Logger
+	mu           sync.Mutex
+	calls        []string
+	resp         map[string][]byte
+	emitted      []*dipper.Message
+	cfg          *config.Config
+	logger       *logging.Logger
+	noWaitParams map[string]map[string]interface{}
 }
 
 func newMockStore(cfg *config.Config) *mockStore {
@@ -115,9 +116,28 @@ func (m *mockStore) Call(feature, method string, params interface{}, labelsKV ..
 }
 
 func (m *mockStore) CallNoWait(feature, method string, params interface{}, labelsKV ...string) error {
-	m.record(feature + ":" + method)
+	key := feature + ":" + method
+	m.record(key)
+	if p, ok := params.(map[string]interface{}); ok {
+		m.mu.Lock()
+		if m.noWaitParams == nil {
+			m.noWaitParams = map[string]map[string]interface{}{}
+		}
+		m.noWaitParams[key] = p
+		m.mu.Unlock()
+	}
 
 	return nil
+}
+
+func (m *mockStore) getNoWaitParams(key string) map[string]interface{} { //nolint:unparam
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.noWaitParams == nil {
+		return nil
+	}
+
+	return m.noWaitParams[key]
 }
 
 func (m *mockStore) CallRaw(feature, method string, params []byte, labelsKV ...string) ([]byte, error) {
@@ -398,13 +418,20 @@ func TestRun_AddsSystemPromptAndUserMessage(t *testing.T) {
 	s.setup(msg, store, false)
 	s.run()
 
-	require.Len(t, s.history, 2)
-	assert.Equal(t, RoleSystem, s.history[0].Role)
-	assert.Equal(t, "You are helpful.", s.history[0].Content)
-	assert.Equal(t, RoleUser, s.history[1].Role)
-	assert.Equal(t, "ping", s.history[1].Content)
+	// Persisted history contains only the user message; no system message stored.
+	require.Len(t, s.history, 1)
+	assert.Equal(t, RoleUser, s.history[0].Role)
+	assert.Equal(t, "ping", s.history[0].Content)
 
+	// Driver receives ephemeral history with system prompt prepended.
 	assert.True(t, store.hasCall("driver:openai:send_to_model"))
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	driverHistory := params["history"].([]AgentMessage)
+	require.Len(t, driverHistory, 2)
+	assert.Equal(t, RoleSystem, driverHistory[0].Role)
+	assert.Equal(t, "You are helpful.", driverHistory[0].Content)
+	assert.Equal(t, RoleUser, driverHistory[1].Role)
 }
 
 func TestRun_InferenceTypeUsesInferencePrompt(t *testing.T) {
@@ -431,17 +458,25 @@ func TestRun_InferenceTypeUsesInferencePrompt(t *testing.T) {
 	s.setup(msg, store, false)
 	s.run()
 
-	require.True(t, len(s.history) >= 1)
-	assert.Equal(t, "inference-specific-prompt", s.history[0].Content)
+	// Driver receives the inference-specific prompt, not the general system prompt.
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	driverHistory := params["history"].([]AgentMessage)
+	require.NotEmpty(t, driverHistory)
+	assert.Equal(t, RoleSystem, driverHistory[0].Role)
+	assert.Equal(t, "inference-specific-prompt", driverHistory[0].Content)
 }
 
-func TestRun_SkipsSystemPromptWhenHistoryExists(t *testing.T) {
+func TestRun_AgentSwitchUsesCurrentSystemPrompt(t *testing.T) {
+	// Simulates a mid-conversation agent switch: the persisted history has no
+	// system message (new behaviour), but sendToDriver always injects the
+	// current agent's system prompt ephemerally.
 	store := newMockStore(nil)
 	store.cfg.DataSet.Agents["a"] = config.Agent{
 		Name:         "a",
 		Driver:       "openai",
 		Engine:       "gpt-4",
-		SystemPrompt: "should not appear",
+		SystemPrompt: "new agent prompt",
 	}
 
 	msg := &dipper.Message{
@@ -451,15 +486,24 @@ func TestRun_SkipsSystemPromptWhenHistoryExists(t *testing.T) {
 
 	s := &AgentSession{}
 	s.setup(msg, store, false)
-	s.history = []AgentMessage{{Role: RoleSystem, Content: "original"}}
+	// Pre-existing history from a prior turn (no system message).
+	s.history = []AgentMessage{
+		{Role: RoleUser, Content: "previous message"},
+		{Role: RoleAgent, Content: "previous reply"},
+	}
 	s.run()
 
-	// History should have [original system, user message] but NOT a second system entry.
-	require.Len(t, s.history, 2)
-	assert.Equal(t, RoleSystem, s.history[0].Role)
-	assert.Equal(t, "original", s.history[0].Content)
-	assert.Equal(t, RoleUser, s.history[1].Role)
-	assert.Equal(t, "followup", s.history[1].Content)
+	// Persisted history gains the new user message; still no system message.
+	require.Len(t, s.history, 3)
+	assert.Equal(t, RoleUser, s.history[2].Role)
+	assert.Equal(t, "followup", s.history[2].Content)
+
+	// Driver receives current agent's system prompt at position 0.
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	driverHistory := params["history"].([]AgentMessage)
+	assert.Equal(t, RoleSystem, driverHistory[0].Role)
+	assert.Equal(t, "new agent prompt", driverHistory[0].Content)
 }
 
 func TestRun_WithUserLabel(t *testing.T) {
@@ -507,8 +551,16 @@ func TestRecover(t *testing.T) {
 	s.recover()
 
 	assert.True(t, store.hasCall("driver:openai:send_to_model"))
-	// recover should NOT modify history
+	// recover should NOT modify the persisted history slice
 	assert.Len(t, s.history, 2)
+	// Driver receives the current agent's system prompt (legacy entry filtered out)
+	// with only the user message appended after it.
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	driverHistory := params["history"].([]AgentMessage)
+	require.Len(t, driverHistory, 2)
+	assert.Equal(t, RoleSystem, driverHistory[0].Role)
+	assert.Equal(t, RoleUser, driverHistory[1].Role)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,1376 @@
+// Copyright 2026 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+	"github.com/op/go-logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// TestMain
+// ---------------------------------------------------------------------------
+
+func TestMain(m *testing.M) {
+	if dipper.Logger == nil {
+		f, _ := os.OpenFile(os.DevNull, os.O_APPEND, 0o777)
+		defer f.Close()
+		dipper.GetLogger("test-agent", "DEBUG", f, f)
+	}
+	os.Exit(m.Run())
+}
+
+// ---------------------------------------------------------------------------
+// mockStore – implements AgentStore for tests
+// ---------------------------------------------------------------------------
+
+type mockStore struct {
+	mu      sync.Mutex
+	calls   []string
+	resp    map[string][]byte
+	emitted []*dipper.Message
+	cfg     *config.Config
+	logger  *logging.Logger
+}
+
+func newMockStore(cfg *config.Config) *mockStore {
+	if cfg == nil {
+		cfg = &config.Config{DataSet: &config.DataSet{
+			Agents:    map[string]config.Agent{},
+			Systems:   map[string]config.System{},
+			Workflows: map[string]config.Workflow{},
+		}}
+	}
+
+	return &mockStore{
+		resp: map[string][]byte{},
+		cfg:  cfg,
+	}
+}
+
+func (m *mockStore) record(s string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, s)
+}
+
+func (m *mockStore) getCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]string(nil), m.calls...)
+}
+
+func (m *mockStore) hasCall(s string) bool {
+	for _, c := range m.getCalls() {
+		if c == s {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *mockStore) getEmitted() []*dipper.Message {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]*dipper.Message(nil), m.emitted...)
+}
+
+// Call looks up responses by "feature:method" and optionally "feature:method:key".
+func (m *mockStore) Call(feature, method string, params interface{}, labelsKV ...string) ([]byte, error) {
+	base := feature + ":" + method
+	if p, ok := params.(map[string]interface{}); ok {
+		if k, ok2 := p["key"].(string); ok2 {
+			full := base + ":" + k
+			if v, ok3 := m.resp[full]; ok3 {
+				m.record(base)
+
+				return v, nil
+			}
+		}
+	}
+	m.record(base)
+	if v, ok := m.resp[base]; ok {
+		return v, nil
+	}
+
+	return []byte("1"), nil
+}
+
+func (m *mockStore) CallNoWait(feature, method string, params interface{}, labelsKV ...string) error {
+	m.record(feature + ":" + method)
+
+	return nil
+}
+
+func (m *mockStore) CallRaw(feature, method string, params []byte, labelsKV ...string) ([]byte, error) {
+	return m.Call(feature, method, nil, labelsKV...)
+}
+
+func (m *mockStore) CallRawNoWait(feature, method string, params []byte, rpcID string, labelsKV ...string) error {
+	return m.CallNoWait(feature, method, nil, labelsKV...)
+}
+
+func (m *mockStore) GetName() string { return "mock-store" }
+
+func (m *mockStore) StartInference(msg *dipper.Message)    {}
+func (m *mockStore) ContinueInference(msg *dipper.Message) {}
+func (m *mockStore) ReceiveInference(msg *dipper.Message)  {}
+
+func (m *mockStore) GetAgent(name string) *config.Agent {
+	a := m.cfg.DataSet.Agents[name]
+
+	return &a
+}
+
+func (m *mockStore) GetSystem(name string) *config.System {
+	s := m.cfg.DataSet.Systems[name]
+
+	return &s
+}
+
+func (m *mockStore) GetWorkflow(name string) *config.Workflow {
+	w := m.cfg.DataSet.Workflows[name]
+
+	return &w
+}
+
+func (m *mockStore) EmitMessage(msg dipper.Message) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.emitted = append(m.emitted, &msg)
+}
+
+func (m *mockStore) GetConfig() *config.Config { return m.cfg }
+
+func (m *mockStore) Stop() {}
+func (m *mockStore) Wait() {}
+
+func (m *mockStore) GetLogger() *logging.Logger { return m.logger }
+
+// ---------------------------------------------------------------------------
+// mockStoreHelper – implements StoreHelper for PersistentAgentStore tests
+// ---------------------------------------------------------------------------
+
+type mockStoreHelper struct {
+	mockStore
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func mustMarshalJSON(v interface{}) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+
+	return b
+}
+
+func makeSystemWithFunc(funcName string) config.System {
+	return config.System{
+		Functions: map[string]config.Function{
+			funcName: {
+				Driver:    "testdriver",
+				RawAction: "action",
+				Meta: map[string]interface{}{
+					"description": "does " + funcName,
+					"inputs": []interface{}{
+						map[string]interface{}{
+							"name":        "param1",
+							"type":        "string",
+							"description": "first parameter",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeWorkflow(name, desc string) config.Workflow {
+	return config.Workflow{
+		Name:        name,
+		Description: desc,
+		Meta: map[string]interface{}{
+			"description": "meta desc for " + name,
+			"inputs": []interface{}{
+				map[string]interface{}{
+					"name":        "wfparam",
+					"type":        "string",
+					"description": "wf parameter",
+				},
+			},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AgentSession.setup tests
+// ---------------------------------------------------------------------------
+
+func TestSetup_NewSession(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["myagent"] = config.Agent{
+		Name:   "myagent",
+		Driver: "openai",
+		Engine: "gpt-4",
+	}
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name":  "myagent",
+			"caller_id":   "sess-1",
+			"caller_type": "workflow",
+		},
+		Payload: map[string]interface{}{
+			"type": AgentSessionTypeInference,
+		},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store)
+
+	assert.NotEmpty(t, s.ID)
+	assert.Equal(t, "sess-1", s.CallerID)
+	assert.Equal(t, "workflow", s.CallerType)
+	assert.Equal(t, AgentSessionTypeInference, s.Type)
+	assert.Equal(t, AgentSessionDefaultTTL, s.TTL)
+	assert.Equal(t, "myagent", s.Agent.Name)
+	assert.Same(t, msg, s.CurrentMsg)
+	assert.Equal(t, store, s.store)
+}
+
+func TestSetup_DefaultsToChatTurnType(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{Name: "a"}
+
+	msg := &dipper.Message{
+		Labels:  map[string]string{"agent_name": "a"},
+		Payload: map[string]interface{}{},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store)
+
+	assert.Equal(t, AgentSessionTypeChatTurn, s.Type)
+}
+
+func TestSetup_CustomTTL(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{Name: "a"}
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name": "a",
+		},
+		Payload: map[string]interface{}{
+			"ttl": "7200",
+		},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store)
+
+	assert.Equal(t, "7200", s.TTL)
+}
+
+func TestSetup_RestoreFromCache(t *testing.T) {
+	store := newMockStore(nil)
+
+	existing := &AgentSession{
+		ID:         "session-abc",
+		CallerID:   "orig-caller",
+		CallerType: "engine",
+		Type:       AgentSessionTypeInference,
+		TTL:        "1800",
+		History: []AgentMessage{
+			{Role: RoleSystem, Content: "system prompt"},
+			{Role: RoleUser, Content: "hello"},
+		},
+	}
+	store.resp["cache:load:"+AgentKeyPrefix+"session-abc"] = mustMarshalJSON(existing)
+
+	newMsg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_session_id": "session-abc",
+		},
+		Payload: map[string]interface{}{},
+	}
+
+	s := &AgentSession{}
+	s.setup(newMsg, store)
+
+	assert.Equal(t, "session-abc", s.ID)
+	assert.Equal(t, "orig-caller", s.CallerID)
+	assert.Equal(t, "engine", s.CallerType)
+	assert.Equal(t, "1800", s.TTL)
+	require.Len(t, s.History, 2)
+	assert.Equal(t, RoleSystem, s.History[0].Role)
+	assert.Same(t, newMsg, s.CurrentMsg)
+	assert.True(t, store.hasCall("cache:load"))
+}
+
+func TestSetup_ChatTurn_NewConvo(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{Name: "a"}
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name": "a",
+		},
+		Payload: map[string]interface{}{
+			"type": AgentSessionTypeChatTurn,
+			// no convo_id
+		},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store)
+
+	assert.Equal(t, AgentSessionTypeChatTurn, s.Type)
+	assert.NotEmpty(t, s.ConvoID)
+	assert.Empty(t, s.History) // no lrange call needed for new convo
+	assert.False(t, store.hasCall("cache:lrange"))
+}
+
+func TestSetup_ChatTurn_ExistingConvo(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{Name: "a"}
+
+	history := []AgentMessage{
+		{Role: RoleSystem, Content: "sys"},
+		{Role: RoleUser, Content: "hi"},
+		{Role: RoleAgent, Content: "hello!"},
+	}
+	store.resp["cache:lrange:"+ConvoHistoryKeyPrefix+"convo-1"] = mustMarshalJSON(history)
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name": "a",
+		},
+		Payload: map[string]interface{}{
+			"type":     AgentSessionTypeChatTurn,
+			"convo_id": "convo-1",
+		},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store)
+
+	assert.Equal(t, "convo-1", s.ConvoID)
+	require.Len(t, s.History, 3)
+	assert.Equal(t, RoleAgent, s.History[2].Role)
+	assert.True(t, store.hasCall("cache:lrange"))
+}
+
+// ---------------------------------------------------------------------------
+// AgentSession.run tests
+// ---------------------------------------------------------------------------
+
+func TestRun_AddsSystemPromptAndUserMessage(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{
+		Name:         "a",
+		Driver:       "openai",
+		Engine:       "gpt-4",
+		SystemPrompt: "You are helpful.",
+	}
+
+	msg := &dipper.Message{
+		Labels:  map[string]string{"agent_name": "a"},
+		Payload: map[string]interface{}{"text": "ping"},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store)
+	s.run()
+
+	require.Len(t, s.History, 2)
+	assert.Equal(t, RoleSystem, s.History[0].Role)
+	assert.Equal(t, "You are helpful.", s.History[0].Content)
+	assert.Equal(t, RoleUser, s.History[1].Role)
+	assert.Equal(t, "ping", s.History[1].Content)
+
+	assert.True(t, store.hasCall("cache:save"))
+	assert.True(t, store.hasCall("driver:openai:send_to_model"))
+}
+
+func TestRun_InferenceTypeUsesInferencePrompt(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{
+		Name:            "a",
+		Driver:          "openai",
+		Engine:          "gpt-4",
+		SystemPrompt:    "system",
+		InferencePrompt: "inference-specific-prompt",
+	}
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name": "a",
+		},
+		Payload: map[string]interface{}{
+			"type": AgentSessionTypeInference,
+			"text": "q",
+		},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store)
+	s.run()
+
+	require.True(t, len(s.History) >= 1)
+	assert.Equal(t, "inference-specific-prompt", s.History[0].Content)
+}
+
+func TestRun_SkipsSystemPromptWhenHistoryExists(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{
+		Name:         "a",
+		Driver:       "openai",
+		Engine:       "gpt-4",
+		SystemPrompt: "should not appear",
+	}
+
+	msg := &dipper.Message{
+		Labels:  map[string]string{"agent_name": "a"},
+		Payload: map[string]interface{}{"text": "followup"},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store)
+	s.History = []AgentMessage{{Role: RoleSystem, Content: "original"}}
+	s.run()
+
+	// History should have [original system, user message] but NOT a second system entry.
+	require.Len(t, s.History, 2)
+	assert.Equal(t, RoleSystem, s.History[0].Role)
+	assert.Equal(t, "original", s.History[0].Content)
+	assert.Equal(t, RoleUser, s.History[1].Role)
+	assert.Equal(t, "followup", s.History[1].Content)
+}
+
+func TestRun_WithUserLabel(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{Name: "a", Driver: "openai", Engine: "e"}
+
+	msg := &dipper.Message{
+		Labels:  map[string]string{"agent_name": "a"},
+		Payload: map[string]interface{}{"text": "hello", "user": "alice"},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store)
+	s.run()
+
+	userMsg := s.History[len(s.History)-1]
+	assert.Equal(t, RoleUser, userMsg.Role)
+	assert.Equal(t, "alice", userMsg.User)
+	assert.Equal(t, "hello", userMsg.Content)
+}
+
+// ---------------------------------------------------------------------------
+// AgentSession.recover tests
+// ---------------------------------------------------------------------------
+
+func TestRecover(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{
+		Name:   "a",
+		Driver: "openai",
+		Engine: "gpt-4",
+	}
+
+	s := &AgentSession{
+		store: store,
+		Agent: &config.Agent{Name: "a", Driver: "openai", Engine: "gpt-4"},
+		ID:    "recover-id",
+		History: []AgentMessage{
+			{Role: RoleSystem, Content: "sys"},
+			{Role: RoleUser, Content: "hello"},
+		},
+	}
+
+	s.recover()
+
+	assert.True(t, store.hasCall("driver:openai:send_to_model"))
+	// recover should NOT modify History
+	assert.Len(t, s.History, 2)
+}
+
+// ---------------------------------------------------------------------------
+// AgentSession.BuildTools tests
+// ---------------------------------------------------------------------------
+
+func TestBuildTools_SystemTool(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Systems["mysys"] = makeSystemWithFunc("doThing")
+	agentA := config.Agent{
+		Name:   "a",
+		Driver: "openai",
+		Tools: []config.AgentToolDef{
+			{Type: "system", Name: "mysys"},
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{
+		store: store,
+		Agent: &agentA,
+	}
+
+	tools := s.BuildTools()
+
+	require.Contains(t, tools, "sys_mysys__doThing")
+	tool := tools["sys_mysys__doThing"]
+	assert.Equal(t, "sys_mysys__doThing", tool.Name)
+	assert.Equal(t, "does doThing", tool.Description)
+	require.Contains(t, tool.Params, "param1")
+}
+
+func TestBuildTools_WorkflowTool(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Workflows["mywf"] = makeWorkflow("mywf", "my workflow")
+	agentA := config.Agent{
+		Name:   "a",
+		Driver: "openai",
+		Tools: []config.AgentToolDef{
+			{Type: "workflow", Name: "mywf"},
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{
+		store: store,
+		Agent: &agentA,
+	}
+
+	tools := s.BuildTools()
+
+	require.Contains(t, tools, "wf__mywf")
+	tool := tools["wf__mywf"]
+	assert.Equal(t, "wf__mywf", tool.Name)
+	assert.Equal(t, "my workflow", tool.Description) // prefers Workflow.Description over Meta
+	require.Contains(t, tool.Params, "wfparam")
+}
+
+func TestBuildTools_WorkflowTool_UsesMetaDescriptionWhenEmpty(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Workflows["mywf"] = makeWorkflow("mywf", "") // empty Description
+	agentA := config.Agent{
+		Name:   "a",
+		Driver: "openai",
+		Tools: []config.AgentToolDef{
+			{Type: "workflow", Name: "mywf"},
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{
+		store: store,
+		Agent: &agentA,
+	}
+
+	tools := s.BuildTools()
+
+	tool := tools["wf__mywf"]
+	assert.Equal(t, "meta desc for mywf", tool.Description)
+}
+
+func TestBuildTools_DuplicateSystemToolSkipped(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Systems["mysys"] = makeSystemWithFunc("fn1")
+	agentA := config.Agent{
+		Name:   "a",
+		Driver: "openai",
+		Tools: []config.AgentToolDef{
+			{Type: "system", Name: "mysys"},
+			{Type: "system", Name: "mysys"}, // duplicate
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{
+		store: store,
+		Agent: &agentA,
+	}
+
+	tools := s.BuildTools()
+
+	// Only one entry despite duplicate tool defs.
+	assert.Len(t, tools, 1)
+}
+
+func TestBuildTools_DuplicateWorkflowToolSkipped(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Workflows["wf1"] = makeWorkflow("wf1", "wf1 desc")
+	agentA := config.Agent{
+		Name:   "a",
+		Driver: "openai",
+		Tools: []config.AgentToolDef{
+			{Type: "workflow", Name: "wf1"},
+			{Type: "workflow", Name: "wf1"},
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{
+		store: store,
+		Agent: &agentA,
+	}
+
+	tools := s.BuildTools()
+
+	assert.Len(t, tools, 1)
+}
+
+func TestBuildTools_ParamTypeDefaultsToString(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Systems["s"] = config.System{
+		Functions: map[string]config.Function{
+			"fn": {
+				Driver:    "d",
+				RawAction: "a",
+				Meta: map[string]interface{}{
+					"description": "fn",
+					"inputs": []interface{}{
+						map[string]interface{}{
+							"name":        "p",
+							"description": "no type field",
+							// "type" is intentionally absent
+						},
+					},
+				},
+			},
+		},
+	}
+	agentA := config.Agent{
+		Name:  "a",
+		Tools: []config.AgentToolDef{{Type: "system", Name: "s"}},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{
+		store: store,
+		Agent: &agentA,
+	}
+	tools := s.BuildTools()
+
+	require.Contains(t, tools, "sys_s__fn")
+	param := tools["sys_s__fn"].Params["p"].(map[string]interface{})
+	assert.Equal(t, "string", param["type"])
+}
+
+func TestBuildTools_Mixed(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Systems["s1"] = makeSystemWithFunc("fn1")
+	store.cfg.DataSet.Systems["s2"] = makeSystemWithFunc("fn2")
+	store.cfg.DataSet.Workflows["wf1"] = makeWorkflow("wf1", "w")
+	agentA := config.Agent{
+		Name: "a",
+		Tools: []config.AgentToolDef{
+			{Type: "system", Name: "s1"},
+			{Type: "system", Name: "s2"},
+			{Type: "workflow", Name: "wf1"},
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{
+		store: store,
+		Agent: &agentA,
+	}
+	tools := s.BuildTools()
+
+	assert.Len(t, tools, 3)
+	assert.Contains(t, tools, "sys_s1__fn1")
+	assert.Contains(t, tools, "sys_s2__fn2")
+	assert.Contains(t, tools, "wf__wf1")
+}
+
+// ---------------------------------------------------------------------------
+// AgentSession.processAgentMessage tests
+// ---------------------------------------------------------------------------
+
+func newSessionForMsgProcessing(t *testing.T, store *mockStore) *AgentSession {
+	t.Helper()
+	store.cfg.DataSet.Agents["a"] = config.Agent{
+		Name:   "a",
+		Driver: "openai",
+		Engine: "gpt-4",
+	}
+	agent := store.cfg.DataSet.Agents["a"]
+
+	return &AgentSession{
+		store: store,
+		Agent: &agent,
+		ID:    "test-session",
+		CurrentMsg: &dipper.Message{
+			Labels:  map[string]string{},
+			Payload: map[string]interface{}{"text": "re-run input"},
+		},
+	}
+}
+
+func TestProcessAgentMessage_ToolCalls(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Systems["s1"] = makeSystemWithFunc("fn1")
+
+	s := newSessionForMsgProcessing(t, store)
+	s.Agent.Tools = []config.AgentToolDef{{Type: "system", Name: "s1"}}
+
+	agentMsg := &AgentMessage{
+		Role: RoleAgent,
+		ToolCalls: []AgentToolCall{
+			{FuncName: "sys_s1__fn1", Params: map[string]interface{}{"param1": "val"}},
+		},
+	}
+
+	s.processAgentMessage(agentMsg)
+
+	// History should contain the agent message.
+	require.Len(t, s.History, 1)
+	assert.Equal(t, RoleAgent, s.History[0].Role)
+
+	// nextToolCall should have emitted agent_command.
+	emitted := store.getEmitted()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "agent_command", emitted[0].Subject)
+}
+
+func TestProcessAgentMessage_FinalReply(t *testing.T) {
+	store := newMockStore(nil)
+	s := newSessionForMsgProcessing(t, store)
+
+	agentMsg := &AgentMessage{
+		Role:    RoleAgent,
+		Content: "Here is the answer.",
+	}
+
+	s.processAgentMessage(agentMsg)
+
+	emitted := store.getEmitted()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "agent_response", emitted[0].Subject)
+	assert.Equal(t, s.ID, emitted[0].Labels["agent_session_id"])
+}
+
+func TestProcessAgentMessage_Thinking_NotEmittedByDefault(t *testing.T) {
+	store := newMockStore(nil)
+	s := newSessionForMsgProcessing(t, store)
+	s.Agent.ShouldEmitThoughts = false
+
+	agentMsg := &AgentMessage{
+		Role:       RoleAgent,
+		IsThinking: true,
+		Content:    "I am thinking...",
+	}
+
+	s.processAgentMessage(agentMsg)
+
+	// Thinking tokens are NOT emitted when ShouldEmitThoughts=false.
+	assert.Empty(t, store.getEmitted())
+}
+
+func TestProcessAgentMessage_Thinking_EmittedWhenEnabled(t *testing.T) {
+	store := newMockStore(nil)
+	s := newSessionForMsgProcessing(t, store)
+	s.Agent.ShouldEmitThoughts = true
+
+	agentMsg := &AgentMessage{
+		Role:       RoleAgent,
+		IsThinking: true,
+		Content:    "reasoning...",
+	}
+
+	s.processAgentMessage(agentMsg)
+
+	emitted := store.getEmitted()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "agent_response", emitted[0].Subject)
+}
+
+func TestProcessAgentMessage_Thinking_DoesNotRerun(t *testing.T) {
+	store := newMockStore(nil)
+	s := newSessionForMsgProcessing(t, store)
+
+	agentMsg := &AgentMessage{
+		Role:       RoleAgent,
+		IsThinking: true,
+		Content:    "thinking...",
+	}
+
+	s.processAgentMessage(agentMsg)
+
+	// run() should NOT have been called (no send_to_model).
+	assert.False(t, store.hasCall("driver:openai:send_to_model"))
+}
+
+func TestProcessAgentMessage_NonAgentRole_Reruns(t *testing.T) {
+	store := newMockStore(nil)
+	s := newSessionForMsgProcessing(t, store)
+
+	agentMsg := &AgentMessage{
+		Role:    "tool",
+		Content: "some tool output",
+	}
+
+	s.processAgentMessage(agentMsg)
+
+	// Non-agent role (not thinking, no tool calls) should trigger s.run().
+	assert.True(t, store.hasCall("driver:openai:send_to_model"))
+}
+
+// ---------------------------------------------------------------------------
+// AgentSession.nextToolCall tests
+// ---------------------------------------------------------------------------
+
+func TestNextToolCall_SystemDispatch(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Systems["mysys"] = makeSystemWithFunc("doWork")
+
+	s := &AgentSession{
+		store:       store,
+		Agent:       &config.Agent{Driver: "openai"},
+		ID:          "tc-session",
+		CurrentCall: 0,
+		ToolCalls: []AgentToolCall{
+			{FuncName: "sys_mysys__doWork", Params: map[string]interface{}{"param1": "v1"}},
+		},
+	}
+
+	s.nextToolCall()
+
+	emitted := store.getEmitted()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "agent_command", emitted[0].Subject)
+	assert.Equal(t, s.ID, emitted[0].Labels["agent_session_id"])
+	assert.True(t, store.hasCall("cache:save")) // persist() was called
+}
+
+func TestNextToolCall_WorkflowDispatch(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Workflows["mywf"] = makeWorkflow("mywf", "desc")
+
+	s := &AgentSession{
+		store:       store,
+		Agent:       &config.Agent{Driver: "openai"},
+		ID:          "tc-wf-session",
+		CurrentCall: 0,
+		ToolCalls: []AgentToolCall{
+			{FuncName: "wf__mywf", Params: map[string]interface{}{"wfparam": "v"}},
+		},
+	}
+
+	s.nextToolCall()
+
+	emitted := store.getEmitted()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "agent_workflow", emitted[0].Subject)
+	assert.Equal(t, "mywf", emitted[0].Payload.(map[string]interface{})["do"].(map[string]interface{})["call_workflow"])
+}
+
+func TestNextToolCall_AllDone_DoesNothing(t *testing.T) {
+	store := newMockStore(nil)
+
+	s := &AgentSession{
+		store:       store,
+		Agent:       &config.Agent{Driver: "openai"},
+		ID:          "done-session",
+		CurrentCall: 2,
+		ToolCalls:   []AgentToolCall{{}, {}}, // 2 entries, CurrentCall == len
+	}
+
+	s.nextToolCall()
+
+	assert.Empty(t, store.getEmitted())
+	assert.False(t, store.hasCall("cache:save"))
+}
+
+// ---------------------------------------------------------------------------
+// AgentSession.processToolResult tests
+// ---------------------------------------------------------------------------
+
+func TestProcessToolResult_WorkflowResult_Advances(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Systems["s1"] = makeSystemWithFunc("fn1")
+
+	s := &AgentSession{
+		store:       store,
+		Agent:       &config.Agent{Driver: "openai"},
+		ID:          "tr-session",
+		CurrentCall: 0,
+		ToolCalls: []AgentToolCall{
+			{FuncName: "wf__mywf"},
+			{FuncName: "wf__otherwf"},
+		},
+		History: []AgentMessage{
+			{
+				Role: RoleAgent,
+				ToolCalls: []AgentToolCall{
+					{FuncName: "wf__mywf"},
+					{FuncName: "wf__otherwf"},
+				},
+			},
+		},
+	}
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"turn_id":      "1",
+			"tool_call_id": "0",
+		},
+		Payload: map[string]interface{}{
+			"data": map[string]interface{}{"output": "done"},
+		},
+	}
+
+	s.processToolResult(msg)
+
+	// Result should be appended.
+	require.Len(t, s.ToolResults, 1)
+	assert.Equal(t, "done", s.ToolResults[0]["data"])
+
+	// CurrentCall should be incremented and next tool dispatched.
+	assert.Equal(t, 1, s.CurrentCall)
+	emitted := store.getEmitted()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "agent_workflow", emitted[0].Subject)
+	assert.Equal(t, "otherwf", emitted[0].Payload.(map[string]interface{})["do"].(map[string]interface{})["call_workflow"])
+}
+
+func TestProcessToolResult_CommandResult_Advances(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Systems["mysys"] = makeSystemWithFunc("doWork")
+
+	toolCalls := []AgentToolCall{
+		{FuncName: "sys_mysys__doWork", Params: map[string]interface{}{"param1": "v"}},
+		{FuncName: "sys_mysys__doWork", Params: map[string]interface{}{"param1": "v2"}},
+	}
+
+	s := &AgentSession{
+		store:       store,
+		Agent:       &config.Agent{Driver: "openai"},
+		ID:          "cmd-session",
+		CurrentCall: 0,
+		ToolCalls:   toolCalls,
+		History: []AgentMessage{
+			{Role: RoleAgent, ToolCalls: toolCalls},
+		},
+	}
+
+	msg := &dipper.Message{
+		Subject: "agent_command_result",
+		Labels:  map[string]string{"status": "success", "turn_id": "1", "tool_call_id": "0"},
+		Payload: map[string]interface{}{},
+	}
+
+	s.processToolResult(msg)
+
+	// Result was appended (may be nil from empty Export, which is valid).
+	assert.Len(t, s.ToolResults, 1)
+
+	// Advances to the next call.
+	assert.Equal(t, 1, s.CurrentCall)
+	emitted := store.getEmitted()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "agent_command", emitted[0].Subject)
+}
+
+func TestProcessToolResult_FeedsBackWhenAllDone(t *testing.T) {
+	// When the last tool call result is received, the session feeds all
+	// collected results back to the model.
+	store := newMockStore(nil)
+
+	toolCalls := []AgentToolCall{{FuncName: "wf__done"}}
+	s := &AgentSession{
+		store:       store,
+		Agent:       &config.Agent{Driver: "openai"},
+		ID:          "feed-session",
+		CurrentCall: 0, // pointing to the only (last) tool call
+		ToolCalls:   toolCalls,
+		ToolResults: []map[string]interface{}{{"prev": "result"}},
+		History: []AgentMessage{
+			{Role: RoleSystem, Content: "sys"},
+			{Role: RoleAgent, ToolCalls: toolCalls},
+		},
+		CurrentMsg: &dipper.Message{
+			Labels:  map[string]string{},
+			Payload: map[string]interface{}{"text": "continue"},
+		},
+	}
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"turn_id":      "2",
+			"tool_call_id": "0",
+		},
+		Payload: map[string]interface{}{
+			"data": map[string]interface{}{"output": "finalval"},
+		},
+	}
+
+	s.processToolResult(msg)
+
+	// ToolResults should have the new result appended.
+	require.Len(t, s.ToolResults, 2)
+
+	// processAgentMessage should have been called → EmitMessage for tool_result response.
+	emitted := store.getEmitted()
+	require.NotEmpty(t, emitted)
+	assert.Equal(t, "agent_response", emitted[0].Subject)
+}
+
+// ---------------------------------------------------------------------------
+// appendConvoHistory tests
+// ---------------------------------------------------------------------------
+
+func TestAppendConvoHistory_WithConvoID_CallsRpush(t *testing.T) {
+	store := newMockStore(nil)
+
+	s := &AgentSession{
+		store:   store,
+		Agent:   &config.Agent{},
+		ID:      "hist-session",
+		ConvoID: "convo-99",
+	}
+
+	s.appendConvoHistory(AgentMessage{Role: RoleUser, Content: "hello"})
+
+	require.Len(t, s.History, 1)
+	assert.True(t, store.hasCall("cache:rpush"))
+}
+
+func TestAppendConvoHistory_WithoutConvoID_NoCacheCall(t *testing.T) {
+	store := newMockStore(nil)
+
+	s := &AgentSession{
+		store:   store,
+		Agent:   &config.Agent{},
+		ID:      "hist-session",
+		ConvoID: "", // no convo
+	}
+
+	s.appendConvoHistory(AgentMessage{Role: RoleUser, Content: "hello"})
+
+	require.Len(t, s.History, 1)
+	assert.False(t, store.hasCall("cache:rpush"))
+}
+
+// ---------------------------------------------------------------------------
+// persist / load tests
+// ---------------------------------------------------------------------------
+
+func TestPersist_WritesToCache(t *testing.T) {
+	store := newMockStore(nil)
+
+	s := &AgentSession{
+		store: store,
+		Agent: &config.Agent{},
+		ID:    "persist-session",
+		TTL:   "1h",
+	}
+
+	s.persist()
+
+	assert.True(t, store.hasCall("cache:save"))
+}
+
+func TestLoad_ReadsFromCache(t *testing.T) {
+	store := newMockStore(nil)
+
+	data := &AgentSession{
+		ID:       "load-session",
+		CallerID: "caller",
+		Type:     AgentSessionTypeInference,
+		TTL:      "1200",
+	}
+	store.resp["cache:load:"+AgentKeyPrefix+"load-session"] = mustMarshalJSON(data)
+
+	s := &AgentSession{store: store}
+	s.load("load-session")
+
+	assert.Equal(t, "load-session", s.ID)
+	assert.Equal(t, "caller", s.CallerID)
+	assert.Equal(t, "1200", s.TTL)
+	assert.True(t, store.hasCall("cache:load"))
+}
+
+// ---------------------------------------------------------------------------
+// PersistentAgentStore tests
+// ---------------------------------------------------------------------------
+
+func TestNewAgentStore_CreatesValidStore(t *testing.T) {
+	helper := &mockStoreHelper{
+		mockStore: *newMockStore(nil),
+	}
+
+	store := NewAgentStore(helper)
+	assert.NotNil(t, store)
+
+	pas, ok := store.(*PersistentAgentStore)
+	require.True(t, ok)
+	assert.NotNil(t, pas.Logger)
+}
+
+func TestPersistentAgentStore_GetLogger(t *testing.T) {
+	helper := &mockStoreHelper{
+		mockStore: *newMockStore(nil),
+	}
+	store := NewAgentStore(helper).(*PersistentAgentStore)
+	assert.NotNil(t, store.GetLogger())
+	assert.Equal(t, store.Logger, store.GetLogger())
+}
+
+func TestPersistentAgentStore_GetAgent(t *testing.T) {
+	cfg := &config.Config{DataSet: &config.DataSet{
+		Agents: map[string]config.Agent{
+			"bot": {Name: "bot", Driver: "openai"},
+		},
+		Systems:   map[string]config.System{},
+		Workflows: map[string]config.Workflow{},
+	}}
+	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
+	store := NewAgentStore(helper).(*PersistentAgentStore)
+
+	agent := store.GetAgent("bot")
+	assert.Equal(t, "bot", agent.Name)
+	assert.Equal(t, "openai", agent.Driver)
+}
+
+func TestPersistentAgentStore_GetSystem(t *testing.T) {
+	sys := makeSystemWithFunc("fn1")
+	cfg := &config.Config{DataSet: &config.DataSet{
+		Agents:    map[string]config.Agent{},
+		Systems:   map[string]config.System{"s1": sys},
+		Workflows: map[string]config.Workflow{},
+	}}
+	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
+	store := NewAgentStore(helper).(*PersistentAgentStore)
+
+	s := store.GetSystem("s1")
+	require.Contains(t, s.Functions, "fn1")
+}
+
+func TestPersistentAgentStore_GetWorkflow(t *testing.T) {
+	wf := makeWorkflow("wf1", "my workflow")
+	cfg := &config.Config{DataSet: &config.DataSet{
+		Agents:    map[string]config.Agent{},
+		Systems:   map[string]config.System{},
+		Workflows: map[string]config.Workflow{"wf1": wf},
+	}}
+	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
+	store := NewAgentStore(helper).(*PersistentAgentStore)
+
+	w := store.GetWorkflow("wf1")
+	assert.Equal(t, "my workflow", w.Description)
+}
+
+func TestPersistentAgentStore_StopAndWait(t *testing.T) {
+	helper := &mockStoreHelper{mockStore: *newMockStore(nil)}
+	store := NewAgentStore(helper).(*PersistentAgentStore)
+
+	// Before Stop, stopped flag is false.
+	assert.False(t, store.stopped.Load())
+
+	store.Stop()
+	assert.True(t, store.stopped.Load())
+
+	// Wait should return immediately (no in-flight sessions).
+	done := make(chan struct{})
+	go func() {
+		store.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		// success
+	default:
+		// Wait returned synchronously, also fine.
+	}
+}
+
+func TestPersistentAgentStore_StartInference(t *testing.T) {
+	cfg := &config.Config{DataSet: &config.DataSet{
+		Agents: map[string]config.Agent{
+			"bot": {Name: "bot", Driver: "openai", Engine: "gpt-4"},
+		},
+		Systems:   map[string]config.System{},
+		Workflows: map[string]config.Workflow{},
+	}}
+	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
+	store := NewAgentStore(helper).(*PersistentAgentStore)
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name":  "bot",
+			"caller_id":   "c1",
+			"caller_type": "engine",
+		},
+		Payload: map[string]interface{}{"text": "hello"},
+	}
+
+	store.StartInference(msg)
+
+	// send_to_model should have been called on the helper.
+	assert.True(t, helper.hasCall("driver:openai:send_to_model"))
+	// session should have been persisted.
+	assert.True(t, helper.hasCall("cache:save"))
+}
+
+func TestPersistentAgentStore_ReceiveInference(t *testing.T) {
+	cfg := &config.Config{DataSet: &config.DataSet{
+		Agents: map[string]config.Agent{
+			"bot": {Name: "bot", Driver: "openai", Engine: "gpt-4"},
+		},
+		Systems:   map[string]config.System{},
+		Workflows: map[string]config.Workflow{},
+	}}
+
+	// Build a persisted session.
+	existing := &AgentSession{
+		ID:         "rcv-session",
+		CallerID:   "c1",
+		CallerType: "engine",
+		Type:       AgentSessionTypeInference,
+		TTL:        "1h",
+		Agent:      &config.Agent{Name: "bot", Driver: "openai", Engine: "gpt-4"},
+		History:    []AgentMessage{{Role: RoleSystem, Content: "sys"}},
+	}
+	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
+	helper.resp["cache:load:"+AgentKeyPrefix+"rcv-session"] = mustMarshalJSON(existing)
+
+	store := NewAgentStore(helper).(*PersistentAgentStore)
+
+	agentMsg := AgentMessage{Role: RoleAgent, Content: "response!"}
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_session_id": "rcv-session",
+		},
+		Payload: map[string]interface{}{
+			"message": map[string]interface{}{
+				"Role":    RoleAgent,
+				"Content": "response!",
+			},
+		},
+	}
+	_ = agentMsg
+
+	store.ReceiveInference(msg)
+
+	// processAgentResponse → processAgentMessage → EmitMessage (agent_response).
+	assert.True(t, helper.hasCall("cache:load"))
+}
+
+func TestPersistentAgentStore_ContinueInference_ProcessResult(t *testing.T) {
+	cfg := &config.Config{DataSet: &config.DataSet{
+		Agents: map[string]config.Agent{
+			"bot": {Name: "bot", Driver: "openai", Engine: "gpt-4"},
+		},
+		Systems:   map[string]config.System{},
+		Workflows: map[string]config.Workflow{},
+	}}
+
+	// Two tool calls; CurrentCall=0 means we're processing the first result
+	// and should advance to dispatch the second.
+	toolCalls := []AgentToolCall{
+		{FuncName: "wf__firststep"},
+		{FuncName: "wf__secondstep"},
+	}
+	existing := &AgentSession{
+		ID:          "cont-session",
+		CallerID:    "c1",
+		CallerType:  "engine",
+		Type:        AgentSessionTypeInference,
+		TTL:         "1h",
+		Agent:       &config.Agent{Name: "bot", Driver: "openai", Engine: "gpt-4"},
+		CurrentCall: 0,
+		ToolCalls:   toolCalls,
+		ToolResults: []map[string]interface{}{},
+		History: []AgentMessage{
+			{Role: RoleSystem, Content: "sys"},
+			{Role: RoleAgent, ToolCalls: toolCalls},
+		},
+	}
+	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
+	helper.resp["cache:load:"+AgentKeyPrefix+"cont-session"] = mustMarshalJSON(existing)
+
+	store := NewAgentStore(helper).(*PersistentAgentStore)
+
+	msg := &dipper.Message{
+		Subject: "agent_workflow_result",
+		Labels: map[string]string{
+			"agent_session_id": "cont-session",
+			"turn_id":          "2",
+			"tool_call_id":     "0",
+		},
+		Payload: map[string]interface{}{
+			"data": map[string]interface{}{"output": "ok"},
+		},
+	}
+
+	store.ContinueInference(msg)
+
+	// Session was loaded from cache.
+	assert.True(t, helper.hasCall("cache:load"))
+	// Advancing to next tool dispatches the second workflow.
+	emitted := helper.getEmitted()
+	require.NotEmpty(t, emitted)
+	assert.Equal(t, "agent_workflow", emitted[0].Subject)
+	assert.Equal(t, "secondstep", emitted[0].Payload.(map[string]interface{})["do"].(map[string]interface{})["call_workflow"])
+}
+
+func TestPersistentAgentStore_ContinueInference_Recover(t *testing.T) {
+	cfg := &config.Config{DataSet: &config.DataSet{
+		Agents: map[string]config.Agent{
+			"bot": {Name: "bot", Driver: "openai", Engine: "gpt-4"},
+		},
+		Systems:   map[string]config.System{},
+		Workflows: map[string]config.Workflow{},
+	}}
+
+	existing := &AgentSession{
+		ID:      "rcv2-session",
+		Type:    AgentSessionTypeInference,
+		TTL:     "1h",
+		Agent:   &config.Agent{Name: "bot", Driver: "openai", Engine: "gpt-4"},
+		History: []AgentMessage{{Role: RoleSystem, Content: "sys"}},
+	}
+	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
+	helper.resp["cache:load:"+AgentKeyPrefix+"rcv2-session"] = mustMarshalJSON(existing)
+
+	store := NewAgentStore(helper).(*PersistentAgentStore)
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_session_id": "rcv2-session",
+			"recover":          "true",
+		},
+		Payload: map[string]interface{}{},
+	}
+
+	store.ContinueInference(msg)
+
+	// recover() should dispatch send_to_model.
+	assert.True(t, helper.hasCall("driver:openai:send_to_model"))
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -133,6 +133,7 @@ func (m *mockStore) GetName() string { return "mock-store" }
 func (m *mockStore) StartInference(msg *dipper.Message)    {}
 func (m *mockStore) ContinueInference(msg *dipper.Message) {}
 func (m *mockStore) ReceiveInference(msg *dipper.Message)  {}
+func (m *mockStore) PollInference(msg *dipper.Message)     {}
 
 func (m *mockStore) GetAgent(name string) *config.Agent {
 	a := m.cfg.DataSet.Agents[name]
@@ -238,9 +239,7 @@ func TestSetup_NewSession(t *testing.T) {
 
 	msg := &dipper.Message{
 		Labels: map[string]string{
-			"agent_name":  "myagent",
-			"caller_id":   "sess-1",
-			"caller_type": "workflow",
+			"agent_name": "myagent",
 		},
 		Payload: map[string]interface{}{
 			"type": AgentSessionTypeInference,
@@ -248,15 +247,13 @@ func TestSetup_NewSession(t *testing.T) {
 	}
 
 	s := &AgentSession{}
-	s.setup(msg, store)
+	s.setup(msg, store, false)
 
 	assert.NotEmpty(t, s.ID)
-	assert.Equal(t, "sess-1", s.CallerID)
-	assert.Equal(t, "workflow", s.CallerType)
 	assert.Equal(t, AgentSessionTypeInference, s.Type)
 	assert.Equal(t, AgentSessionDefaultTTL, s.TTL)
 	assert.Equal(t, "myagent", s.Agent.Name)
-	assert.Same(t, msg, s.CurrentMsg)
+	assert.Equal(t, msg, s.CurrentMsg)
 	assert.Equal(t, store, s.store)
 }
 
@@ -270,7 +267,7 @@ func TestSetup_DefaultsToChatTurnType(t *testing.T) {
 	}
 
 	s := &AgentSession{}
-	s.setup(msg, store)
+	s.setup(msg, store, false)
 
 	assert.Equal(t, AgentSessionTypeChatTurn, s.Type)
 }
@@ -289,7 +286,7 @@ func TestSetup_CustomTTL(t *testing.T) {
 	}
 
 	s := &AgentSession{}
-	s.setup(msg, store)
+	s.setup(msg, store, false)
 
 	assert.Equal(t, "7200", s.TTL)
 }
@@ -298,17 +295,16 @@ func TestSetup_RestoreFromCache(t *testing.T) {
 	store := newMockStore(nil)
 
 	existing := &AgentSession{
-		ID:         "session-abc",
-		CallerID:   "orig-caller",
-		CallerType: "engine",
-		Type:       AgentSessionTypeInference,
-		TTL:        "1800",
-		History: []AgentMessage{
-			{Role: RoleSystem, Content: "system prompt"},
-			{Role: RoleUser, Content: "hello"},
-		},
+		ID:      "session-abc",
+		ConvoID: "convo-abc",
+		Type:    AgentSessionTypeInference,
+		TTL:     "1800",
 	}
 	store.resp["cache:load:"+AgentKeyPrefix+"session-abc"] = mustMarshalJSON(existing)
+	store.resp["cache:lrange:"+ConvoHistoryKeyPrefix+"convo-abc"] = mustMarshalJSON([]AgentMessage{
+		{Role: RoleSystem, Content: "system prompt"},
+		{Role: RoleUser, Content: "hello"},
+	})
 
 	newMsg := &dipper.Message{
 		Labels: map[string]string{
@@ -318,15 +314,12 @@ func TestSetup_RestoreFromCache(t *testing.T) {
 	}
 
 	s := &AgentSession{}
-	s.setup(newMsg, store)
+	s.setup(newMsg, store, false)
 
 	assert.Equal(t, "session-abc", s.ID)
-	assert.Equal(t, "orig-caller", s.CallerID)
-	assert.Equal(t, "engine", s.CallerType)
 	assert.Equal(t, "1800", s.TTL)
-	require.Len(t, s.History, 2)
-	assert.Equal(t, RoleSystem, s.History[0].Role)
-	assert.Same(t, newMsg, s.CurrentMsg)
+	require.Len(t, s.history, 2)
+	assert.Equal(t, RoleSystem, s.history[0].Role)
 	assert.True(t, store.hasCall("cache:load"))
 }
 
@@ -345,11 +338,11 @@ func TestSetup_ChatTurn_NewConvo(t *testing.T) {
 	}
 
 	s := &AgentSession{}
-	s.setup(msg, store)
+	s.setup(msg, store, false)
 
 	assert.Equal(t, AgentSessionTypeChatTurn, s.Type)
 	assert.NotEmpty(t, s.ConvoID)
-	assert.Empty(t, s.History) // no lrange call needed for new convo
+	assert.Empty(t, s.history) // no lrange call needed for new convo
 	assert.False(t, store.hasCall("cache:lrange"))
 }
 
@@ -375,11 +368,11 @@ func TestSetup_ChatTurn_ExistingConvo(t *testing.T) {
 	}
 
 	s := &AgentSession{}
-	s.setup(msg, store)
+	s.setup(msg, store, false)
 
 	assert.Equal(t, "convo-1", s.ConvoID)
-	require.Len(t, s.History, 3)
-	assert.Equal(t, RoleAgent, s.History[2].Role)
+	require.Len(t, s.history, 3)
+	assert.Equal(t, RoleAgent, s.history[2].Role)
 	assert.True(t, store.hasCall("cache:lrange"))
 }
 
@@ -402,14 +395,14 @@ func TestRun_AddsSystemPromptAndUserMessage(t *testing.T) {
 	}
 
 	s := &AgentSession{}
-	s.setup(msg, store)
+	s.setup(msg, store, false)
 	s.run()
 
-	require.Len(t, s.History, 2)
-	assert.Equal(t, RoleSystem, s.History[0].Role)
-	assert.Equal(t, "You are helpful.", s.History[0].Content)
-	assert.Equal(t, RoleUser, s.History[1].Role)
-	assert.Equal(t, "ping", s.History[1].Content)
+	require.Len(t, s.history, 2)
+	assert.Equal(t, RoleSystem, s.history[0].Role)
+	assert.Equal(t, "You are helpful.", s.history[0].Content)
+	assert.Equal(t, RoleUser, s.history[1].Role)
+	assert.Equal(t, "ping", s.history[1].Content)
 
 	assert.True(t, store.hasCall("cache:save"))
 	assert.True(t, store.hasCall("driver:openai:send_to_model"))
@@ -436,11 +429,11 @@ func TestRun_InferenceTypeUsesInferencePrompt(t *testing.T) {
 	}
 
 	s := &AgentSession{}
-	s.setup(msg, store)
+	s.setup(msg, store, false)
 	s.run()
 
-	require.True(t, len(s.History) >= 1)
-	assert.Equal(t, "inference-specific-prompt", s.History[0].Content)
+	require.True(t, len(s.history) >= 1)
+	assert.Equal(t, "inference-specific-prompt", s.history[0].Content)
 }
 
 func TestRun_SkipsSystemPromptWhenHistoryExists(t *testing.T) {
@@ -458,16 +451,16 @@ func TestRun_SkipsSystemPromptWhenHistoryExists(t *testing.T) {
 	}
 
 	s := &AgentSession{}
-	s.setup(msg, store)
-	s.History = []AgentMessage{{Role: RoleSystem, Content: "original"}}
+	s.setup(msg, store, false)
+	s.history = []AgentMessage{{Role: RoleSystem, Content: "original"}}
 	s.run()
 
 	// History should have [original system, user message] but NOT a second system entry.
-	require.Len(t, s.History, 2)
-	assert.Equal(t, RoleSystem, s.History[0].Role)
-	assert.Equal(t, "original", s.History[0].Content)
-	assert.Equal(t, RoleUser, s.History[1].Role)
-	assert.Equal(t, "followup", s.History[1].Content)
+	require.Len(t, s.history, 2)
+	assert.Equal(t, RoleSystem, s.history[0].Role)
+	assert.Equal(t, "original", s.history[0].Content)
+	assert.Equal(t, RoleUser, s.history[1].Role)
+	assert.Equal(t, "followup", s.history[1].Content)
 }
 
 func TestRun_WithUserLabel(t *testing.T) {
@@ -480,10 +473,10 @@ func TestRun_WithUserLabel(t *testing.T) {
 	}
 
 	s := &AgentSession{}
-	s.setup(msg, store)
+	s.setup(msg, store, false)
 	s.run()
 
-	userMsg := s.History[len(s.History)-1]
+	userMsg := s.history[len(s.history)-1]
 	assert.Equal(t, RoleUser, userMsg.Role)
 	assert.Equal(t, "alice", userMsg.User)
 	assert.Equal(t, "hello", userMsg.Content)
@@ -502,10 +495,11 @@ func TestRecover(t *testing.T) {
 	}
 
 	s := &AgentSession{
-		store: store,
-		Agent: &config.Agent{Name: "a", Driver: "openai", Engine: "gpt-4"},
-		ID:    "recover-id",
-		History: []AgentMessage{
+		store:      store,
+		CurrentMsg: &dipper.Message{Labels: map[string]string{"timeout": "9s"}},
+		Agent:      &config.Agent{Name: "a", Driver: "openai", Engine: "gpt-4"},
+		ID:         "recover-id",
+		history: []AgentMessage{
 			{Role: RoleSystem, Content: "sys"},
 			{Role: RoleUser, Content: "hello"},
 		},
@@ -514,8 +508,8 @@ func TestRecover(t *testing.T) {
 	s.recover()
 
 	assert.True(t, store.hasCall("driver:openai:send_to_model"))
-	// recover should NOT modify History
-	assert.Len(t, s.History, 2)
+	// recover should NOT modify history
+	assert.Len(t, s.history, 2)
 }
 
 // ---------------------------------------------------------------------------
@@ -749,8 +743,8 @@ func TestProcessAgentMessage_ToolCalls(t *testing.T) {
 	s.processAgentMessage(agentMsg)
 
 	// History should contain the agent message.
-	require.Len(t, s.History, 1)
-	assert.Equal(t, RoleAgent, s.History[0].Role)
+	require.Len(t, s.history, 1)
+	assert.Equal(t, RoleAgent, s.history[0].Role)
 
 	// nextToolCall should have emitted agent_command.
 	emitted := store.getEmitted()
@@ -769,10 +763,10 @@ func TestProcessAgentMessage_FinalReply(t *testing.T) {
 
 	s.processAgentMessage(agentMsg)
 
-	emitted := store.getEmitted()
-	require.Len(t, emitted, 1)
-	assert.Equal(t, "agent_response", emitted[0].Subject)
-	assert.Equal(t, s.ID, emitted[0].Labels["agent_session_id"])
+	// Final reply is persisted to cache; engine retrieves it on the next poll.
+	assert.True(t, store.hasCall("cache:save"))
+	require.Len(t, s.history, 1)
+	assert.Equal(t, "Here is the answer.", s.history[0].Content)
 }
 
 func TestProcessAgentMessage_Thinking_NotEmittedByDefault(t *testing.T) {
@@ -790,24 +784,6 @@ func TestProcessAgentMessage_Thinking_NotEmittedByDefault(t *testing.T) {
 
 	// Thinking tokens are NOT emitted when ShouldEmitThoughts=false.
 	assert.Empty(t, store.getEmitted())
-}
-
-func TestProcessAgentMessage_Thinking_EmittedWhenEnabled(t *testing.T) {
-	store := newMockStore(nil)
-	s := newSessionForMsgProcessing(t, store)
-	s.Agent.ShouldEmitThoughts = true
-
-	agentMsg := &AgentMessage{
-		Role:       RoleAgent,
-		IsThinking: true,
-		Content:    "reasoning...",
-	}
-
-	s.processAgentMessage(agentMsg)
-
-	emitted := store.getEmitted()
-	require.Len(t, emitted, 1)
-	assert.Equal(t, "agent_response", emitted[0].Subject)
 }
 
 func TestProcessAgentMessage_Thinking_DoesNotRerun(t *testing.T) {
@@ -924,7 +900,7 @@ func TestProcessToolResult_WorkflowResult_Advances(t *testing.T) {
 			{FuncName: "wf__mywf"},
 			{FuncName: "wf__otherwf"},
 		},
-		History: []AgentMessage{
+		history: []AgentMessage{
 			{
 				Role: RoleAgent,
 				ToolCalls: []AgentToolCall{
@@ -974,7 +950,7 @@ func TestProcessToolResult_CommandResult_Advances(t *testing.T) {
 		ID:          "cmd-session",
 		CurrentCall: 0,
 		ToolCalls:   toolCalls,
-		History: []AgentMessage{
+		history: []AgentMessage{
 			{Role: RoleAgent, ToolCalls: toolCalls},
 		},
 	}
@@ -1010,7 +986,7 @@ func TestProcessToolResult_FeedsBackWhenAllDone(t *testing.T) {
 		CurrentCall: 0, // pointing to the only (last) tool call
 		ToolCalls:   toolCalls,
 		ToolResults: []map[string]interface{}{{"prev": "result"}},
-		History: []AgentMessage{
+		history: []AgentMessage{
 			{Role: RoleSystem, Content: "sys"},
 			{Role: RoleAgent, ToolCalls: toolCalls},
 		},
@@ -1035,10 +1011,8 @@ func TestProcessToolResult_FeedsBackWhenAllDone(t *testing.T) {
 	// ToolResults should have the new result appended.
 	require.Len(t, s.ToolResults, 2)
 
-	// processAgentMessage should have been called → EmitMessage for tool_result response.
-	emitted := store.getEmitted()
-	require.NotEmpty(t, emitted)
-	assert.Equal(t, "agent_response", emitted[0].Subject)
+	// processAgentMessage → run() should have fed the results back to the model driver.
+	assert.True(t, store.hasCall("driver:openai:send_to_model"))
 }
 
 // ---------------------------------------------------------------------------
@@ -1057,7 +1031,7 @@ func TestAppendConvoHistory_WithConvoID_CallsRpush(t *testing.T) {
 
 	s.appendConvoHistory(AgentMessage{Role: RoleUser, Content: "hello"})
 
-	require.Len(t, s.History, 1)
+	require.Len(t, s.history, 1)
 	assert.True(t, store.hasCall("cache:rpush"))
 }
 
@@ -1073,7 +1047,7 @@ func TestAppendConvoHistory_WithoutConvoID_NoCacheCall(t *testing.T) {
 
 	s.appendConvoHistory(AgentMessage{Role: RoleUser, Content: "hello"})
 
-	require.Len(t, s.History, 1)
+	require.Len(t, s.history, 1)
 	assert.False(t, store.hasCall("cache:rpush"))
 }
 
@@ -1091,7 +1065,7 @@ func TestPersist_WritesToCache(t *testing.T) {
 		TTL:   "1h",
 	}
 
-	s.persist()
+	s.persist(false)
 
 	assert.True(t, store.hasCall("cache:save"))
 }
@@ -1100,18 +1074,16 @@ func TestLoad_ReadsFromCache(t *testing.T) {
 	store := newMockStore(nil)
 
 	data := &AgentSession{
-		ID:       "load-session",
-		CallerID: "caller",
-		Type:     AgentSessionTypeInference,
-		TTL:      "1200",
+		ID:   "load-session",
+		Type: AgentSessionTypeInference,
+		TTL:  "1200",
 	}
 	store.resp["cache:load:"+AgentKeyPrefix+"load-session"] = mustMarshalJSON(data)
 
-	s := &AgentSession{store: store}
-	s.load("load-session")
+	s := &AgentSession{}
+	s.load("load-session", store)
 
 	assert.Equal(t, "load-session", s.ID)
-	assert.Equal(t, "caller", s.CallerID)
 	assert.Equal(t, "1200", s.TTL)
 	assert.True(t, store.hasCall("cache:load"))
 }
@@ -1222,11 +1194,7 @@ func TestPersistentAgentStore_StartInference(t *testing.T) {
 	store := NewAgentStore(helper).(*PersistentAgentStore)
 
 	msg := &dipper.Message{
-		Labels: map[string]string{
-			"agent_name":  "bot",
-			"caller_id":   "c1",
-			"caller_type": "engine",
-		},
+		Labels:  map[string]string{"agent_name": "bot"},
 		Payload: map[string]interface{}{"text": "hello"},
 	}
 
@@ -1249,13 +1217,11 @@ func TestPersistentAgentStore_ReceiveInference(t *testing.T) {
 
 	// Build a persisted session.
 	existing := &AgentSession{
-		ID:         "rcv-session",
-		CallerID:   "c1",
-		CallerType: "engine",
-		Type:       AgentSessionTypeInference,
-		TTL:        "1h",
-		Agent:      &config.Agent{Name: "bot", Driver: "openai", Engine: "gpt-4"},
-		History:    []AgentMessage{{Role: RoleSystem, Content: "sys"}},
+		ID:      "rcv-session",
+		Type:    AgentSessionTypeInference,
+		TTL:     "1h",
+		Agent:   &config.Agent{Name: "bot", Driver: "openai", Engine: "gpt-4"},
+		history: []AgentMessage{{Role: RoleSystem, Content: "sys"}},
 	}
 	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
 	helper.resp["cache:load:"+AgentKeyPrefix+"rcv-session"] = mustMarshalJSON(existing)
@@ -1299,21 +1265,20 @@ func TestPersistentAgentStore_ContinueInference_ProcessResult(t *testing.T) {
 	}
 	existing := &AgentSession{
 		ID:          "cont-session",
-		CallerID:    "c1",
-		CallerType:  "engine",
+		ConvoID:     "convo-cont",
 		Type:        AgentSessionTypeInference,
 		TTL:         "1h",
 		Agent:       &config.Agent{Name: "bot", Driver: "openai", Engine: "gpt-4"},
 		CurrentCall: 0,
 		ToolCalls:   toolCalls,
 		ToolResults: []map[string]interface{}{},
-		History: []AgentMessage{
-			{Role: RoleSystem, Content: "sys"},
-			{Role: RoleAgent, ToolCalls: toolCalls},
-		},
 	}
 	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
 	helper.resp["cache:load:"+AgentKeyPrefix+"cont-session"] = mustMarshalJSON(existing)
+	helper.resp["cache:lrange:"+ConvoHistoryKeyPrefix+"convo-cont"] = mustMarshalJSON([]AgentMessage{
+		{Role: RoleSystem, Content: "sys"},
+		{Role: RoleAgent, ToolCalls: toolCalls},
+	})
 
 	store := NewAgentStore(helper).(*PersistentAgentStore)
 
@@ -1351,13 +1316,16 @@ func TestPersistentAgentStore_ContinueInference_Recover(t *testing.T) {
 
 	existing := &AgentSession{
 		ID:      "rcv2-session",
+		ConvoID: "convo-rcv2",
 		Type:    AgentSessionTypeInference,
 		TTL:     "1h",
 		Agent:   &config.Agent{Name: "bot", Driver: "openai", Engine: "gpt-4"},
-		History: []AgentMessage{{Role: RoleSystem, Content: "sys"}},
 	}
 	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
 	helper.resp["cache:load:"+AgentKeyPrefix+"rcv2-session"] = mustMarshalJSON(existing)
+	helper.resp["cache:lrange:"+ConvoHistoryKeyPrefix+"convo-rcv2"] = mustMarshalJSON([]AgentMessage{
+		{Role: RoleSystem, Content: "sys"},
+	})
 
 	store := NewAgentStore(helper).(*PersistentAgentStore)
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -404,7 +404,6 @@ func TestRun_AddsSystemPromptAndUserMessage(t *testing.T) {
 	assert.Equal(t, RoleUser, s.history[1].Role)
 	assert.Equal(t, "ping", s.history[1].Content)
 
-	assert.True(t, store.hasCall("cache:save"))
 	assert.True(t, store.hasCall("driver:openai:send_to_model"))
 }
 
@@ -764,8 +763,6 @@ func TestProcessAgentMessage_FinalReply(t *testing.T) {
 
 	s.processAgentMessage(agentMsg)
 
-	// Final reply is persisted to cache; engine retrieves it on the next poll.
-	assert.True(t, store.hasCall("cache:save"))
 	require.Len(t, s.history, 1)
 	assert.Equal(t, "Here is the answer.", s.history[0].Content)
 }
@@ -781,7 +778,6 @@ func TestProcessAgentMessage_StreamingChunk(t *testing.T) {
 
 	assert.Equal(t, "Hello, world", s.PendingContent)
 	assert.Empty(t, s.history, "streaming chunks must not appear in history")
-	assert.True(t, store.hasCall("cache:save"))
 }
 
 func TestProcessAgentMessage_StreamingComplete(t *testing.T) {
@@ -873,7 +869,6 @@ func TestNextToolCall_SystemDispatch(t *testing.T) {
 	require.Len(t, emitted, 1)
 	assert.Equal(t, "agent_command", emitted[0].Subject)
 	assert.Equal(t, s.ID, emitted[0].Labels["agent_session_id"])
-	assert.True(t, store.hasCall("cache:save")) // persist() was called
 }
 
 func TestNextToolCall_WorkflowDispatch(t *testing.T) {
@@ -1039,9 +1034,6 @@ func TestProcessToolResult_FeedsBackWhenAllDone(t *testing.T) {
 	}
 
 	s.processToolResult(msg)
-
-	// ToolResults should have the new result appended.
-	require.Len(t, s.ToolResults, 2)
 
 	// processAgentMessage → run() should have fed the results back to the model driver.
 	assert.True(t, store.hasCall("driver:openai:send_to_model"))
@@ -1352,6 +1344,9 @@ func TestPersistentAgentStore_ContinueInference_Recover(t *testing.T) {
 		Type:    AgentSessionTypeInference,
 		TTL:     "1h",
 		Agent:   &config.Agent{Name: "bot", Driver: "openai", Engine: "gpt-4"},
+		CurrentMsg: &dipper.Message{
+			Labels: map[string]string{},
+		},
 	}
 	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
 	helper.resp["cache:load:"+AgentKeyPrefix+"rcv2-session"] = mustMarshalJSON(existing)

--- a/internal/agent/conversation.go
+++ b/internal/agent/conversation.go
@@ -1,0 +1,59 @@
+package agent
+
+import (
+	"fmt"
+
+	"github.com/honeydipper/honeydipper/pkg/dipper"
+)
+
+const (
+	// ConversationKeyPrefix is the prefix for Redis keys storing conversation session IDs.
+	ConversationKeyPrefix = "convo:"
+)
+
+// Conversation stores a list of agent session IDs associated with a single conversation.
+type Conversation struct {
+	ConvoID    string   `json:"convo_id"`
+	SessionIDs []string `json:"session_ids"`
+}
+
+// trackSessionInConversation is a helper to update the conversation record in the cache via RPC.
+// It should be called whenever a new AgentSession is successfully persisted.
+func trackSessionInConversation(store dipper.RPCCaller, convoID string, sessionID string) error {
+	if convoID == "" {
+		return nil
+	}
+
+	key := ConversationKeyPrefix + convoID
+
+	// 1. Try to load the existing conversation
+	var convo Conversation
+	err := store.Call("cache", "get", map[string]interface{}{
+		"key": key,
+	}, &convo)
+
+	// If not found, initialize a new one
+	if err != nil {
+		convo = Conversation{
+			ConvoID:    convoID,
+			SessionIDs: []string{},
+		}
+	}
+
+	// 2. Check if session is already in the list to avoid duplicates
+	for _, id := range convo.SessionIDs {
+		if id == sessionID {
+			return nil
+		}
+	}
+
+	// 3. Append the new session ID
+	convo.SessionIDs = append(convo.SessionIDs, sessionID)
+
+	// 4. Save the updated conversation back to cache
+	return store.Call("cache", "save", map[string]interface{}{
+		"key":   key,
+		"value": dipper.SerializeContent(convo),
+		"ttl":   86400, // Default 24h TTL for conversation metadata
+	}).(error)
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -63,6 +63,7 @@ type Workflow struct {
 	Context     string
 	Contexts    interface{}
 	Local       interface{} `json:"with" mapstructure:"with"`
+	Parameters  interface{} `json:"parameters" mapstructure:"parameters"`
 
 	Match       interface{} `json:"if_match" mapstructure:"if_match"`
 	UnlessMatch interface{} `json:"unless_match" mapstructure:"unelss_match"`
@@ -93,6 +94,7 @@ type Workflow struct {
 	Function     Function
 	CallFunction string `json:"call_function" mapstructure:"call_function"`
 	CallDriver   string `json:"call_driver" mapstructure:"call_driver"`
+	CallAgent    string `json:"call_agent" mapstructure:"call_agent"`
 	Steps        []Workflow
 	Threads      []Workflow
 	Wait         string
@@ -152,10 +154,32 @@ func (r RepoInfo) Key() RepoKey {
 	return RepoKey{Repo: r.Repo, Branch: r.Branch, Path: r.Path, InitFile: r.InitFile}
 }
 
+// AgentToolDef defines if the workflow is a workflow or a system.
+type AgentToolDef struct {
+	Type string
+	Name string
+}
+
+// Agent is a abstract data structure including AI driver, prompt and tools definitions for an agent session.
+type Agent struct {
+	Name               string
+	Driver             string
+	Engine             string
+	SystemPrompt       string `json:"system_prompt" mapstructure:"system_prompt"`
+	InferencePrompt    string `json:"inference_prompt" mapstructure:"inference_prompt"`
+	ShouldEmitThoughts bool   `json:"should_emit_thoughts" mapstructure:"should_emit_thoughts"`
+	ShouldStream       bool   `json:"should_stream" mapstructure:"should_stream"`
+	Tools              []AgentToolDef
+	ModelData          map[string]interface{} `json:"model_data" mapstructure:"model_data"`
+	Description        string
+	Meta               interface{}
+}
+
 // DataSet is a subset of configuration that can be assembled to the complete final configuration.
 type DataSet struct {
 	Systems   map[string]System
 	Rules     []Rule
+	Agents    map[string]Agent
 	Drivers   map[string]interface{}
 	Includes  []string
 	Repos     []RepoInfo

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -95,6 +95,7 @@ type Workflow struct {
 	CallFunction string `json:"call_function" mapstructure:"call_function"`
 	CallDriver   string `json:"call_driver" mapstructure:"call_driver"`
 	CallAgent    string `json:"call_agent" mapstructure:"call_agent"`
+	WaitAgent    string `json:"wait_agent" mapstructure:"wait_agent"`
 	Steps        []Workflow
 	Threads      []Workflow
 	Wait         string

--- a/internal/service/agent_svc.go
+++ b/internal/service/agent_svc.go
@@ -24,6 +24,7 @@ const (
 	SubjectEventbusAgentRecover   = "agent_recover"
 	SubjectAgentbusRPCInterrupted = "rpc_interrupted"
 	SubjectEventbusAgentPoll      = "agent_poll"
+	SubjectEventbusAgentCall      = "agent_call"
 )
 
 var (
@@ -51,6 +52,7 @@ func StartAgent(cfg *config.Config) {
 	agentSvc.addResponder(ChannelAgentbus+":"+SubjectAgentbusRPCInterrupted, handleRPCInterrupted)
 	agentSvc.addResponder(dipper.ChannelEventbus+":"+SubjectEventbusAgentRecover, handleAgentRecover)
 	agentSvc.addResponder(dipper.ChannelEventbus+":"+SubjectEventbusAgentPoll, handleAgentPoll)
+	agentSvc.addResponder(dipper.ChannelEventbus+":"+SubjectEventbusAgentCall, handleAgentCall)
 
 	// Build the store before start() so the package-level var is set
 	// before any goroutine spawned by a responder can reference it.
@@ -163,6 +165,27 @@ func handleAgentRecover(_ *driver.Runtime, msg *dipper.Message) {
 	msg = dipper.DeserializePayload(msg)
 	msg.Labels["recover"] = "true"
 	go agentStore.ContinueInference(msg)
+}
+
+// handleAgentCall handles an eventbus:agent_call dispatched by an agent session
+// when a model invokes a sub-agent as a tool.
+func handleAgentCall(_ *driver.Runtime, msg *dipper.Message) {
+	defer dipper.SafeExitOnError("[agent] error in handleAgentCall", func(r error) {
+		agentStore.EmitMessage(dipper.Message{
+			Channel: dipper.ChannelEventbus,
+			Subject: dipper.EventbusAgentContinue,
+			Labels: map[string]string{
+				"agent_session_id": msg.Labels["agent_session_id"],
+				"turn_id":          msg.Labels["turn_id"],
+				"tool_call_id":     msg.Labels["tool_call_id"],
+				"status":           "failure",
+				"reason":           r.Error(),
+			},
+		})
+	})
+	<-agentSvc.Ready()
+	msg = dipper.DeserializePayload(msg)
+	go agentStore.StartAgentCall(msg)
 }
 
 func handleAgentPoll(_ *driver.Runtime, msg *dipper.Message) {

--- a/internal/service/agent_svc.go
+++ b/internal/service/agent_svc.go
@@ -19,9 +19,11 @@ const (
 	ChannelAgentbus        = "agentbus"
 	SubjectAgentbusReceive = "receive"
 
-	SubjectEventbusAgentStart    = "agent_start"
-	SubjectEventbusAgentContinue = dipper.EventbusAgentContinue
-	SubjectEventbusAgentRecover  = "agent_recover"
+	SubjectEventbusAgentStart     = "agent_start"
+	SubjectEventbusAgentContinue  = dipper.EventbusAgentContinue
+	SubjectEventbusAgentRecover   = "agent_recover"
+	SubjectAgentbusRPCInterrupted = "rpc_interrupted"
+	SubjectEventbusAgentPoll      = "agent_poll"
 )
 
 var (
@@ -46,8 +48,9 @@ func StartAgent(cfg *config.Config) {
 	agentSvc.addResponder(dipper.ChannelEventbus+":"+SubjectEventbusAgentStart, handleAgentStart)
 	agentSvc.addResponder(dipper.ChannelEventbus+":"+SubjectEventbusAgentContinue, handleAgentContinue)
 	agentSvc.addResponder(ChannelAgentbus+":"+SubjectAgentbusReceive, handleAgentReceive)
-	agentSvc.addResponder(dipper.ChannelEventbus+":"+dipper.EventbusRPCInterrupted, handleRPCInterrupted)
+	agentSvc.addResponder(ChannelAgentbus+":"+SubjectAgentbusRPCInterrupted, handleRPCInterrupted)
 	agentSvc.addResponder(dipper.ChannelEventbus+":"+SubjectEventbusAgentRecover, handleAgentRecover)
+	agentSvc.addResponder(dipper.ChannelEventbus+":"+SubjectEventbusAgentPoll, handleAgentPoll)
 
 	// Build the store before start() so the package-level var is set
 	// before any goroutine spawned by a responder can reference it.
@@ -78,8 +81,10 @@ func AgentFeatures(c *config.DataSet) map[string]interface{} {
 // Agentbus messages from AI drivers are handled entirely by responders and do not need routing.
 func agentRoute(msg *dipper.Message) []RoutedMessage {
 	if msg.Channel == dipper.ChannelEventbus {
-		if bus := agentSvc.getDriverRuntime(dipper.ChannelEventbus); bus != nil {
-			return []RoutedMessage{{driverRuntime: bus, message: msg}}
+		if msg.Subject == "agent_command" || msg.Subject == "agent_workflow" || msg.Subject == "agent_response" {
+			if bus := agentSvc.getDriverRuntime(dipper.ChannelEventbus); bus != nil {
+				return []RoutedMessage{{driverRuntime: bus, message: msg}}
+			}
 		}
 	}
 
@@ -88,20 +93,18 @@ func agentRoute(msg *dipper.Message) []RoutedMessage {
 
 // handleAgentStart receives an agentbus:start message and calls StartInference on the store.
 func handleAgentStart(_ *driver.Runtime, msg *dipper.Message) {
-	callerID := msg.Labels["caller_id"]
-	callerType := msg.Labels["caller_type"]
+	resumeKey := msg.Labels["resume_key"]
+	if resumeKey == "" {
+		dipper.Logger.Panicf("agent recevied start request without resume key %+v", msg.Labels)
+	}
 	defer dipper.SafeExitOnError("[agent] error in handleAgentStart", func(r error) {
-		if callerID == "" {
-			return
-		}
 		agentStore.EmitMessage(dipper.Message{
 			Channel: dipper.ChannelEventbus,
 			Subject: "agent_response",
 			Labels: map[string]string{
-				"caller_id":   callerID,
-				"caller_type": callerType,
-				"status":      "error",
-				"reason":      r.Error(),
+				"resume_key": resumeKey,
+				"status":     "error",
+				"reason":     r.Error(),
 			},
 		})
 	})
@@ -125,7 +128,7 @@ func handleAgentReceive(_ *driver.Runtime, msg *dipper.Message) {
 	defer dipper.SafeExitOnError("[agent] error in handleAgentReceive")
 	<-agentSvc.Ready()
 	msg = dipper.DeserializePayload(msg)
-	go agentStore.ReceiveInference(msg)
+	agentStore.ReceiveInference(msg)
 }
 
 // handleRPCInterrupted handles an eventbus:rpc/interrupted notification from an AI-model
@@ -160,4 +163,26 @@ func handleAgentRecover(_ *driver.Runtime, msg *dipper.Message) {
 	msg = dipper.DeserializePayload(msg)
 	msg.Labels["recover"] = "true"
 	go agentStore.ContinueInference(msg)
+}
+
+func handleAgentPoll(_ *driver.Runtime, msg *dipper.Message) {
+	resumeKey := msg.Labels["resume_key"]
+	if resumeKey == "" {
+		dipper.Logger.Panicf("[agent] poll request received without resume key %+v", msg.Labels)
+	}
+	defer dipper.SafeExitOnError("[agent] error in handleAgentPoll", func(r error) {
+		agentStore.EmitMessage(dipper.Message{
+			Channel: dipper.ChannelEventbus,
+			Subject: "agent_response",
+			Labels: map[string]string{
+				"resume_key": resumeKey,
+				"status":     "error",
+				"reason":     r.Error(),
+			},
+		})
+	})
+	<-agentSvc.Ready()
+
+	msg = dipper.DeserializePayload(msg)
+	go agentStore.PollInference(msg)
 }

--- a/internal/service/agent_svc.go
+++ b/internal/service/agent_svc.go
@@ -1,0 +1,163 @@
+// Copyright 2026 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+package service
+
+import (
+	"github.com/honeydipper/honeydipper/v4/internal/agent"
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	"github.com/honeydipper/honeydipper/v4/internal/daemon"
+	"github.com/honeydipper/honeydipper/v4/internal/driver"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+)
+
+// Channel and subject constants for the agent service.
+const (
+	ChannelAgentbus        = "agentbus"
+	SubjectAgentbusReceive = "receive"
+
+	SubjectEventbusAgentStart    = "agent_start"
+	SubjectEventbusAgentContinue = dipper.EventbusAgentContinue
+	SubjectEventbusAgentRecover  = "agent_recover"
+)
+
+var (
+	agentSvc   *Service
+	agentStore agent.AgentStore
+)
+
+// StartAgent starts the agent service.
+//
+// The service:
+//   - loads all AI-model drivers referenced by the agent configurations;
+//   - receives new inference requests on eventbus:agent_start;
+//   - receives tool-call results from the operator on eventbus:agent_continue;
+//   - receives model responses from AI drivers on agentbus:receive and routes them
+//     to the agent session store for further processing.
+func StartAgent(cfg *config.Config) {
+	agentSvc = NewService(cfg, "agent")
+	agentSvc.Route = agentRoute
+	agentSvc.DiscoverFeatures = AgentFeatures
+
+	// Register responders before start() so no messages are missed.
+	agentSvc.addResponder(dipper.ChannelEventbus+":"+SubjectEventbusAgentStart, handleAgentStart)
+	agentSvc.addResponder(dipper.ChannelEventbus+":"+SubjectEventbusAgentContinue, handleAgentContinue)
+	agentSvc.addResponder(ChannelAgentbus+":"+SubjectAgentbusReceive, handleAgentReceive)
+	agentSvc.addResponder(dipper.ChannelEventbus+":"+dipper.EventbusRPCInterrupted, handleRPCInterrupted)
+	agentSvc.addResponder(dipper.ChannelEventbus+":"+SubjectEventbusAgentRecover, handleAgentRecover)
+
+	// Build the store before start() so the package-level var is set
+	// before any goroutine spawned by a responder can reference it.
+	agentStore = agent.NewAgentStore(agentSvc)
+	agentSvc.Drain = func() {
+		agentStore.Stop()
+		agentStore.Wait()
+	}
+
+	agentSvc.start()
+}
+
+// AgentFeatures discovers all AI-model drivers referenced by agent definitions and
+// returns them as dynamic features so the service loads each one.
+func AgentFeatures(c *config.DataSet) map[string]interface{} {
+	dynamicData := map[string]interface{}{}
+	for _, ag := range c.Agents {
+		if ag.Driver != "" {
+			dynamicData["driver:"+ag.Driver] = nil
+		}
+	}
+
+	return dynamicData
+}
+
+// agentRoute forwards eventbus messages (tool-call dispatches emitted by agent sessions)
+// to the eventbus driver so the operator service can pick them up.
+// Agentbus messages from AI drivers are handled entirely by responders and do not need routing.
+func agentRoute(msg *dipper.Message) []RoutedMessage {
+	if msg.Channel == dipper.ChannelEventbus {
+		if bus := agentSvc.getDriverRuntime(dipper.ChannelEventbus); bus != nil {
+			return []RoutedMessage{{driverRuntime: bus, message: msg}}
+		}
+	}
+
+	return nil
+}
+
+// handleAgentStart receives an agentbus:start message and calls StartInference on the store.
+func handleAgentStart(_ *driver.Runtime, msg *dipper.Message) {
+	callerID := msg.Labels["caller_id"]
+	callerType := msg.Labels["caller_type"]
+	defer dipper.SafeExitOnError("[agent] error in handleAgentStart", func(r error) {
+		if callerID == "" {
+			return
+		}
+		agentStore.EmitMessage(dipper.Message{
+			Channel: dipper.ChannelEventbus,
+			Subject: "agent_response",
+			Labels: map[string]string{
+				"caller_id":   callerID,
+				"caller_type": callerType,
+				"status":      "error",
+				"reason":      r.Error(),
+			},
+		})
+	})
+	<-agentSvc.Ready()
+	msg = dipper.DeserializePayload(msg)
+	go agentStore.StartInference(msg)
+}
+
+// handleAgentContinue receives an agentbus:continue message (tool-call result from the
+// operator) and calls ContinueInference on the store.
+func handleAgentContinue(_ *driver.Runtime, msg *dipper.Message) {
+	defer dipper.SafeExitOnError("[agent] error in handleAgentContinue")
+	<-agentSvc.Ready()
+	msg = dipper.DeserializePayload(msg)
+	go agentStore.ContinueInference(msg)
+}
+
+// handleAgentReceive receives an agentbus:receive message emitted by an AI-model driver
+// when model inference completes and calls ReceiveInference on the store.
+func handleAgentReceive(_ *driver.Runtime, msg *dipper.Message) {
+	defer dipper.SafeExitOnError("[agent] error in handleAgentReceive")
+	<-agentSvc.Ready()
+	msg = dipper.DeserializePayload(msg)
+	go agentStore.ReceiveInference(msg)
+}
+
+// handleRPCInterrupted handles an eventbus:rpc/interrupted notification from an AI-model
+// driver whose context was cancelled mid-inference.  If the message carries an
+// agent_session_id label the session is queued for recovery via the durable
+// agent_recover redis topic.
+func handleRPCInterrupted(_ *driver.Runtime, msg *dipper.Message) {
+	defer dipper.SafeExitOnError("[agent] error in handleRPCInterrupted")
+	if msg.Labels["agent_session_id"] == "" {
+		return
+	}
+	daemon.Go(func() {
+		if agentSvc.drainingGroup != nil {
+			// Wait until all drivers have acknowledged draining so the
+			// redisqueue driver is still running but has stopped reading
+			// its input queues — writes to it will land in redis.
+			agentSvc.drainingGroup.Wait()
+		}
+		agentSvc.getDriverRuntime(dipper.ChannelEventbus).SendMessage(&dipper.Message{
+			Channel: dipper.ChannelEventbus,
+			Subject: SubjectEventbusAgentRecover,
+			Labels:  msg.Labels,
+		})
+	})
+}
+
+// handleAgentRecover handles a durable agent_recover message delivered from redis
+// and retries the interrupted inference session.
+func handleAgentRecover(_ *driver.Runtime, msg *dipper.Message) {
+	defer dipper.SafeExitOnError("[agent] error in handleAgentRecover")
+	<-agentSvc.Ready()
+	msg = dipper.DeserializePayload(msg)
+	msg.Labels["recover"] = "true"
+	go agentStore.ContinueInference(msg)
+}

--- a/internal/service/agent_svc_test.go
+++ b/internal/service/agent_svc_test.go
@@ -52,6 +52,7 @@ func (m *mockAgentStore) StartInference(_ *dipper.Message)    { m.record("start"
 func (m *mockAgentStore) ContinueInference(_ *dipper.Message) { m.record("continue") }
 func (m *mockAgentStore) ReceiveInference(_ *dipper.Message)  { m.record("receive") }
 func (m *mockAgentStore) PollInference(_ *dipper.Message)     { m.record("poll") }
+func (m *mockAgentStore) StartAgentCall(_ *dipper.Message)    { m.record("agent_call") }
 func (m *mockAgentStore) Stop()                               {}
 func (m *mockAgentStore) Wait()                               {}
 

--- a/internal/service/agent_svc_test.go
+++ b/internal/service/agent_svc_test.go
@@ -51,6 +51,7 @@ func (m *mockAgentStore) hasCall(s string) bool {
 func (m *mockAgentStore) StartInference(_ *dipper.Message)    { m.record("start") }
 func (m *mockAgentStore) ContinueInference(_ *dipper.Message) { m.record("continue") }
 func (m *mockAgentStore) ReceiveInference(_ *dipper.Message)  { m.record("receive") }
+func (m *mockAgentStore) PollInference(_ *dipper.Message)     { m.record("poll") }
 func (m *mockAgentStore) Stop()                               {}
 func (m *mockAgentStore) Wait()                               {}
 
@@ -207,7 +208,11 @@ func setupHandlerGlobals(t *testing.T) *mockAgentStore {
 
 func TestHandleAgentStart(t *testing.T) {
 	mock := setupHandlerGlobals(t)
-	msg := &dipper.Message{Channel: dipper.ChannelEventbus, Subject: SubjectEventbusAgentStart}
+	msg := &dipper.Message{
+		Channel: dipper.ChannelEventbus,
+		Subject: SubjectEventbusAgentStart,
+		Labels:  map[string]string{"resume_key": "test-resume-key"},
+	}
 	handleAgentStart(nil, msg)
 	assert.Eventually(t, func() bool { return mock.hasCall("start") }, 200*time.Millisecond, 5*time.Millisecond)
 }
@@ -224,4 +229,15 @@ func TestHandleAgentReceive(t *testing.T) {
 	msg := &dipper.Message{Channel: ChannelAgentbus, Subject: SubjectAgentbusReceive}
 	handleAgentReceive(nil, msg)
 	assert.Eventually(t, func() bool { return mock.hasCall("receive") }, 200*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestHandleAgentPoll(t *testing.T) {
+	mock := setupHandlerGlobals(t)
+	msg := &dipper.Message{
+		Channel: dipper.ChannelEventbus,
+		Subject: SubjectEventbusAgentPoll,
+		Labels:  map[string]string{"resume_key": "test-resume-key"},
+	}
+	handleAgentPoll(nil, msg)
+	assert.Eventually(t, func() bool { return mock.hasCall("poll") }, 200*time.Millisecond, 5*time.Millisecond)
 }

--- a/internal/service/agent_svc_test.go
+++ b/internal/service/agent_svc_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package service
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	"github.com/honeydipper/honeydipper/v4/internal/driver"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+	"github.com/op/go-logging"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// mockAgentStore – minimal AgentStore for agent_svc tests
+// ---------------------------------------------------------------------------
+
+type mockAgentStore struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (m *mockAgentStore) record(s string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, s)
+}
+
+func (m *mockAgentStore) hasCall(s string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, c := range m.calls {
+		if c == s {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *mockAgentStore) StartInference(_ *dipper.Message)    { m.record("start") }
+func (m *mockAgentStore) ContinueInference(_ *dipper.Message) { m.record("continue") }
+func (m *mockAgentStore) ReceiveInference(_ *dipper.Message)  { m.record("receive") }
+func (m *mockAgentStore) Stop()                               {}
+func (m *mockAgentStore) Wait()                               {}
+
+func (m *mockAgentStore) GetAgent(_ string) *config.Agent       { return &config.Agent{} }
+func (m *mockAgentStore) GetSystem(_ string) *config.System     { return &config.System{} }
+func (m *mockAgentStore) GetWorkflow(_ string) *config.Workflow { return &config.Workflow{} }
+func (m *mockAgentStore) EmitMessage(_ dipper.Message)          {}
+func (m *mockAgentStore) GetConfig() *config.Config             { return &config.Config{} }
+func (m *mockAgentStore) GetLogger() *logging.Logger            { return nil }
+func (m *mockAgentStore) GetName() string                       { return "mock-agent-store" }
+
+func (m *mockAgentStore) Call(_, _ string, _ interface{}, _ ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockAgentStore) CallNoWait(_, _ string, _ interface{}, _ ...string) error {
+	return nil
+}
+
+func (m *mockAgentStore) CallRaw(_, _ string, _ []byte, _ ...string) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockAgentStore) CallRawNoWait(_, _ string, _ []byte, _ string, _ ...string) error {
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// AgentFeatures
+// ---------------------------------------------------------------------------
+
+func TestAgentFeatures_Empty(t *testing.T) {
+	ds := &config.DataSet{
+		Agents: map[string]config.Agent{},
+	}
+	features := AgentFeatures(ds)
+	assert.Empty(t, features)
+}
+
+func TestAgentFeatures_WithDrivers(t *testing.T) {
+	ds := &config.DataSet{
+		Agents: map[string]config.Agent{
+			"agent1": {Driver: "openai"},
+			"agent2": {Driver: "anthropic"},
+		},
+	}
+	features := AgentFeatures(ds)
+	assert.Len(t, features, 2)
+	assert.Contains(t, features, "driver:openai")
+	assert.Contains(t, features, "driver:anthropic")
+}
+
+func TestAgentFeatures_SkipsAgentsWithoutDriver(t *testing.T) {
+	ds := &config.DataSet{
+		Agents: map[string]config.Agent{
+			"with":    {Driver: "openai"},
+			"without": {Driver: ""},
+		},
+	}
+	features := AgentFeatures(ds)
+	assert.Len(t, features, 1)
+	assert.Contains(t, features, "driver:openai")
+	assert.NotContains(t, features, "driver:")
+}
+
+// ---------------------------------------------------------------------------
+// agentRoute
+// ---------------------------------------------------------------------------
+
+// readyAgentSvc builds a minimal *Service with its ready channel already closed.
+func readyAgentSvc(runtimes map[string]*driver.Runtime) *Service {
+	readyCh := make(chan struct{})
+	close(readyCh)
+	svc := &Service{
+		name:           "agent",
+		driverRuntimes: runtimes,
+		ready:          readyCh,
+	}
+
+	return svc
+}
+
+func TestAgentRoute_EventbusWithDriver(t *testing.T) {
+	rt := &driver.Runtime{
+		Feature: dipper.ChannelEventbus,
+		Handler: &driver.NullDriverHandler{},
+		State:   driver.DriverAlive,
+		Stream:  make(chan *dipper.Message, 1),
+	}
+	prev := agentSvc
+	agentSvc = readyAgentSvc(map[string]*driver.Runtime{
+		dipper.ChannelEventbus: rt,
+	})
+	t.Cleanup(func() { agentSvc = prev })
+
+	msg := &dipper.Message{Channel: dipper.ChannelEventbus, Subject: "agent_command"}
+	routed := agentRoute(msg)
+
+	assert.Len(t, routed, 1)
+	assert.Same(t, rt, routed[0].driverRuntime)
+	assert.Same(t, msg, routed[0].message)
+}
+
+func TestAgentRoute_EventbusWithoutDriver(t *testing.T) {
+	prev := agentSvc
+	agentSvc = readyAgentSvc(map[string]*driver.Runtime{})
+	t.Cleanup(func() { agentSvc = prev })
+
+	msg := &dipper.Message{Channel: dipper.ChannelEventbus, Subject: "agent_command"}
+	routed := agentRoute(msg)
+
+	assert.Nil(t, routed)
+}
+
+func TestAgentRoute_NonEventbusNotRouted(t *testing.T) {
+	rt := &driver.Runtime{
+		Feature: ChannelAgentbus,
+		Handler: &driver.NullDriverHandler{},
+		State:   driver.DriverAlive,
+		Stream:  make(chan *dipper.Message, 1),
+	}
+	prev := agentSvc
+	agentSvc = readyAgentSvc(map[string]*driver.Runtime{
+		ChannelAgentbus: rt,
+	})
+	t.Cleanup(func() { agentSvc = prev })
+
+	msg := &dipper.Message{Channel: ChannelAgentbus, Subject: SubjectAgentbusReceive}
+	routed := agentRoute(msg)
+
+	assert.Nil(t, routed)
+}
+
+// ---------------------------------------------------------------------------
+// handler dispatch tests
+// ---------------------------------------------------------------------------
+
+// setupHandlerGlobals installs a ready agentSvc and a mock agentStore, returning
+// a cleanup function that restores the originals.
+func setupHandlerGlobals(t *testing.T) *mockAgentStore {
+	t.Helper()
+	mock := &mockAgentStore{}
+	prevSvc := agentSvc
+	prevStore := agentStore
+	agentSvc = readyAgentSvc(map[string]*driver.Runtime{})
+	agentStore = mock
+	t.Cleanup(func() {
+		agentSvc = prevSvc
+		agentStore = prevStore
+	})
+
+	return mock
+}
+
+func TestHandleAgentStart(t *testing.T) {
+	mock := setupHandlerGlobals(t)
+	msg := &dipper.Message{Channel: dipper.ChannelEventbus, Subject: SubjectEventbusAgentStart}
+	handleAgentStart(nil, msg)
+	assert.Eventually(t, func() bool { return mock.hasCall("start") }, 200*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestHandleAgentContinue(t *testing.T) {
+	mock := setupHandlerGlobals(t)
+	msg := &dipper.Message{Channel: dipper.ChannelEventbus, Subject: SubjectEventbusAgentContinue}
+	handleAgentContinue(nil, msg)
+	assert.Eventually(t, func() bool { return mock.hasCall("continue") }, 200*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestHandleAgentReceive(t *testing.T) {
+	mock := setupHandlerGlobals(t)
+	msg := &dipper.Message{Channel: ChannelAgentbus, Subject: SubjectAgentbusReceive}
+	handleAgentReceive(nil, msg)
+	assert.Eventually(t, func() bool { return mock.hasCall("receive") }, 200*time.Millisecond, 5*time.Millisecond)
+}

--- a/internal/service/engine.go
+++ b/internal/service/engine.go
@@ -9,6 +9,7 @@ package service
 import (
 	"context"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/honeydipper/honeydipper/v4/internal/config"
@@ -57,6 +58,8 @@ func StartEngine(cfg *config.Config) {
 	engine.ServiceReload = buildRuleMap
 	engine.EmitMetrics = engineMetrics
 	engine.addResponder("eventbus:message", createSessions)
+	engine.addResponder("eventbus:agent_workflow", createSessions)
+	engine.addResponder("eventbus:agent_response", continueAgentSession)
 	engine.addResponder("eventbus:return", continueSession)
 	engine.addResponder("scheduler:session", continueSession)
 	setupEngineAPIs()
@@ -137,6 +140,34 @@ func continueSession(d *driver.Runtime, msg *dipper.Message) {
 	}
 	dipper.Logger.Infof("[engine] command return for session %s", sessionID)
 	go sessionStore.ContinueSession(sessionID, msg, nil)
+}
+
+// continueAgentSession routes an agent_response message back to the workflow session that
+// issued the call_agent. The caller_id label encodes "<sessionID>.<cursor>" so the workflow
+// engine can load and resume the correct pending session.
+func continueAgentSession(_ *driver.Runtime, msg *dipper.Message) {
+	defer dipper.SafeExitOnError("[engine] continue processing rules")
+	<-engine.Ready()
+	msg = dipper.DeserializePayload(msg)
+	if msg.Labels["caller_type"] != "workflow" {
+		return
+	}
+	callerID := msg.Labels["caller_id"]
+	lastDot := strings.LastIndex(callerID, ".")
+	if lastDot < 0 {
+		dipper.Logger.Warningf("[engine] agent_response with invalid caller_id: %s", callerID)
+
+		return
+	}
+	sessionID := callerID[:lastDot]
+	cursor := callerID[lastDot+1:]
+	msg.Labels["sessionID"] = sessionID
+	msg.Labels["cursor"] = cursor
+	if _, ok := msg.Labels["status"]; !ok {
+		msg.Labels["status"] = "success"
+	}
+	dipper.Logger.Infof("[engine] agent response for session %s", sessionID)
+	go sessionStore.ResumeSession(sessionID, msg)
 }
 
 // buildRuleMap : the purpose is to build a quick map from event(system/trigger) to something that is operable.

--- a/internal/service/engine.go
+++ b/internal/service/engine.go
@@ -9,7 +9,6 @@ package service
 import (
 	"context"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/honeydipper/honeydipper/v4/internal/config"
@@ -59,7 +58,7 @@ func StartEngine(cfg *config.Config) {
 	engine.EmitMetrics = engineMetrics
 	engine.addResponder("eventbus:message", createSessions)
 	engine.addResponder("eventbus:agent_workflow", createSessions)
-	engine.addResponder("eventbus:agent_response", continueAgentSession)
+	engine.addResponder("eventbus:agent_response", resumeWaitingSession)
 	engine.addResponder("eventbus:return", continueSession)
 	engine.addResponder("scheduler:session", continueSession)
 	setupEngineAPIs()
@@ -142,32 +141,22 @@ func continueSession(d *driver.Runtime, msg *dipper.Message) {
 	go sessionStore.ContinueSession(sessionID, msg, nil)
 }
 
-// continueAgentSession routes an agent_response message back to the workflow session that
-// issued the call_agent. The caller_id label encodes "<sessionID>.<cursor>" so the workflow
+// resumeWaitingSession routes a response message back to the workflow session that
+// is waiting. The resume_key label encodes "<sessionID>.<cursor>" by default, so the workflow
 // engine can load and resume the correct pending session.
-func continueAgentSession(_ *driver.Runtime, msg *dipper.Message) {
+func resumeWaitingSession(_ *driver.Runtime, msg *dipper.Message) {
 	defer dipper.SafeExitOnError("[engine] continue processing rules")
 	<-engine.Ready()
-	msg = dipper.DeserializePayload(msg)
-	if msg.Labels["caller_type"] != "workflow" {
-		return
+	resumeKey, ok := msg.Labels["resume_key"]
+	if !ok {
+		dipper.Logger.Panic("[engine] agent response without caller_id")
 	}
-	callerID := msg.Labels["caller_id"]
-	lastDot := strings.LastIndex(callerID, ".")
-	if lastDot < 0 {
-		dipper.Logger.Warningf("[engine] agent_response with invalid caller_id: %s", callerID)
-
-		return
-	}
-	sessionID := callerID[:lastDot]
-	cursor := callerID[lastDot+1:]
-	msg.Labels["sessionID"] = sessionID
-	msg.Labels["cursor"] = cursor
 	if _, ok := msg.Labels["status"]; !ok {
 		msg.Labels["status"] = "success"
 	}
-	dipper.Logger.Infof("[engine] agent response for session %s", sessionID)
-	go sessionStore.ResumeSession(sessionID, msg)
+	dipper.Logger.Infof("[engine] agent response for session %s", resumeKey)
+	msg = dipper.DeserializePayload(msg)
+	go sessionStore.ResumeSession(resumeKey, msg)
 }
 
 // buildRuleMap : the purpose is to build a quick map from event(system/trigger) to something that is operable.

--- a/internal/service/operator.go
+++ b/internal/service/operator.go
@@ -70,6 +70,19 @@ func handleEventbusCommand(msg *dipper.Message) []RoutedMessage {
 					Subject: dipper.EventbusReturn,
 					Labels:  newLabels,
 				})
+			} else if agentSessionID := msg.Labels["agent_session_id"]; agentSessionID != "" {
+				eventbus := operator.getDriverRuntime(dipper.ChannelEventbus)
+				eventbus.SendMessage(&dipper.Message{
+					Channel: dipper.ChannelEventbus,
+					Subject: dipper.EventbusAgentContinue,
+					Labels: map[string]string{
+						"agent_session_id": agentSessionID,
+						"turn_id":          msg.Labels["turn_id"],
+						"tool_call_id":     msg.Labels["tool_call_id"],
+						"status":           "failure",
+						"reason":           fmt.Sprintf("%v", r),
+					},
+				})
 			}
 			panic(r)
 		}

--- a/internal/service/operator.go
+++ b/internal/service/operator.go
@@ -168,11 +168,14 @@ func operatorRoute(msg *dipper.Message) (ret []RoutedMessage) {
 	dipper.Logger.Infof("[operator] routing message %s.%s", msg.Channel, msg.Subject)
 	defer dipper.SafeExitOnError("[operator] continue on processing messages")
 	switch {
-	case msg.Channel == dipper.ChannelEventbus && msg.Subject == dipper.EventbusCommand:
+	case msg.Channel == dipper.ChannelEventbus && (msg.Subject == dipper.EventbusCommand || msg.Subject == dipper.EventbusAgentCommand):
 		ret = handleEventbusCommand(msg)
 	case msg.Channel == dipper.ChannelEventbus && msg.Subject == dipper.EventbusReturnInterrupted:
 		retryInterruptedSession(msg)
-	case msg.Channel == dipper.ChannelEventbus && (msg.Subject == dipper.EventbusReturn || msg.Subject == dipper.EventbusMessage):
+	case msg.Channel == dipper.ChannelEventbus &&
+		(msg.Subject == dipper.EventbusReturn ||
+			msg.Subject == dipper.EventbusMessage ||
+			msg.Subject == dipper.EventbusAgentContinue):
 		ret = []RoutedMessage{
 			{
 				driverRuntime: operator.getDriverRuntime(dipper.ChannelEventbus),
@@ -243,11 +246,21 @@ func retryInterruptedSession(msg *dipper.Message) {
 	drainingFuncs.Add(1)
 	daemon.Go(func() {
 		defer drainingFuncs.Done()
-		if engine.drainingGroup != nil {
-			engine.drainingGroup.Wait()
+		resumeSubject := dipper.EventbusCommand
+		if msg.Labels["dipper_call_subject"] == dipper.EventbusAgentCommand {
+			resumeSubject = dipper.EventbusAgentCommand
 		}
-		msg.Subject = dipper.EventbusCommand
+		delete(msg.Labels, "dipper_call_subject")
+		msg.Subject = resumeSubject
 		msg.Labels["interrupted"] = "true"
-		engine.getDriverRuntime(dipper.ChannelEventbus).SendMessage(msg)
+		if operator.drainingGroup != nil {
+			// all drivers should be in draining mode before the message
+			// is sent to the queue. The redisqueue driver will still
+			// write to the queue but won't read from the queue. This
+			// is to avoid the retried message gets picked up by the
+			// redisqueue driver again.
+			operator.drainingGroup.Wait()
+		}
+		operator.getDriverRuntime(dipper.ChannelEventbus).SendMessage(msg)
 	})
 }

--- a/internal/service/operator.go
+++ b/internal/service/operator.go
@@ -195,11 +195,11 @@ func collapseFunction(s *config.System, f *config.Function) (string, string, map
 	if len(f.Driver) == 0 {
 		childSystem, ok := operator.config.DataSet.Systems[f.Target.System]
 		if !ok {
-			dipper.Logger.Panicf("[operator] system not defined %s", f.Target.System)
+			panic(fmt.Errorf("[operator] system not defined %s", f.Target.System))
 		}
 		childFunction, ok := childSystem.Functions[f.Target.Function]
 		if !ok {
-			dipper.Logger.Panicf("[operator] function not defined %s.%s", f.Target.System, f.Target.Function)
+			panic(fmt.Errorf("[operator] function not defined %s.%s", f.Target.System, f.Target.Function))
 		}
 		driver, rawaction, params, sysData = collapseFunction(&childSystem, &childFunction)
 
@@ -214,7 +214,7 @@ func collapseFunction(s *config.System, f *config.Function) (string, string, map
 		driver = f.Driver
 		rawaction = f.RawAction
 		if len(f.Target.System) > 0 {
-			dipper.Logger.Panicf("[operator] function cannot have both driver and target %s.%s %s", f.Target.System, f.Target.Function, driver)
+			panic(fmt.Errorf("[operator] function cannot have both driver and target %s.%s %s", f.Target.System, f.Target.Function, driver))
 		}
 	}
 
@@ -225,7 +225,7 @@ func collapseFunction(s *config.System, f *config.Function) (string, string, map
 		}
 		err := mergo.Merge(&sysData, currentSysDataCopy, mergo.WithOverride, mergo.WithAppendSlice)
 		if err != nil {
-			dipper.Logger.Panicf("[operator] unable to merge parameters %+v", err)
+			panic(fmt.Errorf("[operator] unable to merge parameters: %w", err))
 		}
 	}
 	if f.Parameters != nil {
@@ -235,7 +235,7 @@ func collapseFunction(s *config.System, f *config.Function) (string, string, map
 		}
 		err := mergo.Merge(&params, currentParamCopy, mergo.WithOverride, mergo.WithAppendSlice)
 		if err != nil {
-			dipper.Logger.Panicf("[operator] unable to merge parameters %+v", err)
+			panic(fmt.Errorf("[operator] unable to merge parameters: %w", err))
 		}
 	}
 

--- a/internal/service/seq_process.go
+++ b/internal/service/seq_process.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/honeydipper/honeydipper/v4/internal/driver"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+)
+
+// process routes an inbound message either to a per-sequence goroutine for
+// ordered, synchronous handling or fires it off asynchronously when no
+// sequence label is present.
+func (s *Service) process(msg dipper.Message, runtime *driver.Runtime) {
+	seq := msg.Labels["sequence"]
+	if seq == "" {
+		go s.asyncProcess(msg, runtime)
+
+		return
+	}
+
+	s.sequenceLock.Lock()
+	defer s.sequenceLock.Unlock()
+
+	seqChan, ok := s.sequences[seq]
+	if !ok {
+		// First message for this sequence key: create the channel and start the
+		// dedicated goroutine that will drain it in order.
+		seqChan = make(chan dipper.Message, 100)
+		s.sequences[seq] = seqChan
+		go s.sequenceProcess(seq, seqChan, runtime)
+	}
+
+	seqChan <- msg
+}
+
+// sequenceProcess drains seqChan in FIFO order, processing each message
+// synchronously.  When the channel is empty the goroutine closes it, removes
+// the entry from s.sequences, and exits — allowing WindDown to detect that all
+// in-flight sequence work has finished.
+func (s *Service) sequenceProcess(seq string, seqChan chan dipper.Message, runtime *driver.Runtime) {
+	for {
+		s.sequenceLock.Lock()
+		select {
+		case m := <-seqChan:
+			s.sequenceLock.Unlock()
+			s.syncProcess(&m, runtime)
+		default:
+			// Channel is empty; clean up and exit.
+			close(seqChan)
+			delete(s.sequences, seq)
+			s.sequenceLock.Unlock()
+
+			return
+		}
+	}
+}
+
+// asyncProcess handles a message concurrently: expect handlers, responders, and
+// the transformer/router pipeline each run in their own goroutines.
+func (s *Service) asyncProcess(msg dipper.Message, runtime *driver.Runtime) {
+	defer dipper.SafeExitOnError("[%s] continue async processing loop", s.name)
+
+	expectKey := fmt.Sprintf("%s:%s", msg.Channel, msg.Subject)
+	if runtime != nil {
+		expectKey = fmt.Sprintf("%s:%s:%s", msg.Channel, msg.Subject, runtime.Handler.Meta().Name)
+	}
+
+	if expects, ok := s.deleteExpect(expectKey); ok {
+		for _, f := range expects {
+			go func(f ExpectHandler) {
+				defer dipper.SafeExitOnError("[%s] continue async processing loop", s.name)
+				f(&msg)
+			}(f)
+		}
+	}
+
+	key := fmt.Sprintf("%s:%s", msg.Channel, msg.Subject)
+	// responder
+	if responders, ok := s.responders[key]; ok {
+		for _, f := range responders {
+			go func(f MessageResponder) {
+				defer dipper.SafeExitOnError("[%s] continue async processing loop", s.name)
+				f(runtime, &msg)
+			}(f)
+		}
+	}
+
+	go func(msg *dipper.Message) {
+		defer dipper.SafeExitOnError("[%s] continue async processing loop", s.name)
+
+		// transformer
+		if transformers, ok := s.transformers[key]; ok {
+			for _, f := range transformers {
+				msg = f(runtime, msg)
+				if msg == nil {
+					break
+				}
+			}
+		}
+
+		if msg != nil && s.Route != nil {
+			// router
+			routedMsgs := s.Route(msg)
+
+			if len(routedMsgs) > 0 {
+				for _, routedMsg := range routedMsgs {
+					routedMsg.driverRuntime.SendMessage(routedMsg.message)
+				}
+			}
+		}
+	}(&msg)
+}
+
+// syncProcess handles a message synchronously in the caller's goroutine:
+// expect handlers, responders, transformers, and the router are all invoked in
+// sequence with no additional goroutine spawning.
+func (s *Service) syncProcess(msg *dipper.Message, runtime *driver.Runtime) {
+	defer dipper.SafeExitOnError("[%s] continue sync processing loop", s.name)
+
+	expectKey := fmt.Sprintf("%s:%s", msg.Channel, msg.Subject)
+	if runtime != nil {
+		expectKey = fmt.Sprintf("%s:%s:%s", msg.Channel, msg.Subject, runtime.Handler.Meta().Name)
+	}
+
+	if expects, ok := s.deleteExpect(expectKey); ok {
+		for _, f := range expects {
+			f(msg)
+		}
+	}
+
+	key := fmt.Sprintf("%s:%s", msg.Channel, msg.Subject)
+	// responder
+	if responders, ok := s.responders[key]; ok {
+		for _, f := range responders {
+			f(runtime, msg)
+		}
+	}
+
+	// transformer
+	if transformers, ok := s.transformers[key]; ok {
+		for _, f := range transformers {
+			msg = f(runtime, msg)
+			if msg == nil {
+				break
+			}
+		}
+	}
+
+	if msg != nil && s.Route != nil {
+		// router
+		routedMsgs := s.Route(msg)
+
+		if len(routedMsgs) > 0 {
+			for _, routedMsg := range routedMsgs {
+				routedMsg.driverRuntime.SendMessage(routedMsg.message)
+			}
+		}
+	}
+}

--- a/internal/service/seq_process_test.go
+++ b/internal/service/seq_process_test.go
@@ -1,0 +1,126 @@
+// Copyright 2022 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package service
+
+import (
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/honeydipper/honeydipper/v4/internal/driver"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSequenceProcessingOrder(t *testing.T) {
+	if dipper.Logger == nil {
+		f, _ := os.OpenFile(os.DevNull, os.O_APPEND, 0o777)
+		defer f.Close()
+		dipper.GetLogger("test service", "DEBUG", f, f)
+	}
+
+	var mu sync.Mutex
+	var processed []string
+
+	svc := &Service{
+		name:       "testsvc",
+		sequences:  map[string]chan dipper.Message{},
+		responders: map[string][]MessageResponder{},
+		transformers: map[string][]func(*driver.Runtime, *dipper.Message) *dipper.Message{
+			"test:seq": {
+				func(d *driver.Runtime, m *dipper.Message) *dipper.Message {
+					mu.Lock()
+					processed = append(processed, m.Labels["order"])
+					mu.Unlock()
+
+					return m
+				},
+			},
+		},
+	}
+
+	svc.process(dipper.Message{Channel: "test", Subject: "seq", Labels: map[string]string{"sequence": "s1", "order": "1"}}, nil)
+	svc.process(dipper.Message{Channel: "test", Subject: "seq", Labels: map[string]string{"sequence": "s1", "order": "2"}}, nil)
+	svc.process(dipper.Message{Channel: "test", Subject: "seq", Labels: map[string]string{"sequence": "s1", "order": "3"}}, nil)
+
+	// wait for the sequence goroutine to drain
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"1", "2", "3"}, processed, "messages should be processed in order")
+}
+
+func TestSequenceCleanup(t *testing.T) {
+	if dipper.Logger == nil {
+		f, _ := os.OpenFile(os.DevNull, os.O_APPEND, 0o777)
+		defer f.Close()
+		dipper.GetLogger("test service", "DEBUG", f, f)
+	}
+
+	svc := &Service{
+		name:         "testsvc",
+		sequences:    map[string]chan dipper.Message{},
+		responders:   map[string][]MessageResponder{},
+		transformers: map[string][]func(*driver.Runtime, *dipper.Message) *dipper.Message{},
+	}
+
+	svc.process(dipper.Message{Channel: "test", Subject: "cleanup", Labels: map[string]string{"sequence": "s2"}}, nil)
+
+	// wait for the sequence goroutine to drain and clean up
+	time.Sleep(50 * time.Millisecond)
+
+	svc.sequenceLock.Lock()
+	defer svc.sequenceLock.Unlock()
+	assert.Empty(t, svc.sequences, "sequences map should be empty after all messages are processed")
+}
+
+func TestSequenceIsolation(t *testing.T) {
+	if dipper.Logger == nil {
+		f, _ := os.OpenFile(os.DevNull, os.O_APPEND, 0o777)
+		defer f.Close()
+		dipper.GetLogger("test service", "DEBUG", f, f)
+	}
+
+	var mu sync.Mutex
+	processed := map[string][]string{}
+
+	svc := &Service{
+		name:       "testsvc",
+		sequences:  map[string]chan dipper.Message{},
+		responders: map[string][]MessageResponder{},
+		transformers: map[string][]func(*driver.Runtime, *dipper.Message) *dipper.Message{
+			"test:seq": {
+				func(d *driver.Runtime, m *dipper.Message) *dipper.Message {
+					mu.Lock()
+					seq := m.Labels["sequence"]
+					processed[seq] = append(processed[seq], m.Labels["order"])
+					mu.Unlock()
+
+					return m
+				},
+			},
+		},
+	}
+
+	// two independent sequences
+	svc.process(dipper.Message{Channel: "test", Subject: "seq", Labels: map[string]string{"sequence": "a", "order": "1"}}, nil)
+	svc.process(dipper.Message{Channel: "test", Subject: "seq", Labels: map[string]string{"sequence": "b", "order": "1"}}, nil)
+	svc.process(dipper.Message{Channel: "test", Subject: "seq", Labels: map[string]string{"sequence": "a", "order": "2"}}, nil)
+	svc.process(dipper.Message{Channel: "test", Subject: "seq", Labels: map[string]string{"sequence": "b", "order": "2"}}, nil)
+
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"1", "2"}, processed["a"], "sequence a messages should be ordered")
+	assert.Equal(t, []string{"1", "2"}, processed["b"], "sequence b messages should be ordered")
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -82,6 +82,8 @@ type Service struct {
 	ready              chan struct{}
 	context            context.Context
 	cancel             context.CancelFunc
+	sequences          map[string]chan dipper.Message
+	sequenceLock       sync.Mutex
 
 	Drain func()
 }
@@ -106,6 +108,7 @@ func NewService(cfg *config.Config, name string) *Service {
 		driverRuntimes: map[string]*driver.Runtime{},
 		expects:        map[string][]ExpectHandler{},
 		responders:     map[string][]MessageResponder{},
+		sequences:      map[string]chan dipper.Message{},
 		ready:          make(chan struct{}),
 	}
 	svc.context, svc.cancel = context.WithCancel(context.Background())
@@ -503,7 +506,7 @@ func (s *Service) serviceLoop() {
 
 				s.driverLock.Lock()
 				defer s.driverLock.Unlock()
-				go s.process(*msg, runtime)
+				s.process(*msg, runtime)
 			}()
 
 		case !ok && chosen < len(orderedRuntimes):
@@ -531,60 +534,6 @@ func (s *Service) serviceLoop() {
 		}()
 	}
 	dipper.Logger.Warningf("[%s] service closed for business", s.name)
-}
-
-func (s *Service) process(msg dipper.Message, runtime *driver.Runtime) {
-	defer dipper.SafeExitOnError("[%s] continue  message loop", s.name)
-
-	expectKey := fmt.Sprintf("%s:%s", msg.Channel, msg.Subject)
-	if runtime != nil {
-		expectKey = fmt.Sprintf("%s:%s:%s", msg.Channel, msg.Subject, runtime.Handler.Meta().Name)
-	}
-
-	if expects, ok := s.deleteExpect(expectKey); ok {
-		for _, f := range expects {
-			go func(f ExpectHandler) {
-				defer dipper.SafeExitOnError("[%s] continue  message loop", s.name)
-				f(&msg)
-			}(f)
-		}
-	}
-
-	key := fmt.Sprintf("%s:%s", msg.Channel, msg.Subject)
-	// responder
-	if responders, ok := s.responders[key]; ok {
-		for _, f := range responders {
-			go func(f MessageResponder) {
-				defer dipper.SafeExitOnError("[%s] continue  message loop", s.name)
-				f(runtime, &msg)
-			}(f)
-		}
-	}
-
-	go func(msg *dipper.Message) {
-		defer dipper.SafeExitOnError("[%s] continue  message loop", s.name)
-
-		// transformer
-		if transformers, ok := s.transformers[key]; ok {
-			for _, f := range transformers {
-				msg = f(runtime, msg)
-				if msg == nil {
-					break
-				}
-			}
-		}
-
-		if msg != nil && s.Route != nil {
-			// router
-			routedMsgs := s.Route(msg)
-
-			if len(routedMsgs) > 0 {
-				for _, routedMsg := range routedMsgs {
-					routedMsg.driverRuntime.SendMessage(routedMsg.message)
-				}
-			}
-		}
-	}(&msg)
 }
 
 func (s *Service) addResponder(channelSubject string, f MessageResponder) {
@@ -881,6 +830,17 @@ func (s *Service) WindDown() {
 
 	if s.Drain != nil {
 		s.Drain()
+	}
+
+	deadline := time.Now().Add(time.Second * 15)
+	for time.Now().Before(deadline) {
+		s.sequenceLock.Lock()
+		empty := len(s.sequences) == 0
+		s.sequenceLock.Unlock()
+		if empty {
+			break
+		}
+		time.Sleep(DriverGracefulTimeout * time.Millisecond)
 	}
 
 	s.driverLock.Lock()

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -535,7 +535,12 @@ func (s *Service) serviceLoop() {
 
 func (s *Service) process(msg dipper.Message, runtime *driver.Runtime) {
 	defer dipper.SafeExitOnError("[%s] continue  message loop", s.name)
-	expectKey := fmt.Sprintf("%s:%s:%s", msg.Channel, msg.Subject, runtime.Handler.Meta().Name)
+
+	expectKey := fmt.Sprintf("%s:%s", msg.Channel, msg.Subject)
+	if runtime != nil {
+		expectKey = fmt.Sprintf("%s:%s:%s", msg.Channel, msg.Subject, runtime.Handler.Meta().Name)
+	}
+
 	if expects, ok := s.deleteExpect(expectKey); ok {
 		for _, f := range expects {
 			go func(f ExpectHandler) {
@@ -897,6 +902,7 @@ func (s *Service) WindDown() {
 	s.config.AdvanceStage(s.name, config.StageDrained)
 }
 
+// StopAll stops all services and the daemon.
 func StopAll() {
 	drained := &sync.WaitGroup{}
 	for _, s := range Services {
@@ -913,4 +919,14 @@ func StopAll() {
 
 func (s *Service) Ready() <-chan struct{} {
 	return s.ready
+}
+
+// GetConfig returns the service's current configuration.
+func (s *Service) GetConfig() *config.Config {
+	return s.config
+}
+
+// EmitMessage emits a message to the service's router.
+func (s *Service) EmitMessage(msg dipper.Message) {
+	s.process(msg, nil)
 }

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -1,0 +1,48 @@
+// Copyright 2022 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+// Package agent provides shared types used by the agent engine and AI model drivers.
+package agent
+
+// Session type labels placed in message labels.
+const (
+	SessionTypeInference = "inference"
+	SessionTypeChatTurn  = "chat_turn"
+)
+
+// Role labels used in conversation history entries.
+const (
+	RoleSystem     = "system"
+	RoleUser       = "user"
+	RoleAgent      = "agent"
+	RoleTool       = "tool"
+	RoleToolResult = "tool_result"
+)
+
+// Message is a single entry in the conversation history exchanged between the engine and drivers.
+type Message struct {
+	Role       string
+	User       string                   // optional; distinguishes speakers in multi-user conversations.
+	IsThinking bool                     // true when the message carries intermediate model reasoning.
+	ToolCalls  []ToolCall               // non-empty when the model requests tool invocations.
+	ToolResult []map[string]interface{} // non-empty for tool-result messages; Content will be empty.
+	Content    string                   `json:"content" mapstructure:"content"`         // the main content of the message.
+	IsComplete bool                     `json:"is_complete" mapstructure:"is_complete"` // true when this is the final (non-streaming) message for a turn.
+	ChunkSeq   int                      // sequence number for ordering message chunks within a turn.
+}
+
+// Tool describes a callable tool exposed to the model.
+type Tool struct {
+	Name        string
+	Description string
+	Params      map[string]interface{}
+}
+
+// ToolCall records a single tool invocation requested by the model.
+type ToolCall struct {
+	FuncName string
+	Params   map[string]interface{}
+}

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -29,9 +29,8 @@ type Message struct {
 	IsThinking bool                     // true when the message carries intermediate model reasoning.
 	ToolCalls  []ToolCall               // non-empty when the model requests tool invocations.
 	ToolResult []map[string]interface{} // non-empty for tool-result messages; Content will be empty.
-	Content    string                   `json:"content" mapstructure:"content"`         // the main content of the message.
-	IsComplete bool                     `json:"is_complete" mapstructure:"is_complete"` // true when this is the final (non-streaming) message for a turn.
-	ChunkSeq   int                      // sequence number for ordering message chunks within a turn.
+	Content    string                   `json:"content" mapstructure:"content"`
+	IsComplete bool                     `json:"is_complete" mapstructure:"is_complete"`
 }
 
 // Tool describes a callable tool exposed to the model.

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -24,13 +24,15 @@ const (
 
 // Message is a single entry in the conversation history exchanged between the engine and drivers.
 type Message struct {
-	Role       string
-	User       string                   // optional; distinguishes speakers in multi-user conversations.
-	IsThinking bool                     // true when the message carries intermediate model reasoning.
-	ToolCalls  []ToolCall               // non-empty when the model requests tool invocations.
-	ToolResult []map[string]interface{} // non-empty for tool-result messages; Content will be empty.
-	Content    string                   `json:"content" mapstructure:"content"`
-	IsComplete bool                     `json:"is_complete" mapstructure:"is_complete"`
+	Role         string
+	User         string                   // optional; distinguishes speakers in multi-user conversations.
+	IsThinking   bool                     // true when the message carries intermediate model reasoning.
+	ToolCalls    []ToolCall               // non-empty when the model requests tool invocations.
+	ToolResult   []map[string]interface{} // non-empty for tool-result messages; Content will be empty.
+	Content      string                   `json:"content" mapstructure:"content"`
+	IsComplete   bool                     `json:"is_complete" mapstructure:"is_complete"`
+	InputTokens  int                      `json:"input_tokens" mapstructure:"input_tokens"`
+	OutputTokens int                      `json:"output_tokens" mapstructure:"output_tokens"`
 }
 
 // Tool describes a callable tool exposed to the model.
@@ -44,4 +46,13 @@ type Tool struct {
 type ToolCall struct {
 	FuncName string
 	Params   map[string]interface{}
+}
+
+// State reports the runtime state of an agent session at the end of a turn.
+// It is included in every agent_response payload so the workflow engine can
+// make decisions such as triggering history compaction.
+type State struct {
+	HistoryLen  int    `json:"history_len" mapstructure:"history_len"`
+	TotalTokens int    `json:"total_tokens" mapstructure:"total_tokens"`
+	ConvoID     string `json:"convo_id" mapstructure:"convo_id"`
 }

--- a/pkg/dipper/comm.go
+++ b/pkg/dipper/comm.go
@@ -27,6 +27,9 @@ const (
 	EventbusCommand           = "command"
 	EventbusReturn            = "return"
 	EventbusReturnInterrupted = "return/interrupted"
+	EventbusRPCInterrupted    = "rpc/interrupted"
+	EventbusAgentCommand      = "agent_command"
+	EventbusAgentContinue     = "agent_continue"
 )
 
 // CommLocks : comm channels are protected with locks.

--- a/pkg/dipper/commandHandler.go
+++ b/pkg/dipper/commandHandler.go
@@ -62,6 +62,7 @@ func (p *CommandProvider) ReturnInterrupted(call *Message) {
 	msg := *call
 	msg.Channel = p.Channel
 	msg.Subject = p.InterruptedSubject
+	msg.Labels["dipper_call_subject"] = call.Subject
 
 	Logger.Warningf("[operator] interrupted, sessionID: %+v", msg)
 
@@ -96,7 +97,7 @@ func (p *CommandProvider) Return(call *Message, retval *Message) {
 
 	retMsg := &Message{
 		Channel: p.Channel,
-		Subject: p.Subject,
+		Subject: p.returnSubject(call.Subject),
 		Labels:  call.Labels,
 	}
 	delete(retMsg.Labels, "backoff_ms")
@@ -225,6 +226,15 @@ func (w *commandWrapper) attempt(replyChannel chan Message) {
 		}
 	}()
 	w.f(&m)
+}
+
+// returnSubject maps an incoming call subject to its corresponding return subject.
+func (p *CommandProvider) returnSubject(callSubject string) string {
+	if callSubject == EventbusAgentCommand {
+		return EventbusAgentContinue
+	}
+
+	return p.Subject
 }
 
 // Router : route the message to rpc handlers.

--- a/pkg/dipper/commandHandler.go
+++ b/pkg/dipper/commandHandler.go
@@ -91,7 +91,9 @@ func (p *CommandProvider) Return(call *Message, retval *Message) {
 		}
 	}()
 
-	if _, ok := call.Labels["sessionID"]; !ok {
+	_, hasSessionID := call.Labels["sessionID"]
+	_, hasAgentSessionID := call.Labels["agent_session_id"]
+	if !hasSessionID && !hasAgentSessionID {
 		return
 	}
 

--- a/pkg/dipper/driver.go
+++ b/pkg/dipper/driver.go
@@ -96,7 +96,7 @@ func NewDriver(service string, name string, opts ...DriverOption) *Driver {
 	driver.RPCProvider.Init("rpc", "return", driver.Out)
 	driver.RPCProvider.Handler = driver.ctx
 	if service == "agent" {
-		driver.InterruptedChannel = ChannelEventbus
+		driver.InterruptedChannel = "agentbus"
 		driver.RPCProvider.InterruptedSubject = EventbusRPCInterrupted
 	}
 	driver.RPCCallerBase.Init(&driver, "rpc", "call")

--- a/pkg/dipper/driver.go
+++ b/pkg/dipper/driver.go
@@ -94,19 +94,25 @@ func NewDriver(service string, name string, opts ...DriverOption) *Driver {
 	}
 
 	driver.RPCProvider.Init("rpc", "return", driver.Out)
+	driver.RPCProvider.Handler = driver.ctx
+	if service == "agent" {
+		driver.InterruptedChannel = ChannelEventbus
+		driver.RPCProvider.InterruptedSubject = EventbusRPCInterrupted
+	}
 	driver.RPCCallerBase.Init(&driver, "rpc", "call")
 	driver.ctx, driver.cancel = context.WithCancel(context.Background())
 	driver.CommandProvider.Init(ChannelEventbus, EventbusReturn, EventbusReturnInterrupted, driver.Out, driver.ctx)
 
 	driver.MessageHandlers = map[string]MessageHandler{
-		"command:options":  driver.ReceiveOptions,
-		"command:ping":     driver.Ping,
-		"command:start":    driver.start,
-		"command:stop":     driver.stop,
-		"command:drain":    driver.drain,
-		"rpc:call":         driver.RPCProvider.Router,
-		"rpc:return":       driver.HandleReturn,
-		"eventbus:command": driver.CommandProvider.Router,
+		"command:options":        driver.ReceiveOptions,
+		"command:ping":           driver.Ping,
+		"command:start":          driver.start,
+		"command:stop":           driver.stop,
+		"command:drain":          driver.drain,
+		"rpc:call":               driver.RPCProvider.Router,
+		"rpc:return":             driver.HandleReturn,
+		"eventbus:command":       driver.CommandProvider.Router,
+		"eventbus:agent_command": driver.CommandProvider.Router,
 	}
 
 	driver.GetLogger()
@@ -341,6 +347,7 @@ func (d *Driver) Flush(shutdown bool) {
 
 	if !shutdown {
 		d.ctx, d.cancel = context.WithCancel(context.Background())
-		d.Handler = d.ctx
+		d.CommandProvider.Handler = d.ctx
+		d.RPCProvider.Handler = d.ctx
 	}
 }

--- a/pkg/dipper/interpolation.go
+++ b/pkg/dipper/interpolation.go
@@ -109,7 +109,7 @@ func InterpolateGoTemplate(mode string, title string, pattern string, data inter
 		buf := new(bytes.Buffer)
 		if err := parsed.Execute(buf, data); err != nil {
 			Logger.Warningf("interpolation pattern failed: %+v", pattern)
-			Logger.Panicf("failed to interpolate: %+v", err)
+			panic(fmt.Errorf("failed to interpolate: %w", err))
 		}
 
 		if useRet {

--- a/pkg/dipper/rpc.go
+++ b/pkg/dipper/rpc.go
@@ -7,6 +7,7 @@
 package dipper
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -246,11 +247,14 @@ func (c *RPCCallerBase) HandleReturn(m *Message) {
 
 // RPCProvider : an interface for providing RPC handling feature.
 type RPCProvider struct {
-	Live          sync.WaitGroup
-	RPCHandlers   map[string]MessageHandler
-	DefaultReturn io.Writer
-	Channel       string
-	Subject       string
+	Live               sync.WaitGroup
+	RPCHandlers        map[string]MessageHandler
+	DefaultReturn      io.Writer
+	Channel            string
+	Subject            string
+	Handler            context.Context
+	InterruptedChannel string
+	InterruptedSubject string
 }
 
 // Init : initializing rpc provider.
@@ -309,7 +313,12 @@ func (p *RPCProvider) Router(msg *Message) {
 	if !ok {
 		f, ok = p.RPCHandlers[method+"|interruptible"]
 		if !ok {
-			p.ReturnError(msg, "unknown method "+method)
+			if msg.Labels["rpcID"] != RPCSkip {
+				p.Live.Add(1) // ReturnError will call Done, so add before to avoid panic
+				p.ReturnError(msg, "unknown method "+method)
+			} else {
+				GetLogger("rpc", "info").Warningf("unknown method: %s", method)
+			}
 
 			return
 		}
@@ -351,5 +360,37 @@ func (p *RPCProvider) Router(msg *Message) {
 			<-returnerExited
 		}()
 	}
+
+	// NoWait interruptible: run handler concurrently and send an eventbus notification
+	// if the driver's context is cancelled before the handler completes.
+	if msg.Labels["rpcID"] == RPCSkip && msg.Labels["interruptible"] == "true" &&
+		p.Handler != nil && p.InterruptedSubject != "" {
+		handlerDone := make(chan struct{})
+
+		go func() {
+			defer close(handlerDone)
+			defer SafeExitOnError("[rpc] interruptible NoWait handler panic")
+			f(msg)
+		}()
+
+		select {
+		case <-handlerDone:
+			// completed normally
+		case <-p.Handler.Done():
+			select {
+			case <-handlerDone:
+				// handler finished just before context was canceled; nothing to do
+			default:
+				SendMessage(p.DefaultReturn, &Message{
+					Channel: p.InterruptedChannel,
+					Subject: p.InterruptedSubject,
+					Labels:  msg.Labels,
+				})
+			}
+		}
+
+		return
+	}
+
 	f(msg)
 }

--- a/pkg/workflow/activate.go
+++ b/pkg/workflow/activate.go
@@ -191,8 +191,9 @@ func (w *Session) progress() {
 			return
 		case w.pending:
 			w.resume()
-			if w.pending {
-				// a hook is fired in resume and the session is still pending.
+			if w.pending || w.State == SessionStateDone {
+				// a hook is fired in resume and the session is still pending,
+				// or the session completed during resume.
 				return
 			}
 

--- a/pkg/workflow/execute.go
+++ b/pkg/workflow/execute.go
@@ -359,7 +359,7 @@ func (w *Session) waitAgent() {
 	delete(labels, "performing")
 
 	w.incCursor()
-	labels["agent_session"] = w.Workflow.WaitAgent
+	labels["agent_session_id"] = w.Workflow.WaitAgent
 	labels["resume_key"] = w.ID + "." + w.CurrentMsg.Labels["cursor"]
 	labels["timeout"] = w.agentTimeout()
 	if resumeKey, _ := dipper.GetMapDataStr(w.Ctx, "resume_key"); resumeKey != "" {
@@ -376,11 +376,19 @@ func (w *Session) waitAgent() {
 	})
 	duration := dipper.Must(time.ParseDuration(w.agentTimeout())).(time.Duration)
 	if _, ok := w.Ctx["timeout_message"]; !ok {
+		labels := map[string]string{}
+		for k, v := range w.CurrentMsg.Labels {
+			labels[k] = v
+		}
+		labels["agent_session_id"] = w.Workflow.WaitAgent
+		labels["status"] = "failure"
+		labels["reason"] = "poll timeout (engine) after " + w.agentTimeout()
+
+		if w.EventID != "" {
+			labels["eventID"] = w.EventID
+		}
 		w.Ctx["timeout_message"] = map[string]any{
-			"labels": map[string]any{
-				"status": "failure",
-				"reason": "poll timeout (engine) after " + w.agentTimeout(),
-			},
+			"labels": labels,
 		}
 	}
 	w.waitPeriod(duration)

--- a/pkg/workflow/execute.go
+++ b/pkg/workflow/execute.go
@@ -48,6 +48,12 @@ func (w *Session) execute() {
 		w.Action++
 		w.callShorthandFunction(w.Workflow.CallFunction)
 		w.pending = true
+	case w.Workflow.CallAgent != "":
+		// Handle agent calls.
+		w.setPerforming("calling agent: " + w.Workflow.CallAgent)
+		w.Action++
+		w.callAgent()
+		w.pending = true
 	case w.Workflow.SendEvent != nil:
 		w.setPerforming("sending eventbus:message")
 		w.Action++
@@ -151,11 +157,41 @@ func (w *Session) triggerResume() {
 	}
 }
 
+// registerSchedulerDue registers a due message with the scheduler under the given key.
+// It stamps the session ID and current cursor into dueMsg labels before registering.
+func (w *Session) registerSchedulerDue(key string, duration time.Duration, dueMsg map[string]any) {
+	if dueMsg == nil {
+		dueMsg = map[string]any{}
+	}
+	if _, ok := dueMsg["labels"].(map[string]any); !ok {
+		dueMsg["labels"] = map[string]any{}
+	}
+	dueMsg["labels"].(map[string]any)["sessionID"] = w.ID
+	dueMsg["labels"].(map[string]any)["cursor"] = w.CurrentMsg.Labels["cursor"]
+	due := time.Now().Add(duration).UnixMicro()
+	dipper.Must(w.store.Call("scheduler", "once", map[string]any{
+		"due":         strconv.FormatInt(due, 10),
+		"type":        "session",
+		"key":         key,
+		"due_message": dueMsg,
+	}))
+}
+
+// agentTimeout returns the configured agent timeout duration, defaulting to one hour.
+func (w *Session) agentTimeout() time.Duration {
+	if v, _ := dipper.GetMapDataStr(w.Ctx, "agent_timeout"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+
+	return time.Hour
+}
+
 // enterWait sets the session state to waiting and increments the cursor.
 func (w *Session) enterWait() {
 	w.incCursor()
 	duration := dipper.Must(time.ParseDuration(w.Workflow.Wait)).(time.Duration)
-	due := time.Now().Add(duration).UnixMicro()
 	w.setPerforming("waiting")
 	key := w.ID + "." + w.CurrentMsg.Labels["cursor"]
 	if k, ok := w.Ctx["resume_key"]; ok && k != nil && k.(string) != "" {
@@ -167,17 +203,7 @@ func (w *Session) enterWait() {
 			dueMsg = m
 		}
 	}
-	if _, ok := dueMsg["labels"].(map[string]any); !ok {
-		dueMsg["labels"] = map[string]any{}
-	}
-	dueMsg["labels"].(map[string]any)["sessionID"] = w.ID
-	dueMsg["labels"].(map[string]any)["cursor"] = w.CurrentMsg.Labels["cursor"]
-	dipper.Must(w.store.Call("scheduler", "once", map[string]any{
-		"due":         strconv.FormatInt(due, 10),
-		"type":        "session",
-		"key":         key,
-		"due_message": dueMsg,
-	}))
+	w.registerSchedulerDue(key, duration, dueMsg)
 	w.pending = true
 }
 
@@ -224,23 +250,23 @@ func (w *Session) callDriver(f string) {
 	}
 	driverName, rawActionName := interpolatedNames[0], interpolatedNames[1]
 
-	var locals map[string]interface{}
-	if w.Workflow.Local != nil {
+	var params map[string]interface{}
+	if w.Workflow.Parameters != nil {
 		envData := w.buildEnvData()
-		if layers, ok := w.Workflow.Local.([]any); ok {
+		if layers, ok := w.Workflow.Parameters.([]any); ok {
 			for _, layer := range layers {
 				delta := dipper.Interpolate("execute", layer, envData).(map[string]any)
-				locals = dipper.MergeMap(locals, delta)
+				params = dipper.MergeMap(params, delta)
 			}
 		} else {
-			locals = dipper.Interpolate("execute", w.Workflow.Local, envData).(map[string]interface{})
+			params = dipper.Interpolate("execute", w.Workflow.Parameters, envData).(map[string]interface{})
 		}
 	}
 
 	w.callFunction(&config.Function{
 		Driver:     driverName,
 		RawAction:  rawActionName,
-		Parameters: locals,
+		Parameters: params,
 	})
 }
 
@@ -259,6 +285,69 @@ func (w *Session) callShorthandFunction(f string) {
 			Function: funcName,
 		},
 	})
+}
+
+// callAgent sends an agent_start message to invoke an AI agent and waits for the response.
+// The agent name is taken from the workflow's CallAgent field (interpolated). The `with` block
+// provides the payload (must include `text`). Optional labels such as `convo_id`,
+// `agent_session_type`, and `agent_session_ttl` are read from the session context.
+func (w *Session) callAgent() {
+	agentSessionID, _ := dipper.GetMapDataStr(w.Ctx, "agent_session_id")
+	isComplete, streaming := dipper.GetMapDataBool(w.Ctx, "agent_message.is_complete")
+
+	dueMsg := map[string]any{
+		"labels": map[string]any{
+			"status": "error",
+			"reason": "agent response timeout",
+		},
+	}
+
+	if agentSessionID != "" && !isComplete && streaming {
+		// Streaming non-final chunk: skip sending a new agent_start but re-register the
+		// scheduler due entry so the session does not get stuck if the agent goes silent.
+		w.registerSchedulerDue(w.ID, w.agentTimeout(), dueMsg)
+
+		return
+	}
+
+	w.incCursor()
+
+	envData := w.buildEnvData()
+	agentName := dipper.InterpolateStr("execute", w.Workflow.CallAgent, envData)
+	w.setPerforming("calling agent: " + agentName)
+
+	labels := map[string]string{}
+	for k, v := range w.CurrentMsg.Labels {
+		labels[k] = v
+	}
+	delete(labels, "status")
+	delete(labels, "reason")
+	delete(labels, "performing")
+	labels["agent_name"] = agentName
+	labels["caller_id"] = w.ID + "." + w.CurrentMsg.Labels["cursor"]
+	labels["caller_type"] = "workflow"
+	if w.EventID != "" {
+		labels["eventID"] = w.EventID
+	}
+
+	user, _ := dipper.GetMapDataStr(w.Ctx, "user")
+	sessionType, _ := dipper.GetMapDataStr(w.Ctx, "type")
+	convoID, _ := dipper.GetMapDataStr(w.Ctx, "convo_id")
+
+	w.store.SendMessage(&dipper.Message{
+		Channel: dipper.ChannelEventbus,
+		Subject: "agent_start",
+		Labels:  labels,
+		Payload: map[string]interface{}{
+			"text":     dipper.MustGetMapDataStr(w.Ctx, "text"),
+			"user":     user,
+			"type":     sessionType,
+			"convo_id": convoID,
+		},
+	})
+
+	// Register a scheduler due entry so the session can be recovered if the agent never responds.
+	w.registerSchedulerDue(w.ID, w.agentTimeout(), dueMsg)
 }
 
 // sendEventbusMessage emits an eventbus:message for engine rule processing.

--- a/pkg/workflow/execute.go
+++ b/pkg/workflow/execute.go
@@ -18,6 +18,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+const AgentSessionInitiationTTL = time.Second * 10
+
 // execute takes actions for a single iteration in a single loop round.
 // It handles different workflow types including parallel iterations, nested workflows,
 // function calls, driver calls, steps, threads and switch cases.
@@ -53,6 +55,12 @@ func (w *Session) execute() {
 		w.setPerforming("calling agent: " + w.Workflow.CallAgent)
 		w.Action++
 		w.callAgent()
+		w.pending = true
+	case w.Workflow.WaitAgent != "":
+		// Handle waiting for agent response.
+		w.setPerforming("waiting for agent response: " + w.Workflow.WaitAgent)
+		w.Action++
+		w.waitAgent()
 		w.pending = true
 	case w.Workflow.SendEvent != nil:
 		w.setPerforming("sending eventbus:message")
@@ -177,15 +185,13 @@ func (w *Session) registerSchedulerDue(key string, duration time.Duration, dueMs
 	}))
 }
 
-// agentTimeout returns the configured agent timeout duration, defaulting to one hour.
-func (w *Session) agentTimeout() time.Duration {
-	if v, _ := dipper.GetMapDataStr(w.Ctx, "agent_timeout"); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
-			return d
-		}
+// agentTimeout returns the configured agent stream chunk timeout duration in string, defaulting to 9 seconds.
+func (w *Session) agentTimeout() string {
+	if v, _ := dipper.GetMapDataStr(w.Ctx, "chunk_timeout"); v != "" {
+		return v
 	}
 
-	return time.Hour
+	return "9s"
 }
 
 // enterWait sets the session state to waiting and increments the cursor.
@@ -193,6 +199,12 @@ func (w *Session) enterWait() {
 	w.incCursor()
 	duration := dipper.Must(time.ParseDuration(w.Workflow.Wait)).(time.Duration)
 	w.setPerforming("waiting")
+
+	w.waitPeriod(duration)
+}
+
+// waitPeriod sets the session state to waiting for the specified duration.
+func (w *Session) waitPeriod(duration time.Duration) {
 	key := w.ID + "." + w.CurrentMsg.Labels["cursor"]
 	if k, ok := w.Ctx["resume_key"]; ok && k != nil && k.(string) != "" {
 		key = k.(string)
@@ -292,29 +304,7 @@ func (w *Session) callShorthandFunction(f string) {
 // provides the payload (must include `text`). Optional labels such as `convo_id`,
 // `agent_session_type`, and `agent_session_ttl` are read from the session context.
 func (w *Session) callAgent() {
-	agentSessionID, _ := dipper.GetMapDataStr(w.Ctx, "agent_session_id")
-	isComplete, streaming := dipper.GetMapDataBool(w.Ctx, "agent_message.is_complete")
-
-	dueMsg := map[string]any{
-		"labels": map[string]any{
-			"status": "error",
-			"reason": "agent response timeout",
-		},
-	}
-
-	if agentSessionID != "" && !isComplete && streaming {
-		// Streaming non-final chunk: skip sending a new agent_start but re-register the
-		// scheduler due entry so the session does not get stuck if the agent goes silent.
-		w.registerSchedulerDue(w.ID, w.agentTimeout(), dueMsg)
-
-		return
-	}
-
-	w.incCursor()
-
-	envData := w.buildEnvData()
-	agentName := dipper.InterpolateStr("execute", w.Workflow.CallAgent, envData)
-	w.setPerforming("calling agent: " + agentName)
+	w.setPerforming("calling agent: " + w.Workflow.CallAgent)
 
 	labels := map[string]string{}
 	for k, v := range w.CurrentMsg.Labels {
@@ -323,9 +313,13 @@ func (w *Session) callAgent() {
 	delete(labels, "status")
 	delete(labels, "reason")
 	delete(labels, "performing")
-	labels["agent_name"] = agentName
-	labels["caller_id"] = w.ID + "." + w.CurrentMsg.Labels["cursor"]
-	labels["caller_type"] = "workflow"
+
+	w.incCursor()
+	labels["agent_name"] = w.Workflow.CallAgent
+	labels["resume_key"] = w.ID + "." + w.CurrentMsg.Labels["cursor"]
+	if resumeKey, _ := dipper.GetMapDataStr(w.Ctx, "resume_key"); resumeKey != "" {
+		labels["resume_key"] = resumeKey
+	}
 	if w.EventID != "" {
 		labels["eventID"] = w.EventID
 	}
@@ -333,6 +327,8 @@ func (w *Session) callAgent() {
 	user, _ := dipper.GetMapDataStr(w.Ctx, "user")
 	sessionType, _ := dipper.GetMapDataStr(w.Ctx, "type")
 	convoID, _ := dipper.GetMapDataStr(w.Ctx, "convo_id")
+	timeout, _ := dipper.GetMapDataStr(w.Ctx, "turn_timeout")
+	ttl, _ := dipper.GetMapDataStr(w.Ctx, "turn_ttl")
 
 	w.store.SendMessage(&dipper.Message{
 		Channel: dipper.ChannelEventbus,
@@ -343,11 +339,51 @@ func (w *Session) callAgent() {
 			"user":     user,
 			"type":     sessionType,
 			"convo_id": convoID,
+			"timeout":  timeout,
+			"ttl":      ttl,
 		},
 	})
 
-	// Register a scheduler due entry so the session can be recovered if the agent never responds.
-	w.registerSchedulerDue(w.ID, w.agentTimeout(), dueMsg)
+	w.waitPeriod(AgentSessionInitiationTTL)
+}
+
+func (w *Session) waitAgent() {
+	w.setPerforming("waiting for agent response")
+
+	labels := map[string]string{}
+	for k, v := range w.CurrentMsg.Labels {
+		labels[k] = v
+	}
+	delete(labels, "status")
+	delete(labels, "reason")
+	delete(labels, "performing")
+
+	w.incCursor()
+	labels["agent_session"] = w.Workflow.WaitAgent
+	labels["resume_key"] = w.ID + "." + w.CurrentMsg.Labels["cursor"]
+	labels["timeout"] = w.agentTimeout()
+	if resumeKey, _ := dipper.GetMapDataStr(w.Ctx, "resume_key"); resumeKey != "" {
+		labels["resume_key"] = resumeKey
+	}
+	if w.EventID != "" {
+		labels["eventID"] = w.EventID
+	}
+
+	w.store.SendMessage(&dipper.Message{
+		Channel: dipper.ChannelEventbus,
+		Subject: "agent_poll",
+		Labels:  labels,
+	})
+	duration := dipper.Must(time.ParseDuration(w.agentTimeout())).(time.Duration)
+	if _, ok := w.Ctx["timeout_message"]; !ok {
+		w.Ctx["timeout_message"] = map[string]any{
+			"labels": map[string]any{
+				"status": "failure",
+				"reason": "poll timeout (engine) after " + w.agentTimeout(),
+			},
+		}
+	}
+	w.waitPeriod(duration)
 }
 
 // sendEventbusMessage emits an eventbus:message for engine rule processing.

--- a/pkg/workflow/execute_test.go
+++ b/pkg/workflow/execute_test.go
@@ -587,75 +587,64 @@ func TestCallAgent_RegistersSchedulerDue(t *testing.T) {
 	if !ok || params["type"] != "session" {
 		t.Errorf("unexpected scheduler params: %v", es.lastCallParams)
 	}
-	if params["key"] != s.ID {
+	// waitPeriod uses key = w.ID + "." + cursor
+	if params["key"] != s.ID+".4" {
 		t.Errorf("unexpected scheduler key: %v", params["key"])
-	}
-	dueMsg, _ := params["due_message"].(map[string]any)
-	labels, _ := dueMsg["labels"].(map[string]any)
-	if labels["status"] != "error" {
-		t.Errorf("expected due_message status error, got %v", labels["status"])
-	}
-	if labels["reason"] != "agent response timeout" {
-		t.Errorf("expected due_message reason 'agent response timeout', got %v", labels["reason"])
 	}
 }
 
-func TestCallAgent_StreamingNonFinalReregisters(t *testing.T) {
+func TestWaitAgent_SendsPollAndSchedules(t *testing.T) {
 	s := makeExecuteSession()
 	es := &execTestStore{}
 	s.store = es
-	s.Workflow.CallAgent = "openai"
-	s.Ctx["agent_session_id"] = "agt-1"
-	s.Ctx["agent_message"] = map[string]any{"is_complete": false}
+	s.Workflow.WaitAgent = "openai"
 	s.CurrentMsg.Labels["cursor"] = "5"
 
-	s.callAgent()
+	s.waitAgent()
 
-	// No new agent_start message should be sent
-	if len(es.lastSentMessages) != 0 {
-		t.Errorf("expected no message sent for streaming non-final, got %d", len(es.lastSentMessages))
+	// Should send agent_poll message
+	if len(es.lastSentMessages) != 1 {
+		t.Fatalf("expected 1 message sent, got %d", len(es.lastSentMessages))
 	}
-	// cursor must NOT be incremented
-	if s.CurrentMsg.Labels["cursor"] != "5" {
-		t.Errorf("cursor should stay 5, got %s", s.CurrentMsg.Labels["cursor"])
+	if es.lastSentMessages[0].Subject != "agent_poll" {
+		t.Errorf("expected agent_poll, got %s", es.lastSentMessages[0].Subject)
 	}
-	// scheduler due entry must still be re-registered
+	// cursor must be incremented
+	if s.CurrentMsg.Labels["cursor"] != "6" {
+		t.Errorf("expected cursor 6, got %s", s.CurrentMsg.Labels["cursor"])
+	}
+	// scheduler.once must be registered with key = w.ID + "." + cursor
 	if es.lastCallFeature != "scheduler" || es.lastCallMethod != "once" {
-		t.Errorf("scheduler not called for streaming re-register: %s %s", es.lastCallFeature, es.lastCallMethod)
+		t.Errorf("scheduler not called: %s %s", es.lastCallFeature, es.lastCallMethod)
 	}
 	params, _ := es.lastCallParams.(map[string]any)
-	if params["key"] != s.ID {
-		t.Errorf("unexpected scheduler key for streaming: %v", params["key"])
+	if params["key"] != s.ID+".6" {
+		t.Errorf("unexpected scheduler key: %v", params["key"])
 	}
-	dueMsg, _ := params["due_message"].(map[string]any)
-	labels, _ := dueMsg["labels"].(map[string]any)
-	if labels["status"] != "error" {
-		t.Errorf("expected due_message status error, got %v", labels["status"])
-	}
-	if labels["reason"] != "agent response timeout" {
-		t.Errorf("expected due_message reason 'agent response timeout', got %v", labels["reason"])
+	if !s.pending {
+		t.Error("waitAgent should set pending")
 	}
 }
 
 func TestAgentTimeout_Default(t *testing.T) {
 	s := makeExecuteSession()
-	if s.agentTimeout() != time.Hour {
-		t.Errorf("default agent timeout should be 1h, got %v", s.agentTimeout())
+	if s.agentTimeout() != "9s" {
+		t.Errorf("default agent timeout should be 9s, got %v", s.agentTimeout())
 	}
 }
 
 func TestAgentTimeout_Custom(t *testing.T) {
 	s := makeExecuteSession()
-	s.Ctx["agent_timeout"] = "30m"
-	if s.agentTimeout() != 30*time.Minute {
+	s.Ctx["chunk_timeout"] = "30m"
+	if s.agentTimeout() != "30m" {
 		t.Errorf("expected 30m, got %v", s.agentTimeout())
 	}
 }
 
 func TestAgentTimeout_Invalid(t *testing.T) {
 	s := makeExecuteSession()
-	s.Ctx["agent_timeout"] = "notaduration"
-	if s.agentTimeout() != time.Hour {
-		t.Errorf("invalid duration should fall back to 1h, got %v", s.agentTimeout())
+	s.Ctx["chunk_timeout"] = "notaduration"
+	if s.agentTimeout() != "notaduration" {
+		t.Errorf("invalid duration string should be returned as-is, got %v", s.agentTimeout())
 	}
 }

--- a/pkg/workflow/execute_test.go
+++ b/pkg/workflow/execute_test.go
@@ -557,3 +557,105 @@ func TestEnterWait_WithResumeKey(t *testing.T) {
 		t.Errorf("expected custom key, got %v", params["key"])
 	}
 }
+
+func TestCallAgent_RegistersSchedulerDue(t *testing.T) {
+	s := makeExecuteSession()
+	es := &execTestStore{}
+	s.store = es
+	s.Workflow.CallAgent = "openai"
+	s.Ctx["text"] = "hello"
+	s.CurrentMsg.Labels["cursor"] = "3"
+
+	s.callAgent()
+
+	// Should send agent_start message
+	if len(es.lastSentMessages) != 1 {
+		t.Fatalf("expected 1 message sent, got %d", len(es.lastSentMessages))
+	}
+	if es.lastSentMessages[0].Subject != "agent_start" {
+		t.Errorf("expected agent_start, got %s", es.lastSentMessages[0].Subject)
+	}
+	// cursor should be incremented
+	if s.CurrentMsg.Labels["cursor"] != "4" {
+		t.Errorf("expected cursor 4, got %s", s.CurrentMsg.Labels["cursor"])
+	}
+	// scheduler.once must be called
+	if es.lastCallFeature != "scheduler" || es.lastCallMethod != "once" {
+		t.Errorf("scheduler not called: %s %s", es.lastCallFeature, es.lastCallMethod)
+	}
+	params, ok := es.lastCallParams.(map[string]any)
+	if !ok || params["type"] != "session" {
+		t.Errorf("unexpected scheduler params: %v", es.lastCallParams)
+	}
+	if params["key"] != s.ID {
+		t.Errorf("unexpected scheduler key: %v", params["key"])
+	}
+	dueMsg, _ := params["due_message"].(map[string]any)
+	labels, _ := dueMsg["labels"].(map[string]any)
+	if labels["status"] != "error" {
+		t.Errorf("expected due_message status error, got %v", labels["status"])
+	}
+	if labels["reason"] != "agent response timeout" {
+		t.Errorf("expected due_message reason 'agent response timeout', got %v", labels["reason"])
+	}
+}
+
+func TestCallAgent_StreamingNonFinalReregisters(t *testing.T) {
+	s := makeExecuteSession()
+	es := &execTestStore{}
+	s.store = es
+	s.Workflow.CallAgent = "openai"
+	s.Ctx["agent_session_id"] = "agt-1"
+	s.Ctx["agent_message"] = map[string]any{"is_complete": false}
+	s.CurrentMsg.Labels["cursor"] = "5"
+
+	s.callAgent()
+
+	// No new agent_start message should be sent
+	if len(es.lastSentMessages) != 0 {
+		t.Errorf("expected no message sent for streaming non-final, got %d", len(es.lastSentMessages))
+	}
+	// cursor must NOT be incremented
+	if s.CurrentMsg.Labels["cursor"] != "5" {
+		t.Errorf("cursor should stay 5, got %s", s.CurrentMsg.Labels["cursor"])
+	}
+	// scheduler due entry must still be re-registered
+	if es.lastCallFeature != "scheduler" || es.lastCallMethod != "once" {
+		t.Errorf("scheduler not called for streaming re-register: %s %s", es.lastCallFeature, es.lastCallMethod)
+	}
+	params, _ := es.lastCallParams.(map[string]any)
+	if params["key"] != s.ID {
+		t.Errorf("unexpected scheduler key for streaming: %v", params["key"])
+	}
+	dueMsg, _ := params["due_message"].(map[string]any)
+	labels, _ := dueMsg["labels"].(map[string]any)
+	if labels["status"] != "error" {
+		t.Errorf("expected due_message status error, got %v", labels["status"])
+	}
+	if labels["reason"] != "agent response timeout" {
+		t.Errorf("expected due_message reason 'agent response timeout', got %v", labels["reason"])
+	}
+}
+
+func TestAgentTimeout_Default(t *testing.T) {
+	s := makeExecuteSession()
+	if s.agentTimeout() != time.Hour {
+		t.Errorf("default agent timeout should be 1h, got %v", s.agentTimeout())
+	}
+}
+
+func TestAgentTimeout_Custom(t *testing.T) {
+	s := makeExecuteSession()
+	s.Ctx["agent_timeout"] = "30m"
+	if s.agentTimeout() != 30*time.Minute {
+		t.Errorf("expected 30m, got %v", s.agentTimeout())
+	}
+}
+
+func TestAgentTimeout_Invalid(t *testing.T) {
+	s := makeExecuteSession()
+	s.Ctx["agent_timeout"] = "notaduration"
+	if s.agentTimeout() != time.Hour {
+		t.Errorf("invalid duration should fall back to 1h, got %v", s.agentTimeout())
+	}
+}

--- a/pkg/workflow/persisted_store.go
+++ b/pkg/workflow/persisted_store.go
@@ -207,6 +207,21 @@ func (s *PersistedStore) EmitResult(w *Session) {
 	mesg["topic"] = "workflow"
 	mesg["subject"] = BroadcaseSubjectResult
 	dipper.Must(s.CallNoWait("driver:redispubsub", "send", mesg))
+
+	if id := w.OriginLabels["agent_session_id"]; id != "" {
+		s.SendMessage(&dipper.Message{
+			Channel: "eventbus",
+			Subject: "agent_continue",
+			Labels: map[string]string{
+				"agent_session_id": id,
+				"turn_id":          w.OriginLabels["turn_id"],
+				"tool_call_id":     w.OriginLabels["tool_call_id"],
+				"status":           w.CurrentMsg.Labels["status"],
+				"reason":           w.CurrentMsg.Labels["reason"],
+			},
+			Payload: mesg,
+		})
+	}
 }
 
 func (s *PersistedStore) uncaughtErrorHandler(w *Session, msg *dipper.Message) func(r error) {
@@ -238,7 +253,7 @@ func (s *PersistedStore) uncaughtErrorHandler(w *Session, msg *dipper.Message) f
 		if w.ID != "" {
 			s.persist(w)
 		}
-		if w.Parent == "" && w.EventID != "" {
+		if w.Parent == "" && (w.EventID != "" || w.OriginLabels["agent_session_id"] != "") {
 			if w.ID == "" {
 				w.ID = s.GetNextID()
 				s.persist(w)
@@ -298,9 +313,16 @@ func (s *PersistedStore) StartDynamicSession(spec *dipper.Message, ctx map[strin
 // ContinueSession continues a session with given dipper message.
 func (s *PersistedStore) ContinueSession(sessionID string, msg *dipper.Message, child *Session) {
 	defer dipper.SafeExitOnError("[workflow] error when loading workflow session %s", sessionID)
+
+	agentLockID := msg.Labels["agent_session_id"]
+
 	w := s.loadSession(sessionID, msg, child)
 	if w == nil {
 		return
+	}
+
+	if agentLockID != "" {
+		w.AgentLockID = agentLockID
 	}
 
 	defer dipper.SafeExitOnError("[workflow] error when starting workflow session", s.uncaughtErrorHandler(w, msg))
@@ -311,21 +333,33 @@ func (s *PersistedStore) ContinueSession(sessionID string, msg *dipper.Message, 
 // ResumeSession resume a session that is in waiting state.
 func (s *PersistedStore) ResumeSession(key string, msg *dipper.Message) bool {
 	m := dipper.Must(dipper.MessageCopy(msg)).(*dipper.Message)
+
+	if m.Labels == nil {
+		m.Labels = map[string]string{}
+	}
+
+	agentLockID := m.Labels["agent_session_id"]
+	sessionSeqStr := m.Labels["session_seq"]
+	if m.Subject == "agent_response" && agentLockID != "" && sessionSeqStr != "" {
+		sessionSeq := dipper.Must(strconv.Atoi(sessionSeqStr)).(int)
+		s.lockAgentStreamKey(agentLockID, sessionSeq)
+	}
+
 	data, _ := s.Call("scheduler", "cancel", map[string]any{"type": "session", "key": key})
 	if data == nil {
 		s.Warningf("unable to resume for key %s, no payload received from waiter.", key)
+		if m.Subject == "agent_response" && agentLockID != "" && sessionSeqStr != "" {
+			s.unlockAgentStreamKey(agentLockID)
+		}
 
 		return false
 	}
 
 	payload := dipper.DeserializeContent(data)
-	s.Debugf("resuming session with key %s and payload %+v", key, payload)
+	s.Debugf("resuming session with key %s and payload %+v", key, m)
 	sessionID := dipper.MustGetMapDataStr(payload, "labels.sessionID")
 	cursor := dipper.MustGetMapDataStr(payload, "labels.cursor")
 
-	if m.Labels == nil {
-		m.Labels = map[string]string{}
-	}
 	m.Labels["sessionID"] = sessionID
 	m.Labels["cursor"] = cursor
 	if _, ok := m.Labels["status"]; !ok {
@@ -350,6 +384,25 @@ func (s *PersistedStore) unlockSessionKey(key string) {
 	})
 	if err != nil {
 		s.Debugf("failed to unlock session key %s (lock will auto-expire): %v", key, err)
+	}
+}
+
+func (s *PersistedStore) lockAgentStreamKey(agentSessionID string, sq int) {
+	dipper.Must(s.Call("locker", "lock", map[string]interface{}{
+		"name":   StoreAgentLockPrefix + agentSessionID,
+		"expire": "3600s",
+		"sq":     sq,
+	}))
+}
+
+func (s *PersistedStore) unlockAgentStreamKey(agentSessionID string) {
+	_, err := s.Call("locker", "unlock", map[string]interface{}{
+		"name": StoreAgentLockPrefix + agentSessionID,
+	})
+	if err != nil {
+		s.Warningf("failed to unlock agent stream key %s (lock will auto-expire): %v", agentSessionID, err)
+	} else {
+		s.Debugf("unlocked agent stream key %s", agentSessionID)
 	}
 }
 
@@ -927,6 +980,19 @@ func (s *PersistedStore) persist(w *Session) {
 		ttl = time.Hour * 24
 	}
 
+	// Find the tail session to decide whether to release the agent stream lock.
+	tail := root
+	for tail.child != nil {
+		tail = tail.child
+	}
+	agentLockIDToRelease := ""
+	if root.AgentLockID != "" &&
+		((tail.Workflow.CallAgent != "" && tail.State == SessionStateAction) ||
+			(root.child == nil && root.Parent == "" && root.State == SessionStateDone)) {
+		agentLockIDToRelease = root.AgentLockID
+		root.AgentLockID = ""
+	}
+
 	current := root
 	cursor := ""
 	for {
@@ -977,6 +1043,9 @@ func (s *PersistedStore) persist(w *Session) {
 		}
 	} else {
 		s.unlockSessionKey(key)
+		if agentLockIDToRelease != "" {
+			s.unlockAgentStreamKey(agentLockIDToRelease)
+		}
 	}
 
 	if root.State == SessionStateDone && root.Parent == "" {
@@ -1025,7 +1094,23 @@ func (s *PersistedStore) loadSession(sessionID string, msg *dipper.Message, chil
 	} else {
 		s.Infof("session [%s.%s] loaded from cache", w.ID, tail.CurrentMsg.Labels["cursor"])
 	}
-	if tail.CurrentMsg.Labels["cursor"] != msg.Labels["cursor"] {
+
+	if tail.Workflow.CallAgent != "" {
+		// allow streaming agent response to continue the session without matching cursor,
+		// as long as the agent_session_id matches, to better support long-running agent sessions.
+		agentSessionID := tail.CurrentMsg.Labels["agent_session_id"]
+		if agentSessionID != "" && agentSessionID != msg.Labels["agent_session_id"] {
+			s.Warningf("session %s ignoring mismatched agent_session_id: expected %s, got %s",
+				sessionID,
+				agentSessionID,
+				msg.Labels["agent_session_id"],
+			)
+			s.unlockSessionKey(key)
+
+			return nil
+		}
+	} else if tail.CurrentMsg.Labels["cursor"] != msg.Labels["cursor"] {
+		// For non-agent sessions, cursor must match to prevent out-of-order message processing.
 		s.Warningf("session %s ignoring mismatched cursor: expected %s, got %s",
 			sessionID,
 			tail.CurrentMsg.Labels["cursor"],

--- a/pkg/workflow/persisted_store.go
+++ b/pkg/workflow/persisted_store.go
@@ -314,15 +314,9 @@ func (s *PersistedStore) StartDynamicSession(spec *dipper.Message, ctx map[strin
 func (s *PersistedStore) ContinueSession(sessionID string, msg *dipper.Message, child *Session) {
 	defer dipper.SafeExitOnError("[workflow] error when loading workflow session %s", sessionID)
 
-	agentLockID := msg.Labels["agent_session_id"]
-
 	w := s.loadSession(sessionID, msg, child)
 	if w == nil {
 		return
-	}
-
-	if agentLockID != "" {
-		w.AgentLockID = agentLockID
 	}
 
 	defer dipper.SafeExitOnError("[workflow] error when starting workflow session", s.uncaughtErrorHandler(w, msg))
@@ -338,19 +332,9 @@ func (s *PersistedStore) ResumeSession(key string, msg *dipper.Message) bool {
 		m.Labels = map[string]string{}
 	}
 
-	agentLockID := m.Labels["agent_session_id"]
-	sessionSeqStr := m.Labels["session_seq"]
-	if m.Subject == "agent_response" && agentLockID != "" && sessionSeqStr != "" {
-		sessionSeq := dipper.Must(strconv.Atoi(sessionSeqStr)).(int)
-		s.lockAgentStreamKey(agentLockID, sessionSeq)
-	}
-
 	data, _ := s.Call("scheduler", "cancel", map[string]any{"type": "session", "key": key})
 	if data == nil {
 		s.Warningf("unable to resume for key %s, no payload received from waiter.", key)
-		if m.Subject == "agent_response" && agentLockID != "" && sessionSeqStr != "" {
-			s.unlockAgentStreamKey(agentLockID)
-		}
 
 		return false
 	}
@@ -384,25 +368,6 @@ func (s *PersistedStore) unlockSessionKey(key string) {
 	})
 	if err != nil {
 		s.Debugf("failed to unlock session key %s (lock will auto-expire): %v", key, err)
-	}
-}
-
-func (s *PersistedStore) lockAgentStreamKey(agentSessionID string, sq int) {
-	dipper.Must(s.Call("locker", "lock", map[string]interface{}{
-		"name":   StoreAgentLockPrefix + agentSessionID,
-		"expire": "3600s",
-		"sq":     sq,
-	}))
-}
-
-func (s *PersistedStore) unlockAgentStreamKey(agentSessionID string) {
-	_, err := s.Call("locker", "unlock", map[string]interface{}{
-		"name": StoreAgentLockPrefix + agentSessionID,
-	})
-	if err != nil {
-		s.Warningf("failed to unlock agent stream key %s (lock will auto-expire): %v", agentSessionID, err)
-	} else {
-		s.Debugf("unlocked agent stream key %s", agentSessionID)
 	}
 }
 
@@ -980,19 +945,6 @@ func (s *PersistedStore) persist(w *Session) {
 		ttl = time.Hour * 24
 	}
 
-	// Find the tail session to decide whether to release the agent stream lock.
-	tail := root
-	for tail.child != nil {
-		tail = tail.child
-	}
-	agentLockIDToRelease := ""
-	if root.AgentLockID != "" &&
-		((tail.Workflow.CallAgent != "" && tail.State == SessionStateAction) ||
-			(root.child == nil && root.Parent == "" && root.State == SessionStateDone)) {
-		agentLockIDToRelease = root.AgentLockID
-		root.AgentLockID = ""
-	}
-
 	current := root
 	cursor := ""
 	for {
@@ -1043,9 +995,6 @@ func (s *PersistedStore) persist(w *Session) {
 		}
 	} else {
 		s.unlockSessionKey(key)
-		if agentLockIDToRelease != "" {
-			s.unlockAgentStreamKey(agentLockIDToRelease)
-		}
 	}
 
 	if root.State == SessionStateDone && root.Parent == "" {
@@ -1095,21 +1044,7 @@ func (s *PersistedStore) loadSession(sessionID string, msg *dipper.Message, chil
 		s.Infof("session [%s.%s] loaded from cache", w.ID, tail.CurrentMsg.Labels["cursor"])
 	}
 
-	if tail.Workflow.CallAgent != "" {
-		// allow streaming agent response to continue the session without matching cursor,
-		// as long as the agent_session_id matches, to better support long-running agent sessions.
-		agentSessionID := tail.CurrentMsg.Labels["agent_session_id"]
-		if agentSessionID != "" && agentSessionID != msg.Labels["agent_session_id"] {
-			s.Warningf("session %s ignoring mismatched agent_session_id: expected %s, got %s",
-				sessionID,
-				agentSessionID,
-				msg.Labels["agent_session_id"],
-			)
-			s.unlockSessionKey(key)
-
-			return nil
-		}
-	} else if tail.CurrentMsg.Labels["cursor"] != msg.Labels["cursor"] {
+	if tail.CurrentMsg.Labels["cursor"] != msg.Labels["cursor"] {
 		// For non-agent sessions, cursor must match to prevent out-of-order message processing.
 		s.Warningf("session %s ignoring mismatched cursor: expected %s, got %s",
 			sessionID,

--- a/pkg/workflow/session.go
+++ b/pkg/workflow/session.go
@@ -86,6 +86,8 @@ type Session struct {
 	OrigMsg *dipper.Message
 	// OrigChild is the original child session before hook execution.
 	OrigChild *Session
+	// OriginLabels is a copy of the labels from the initial trigger message.
+	OriginLabels map[string]string
 
 	// CurrentHook is the current hook that is being executed.
 	CurrentHook string
@@ -108,6 +110,9 @@ type Session struct {
 	Cancelled bool
 	// CancelReason captures optional user-provided cancellation reason.
 	CancelReason string
+	// AgentLockID holds the agent_session_id whose stream lock is currently held by this root session.
+	// Persisted so the lock can be released after intermediate function calls reload the session.
+	AgentLockID string
 	// AsyncChildren tracks detached async child session IDs created by this frame.
 	AsyncChildren map[string]bool
 	// PendingMessages is a queue of messages received in paused state.
@@ -345,6 +350,7 @@ func (w *Session) checkIsNoop() bool {
 	case w.Workflow.Wait != "":
 	case w.Workflow.Switch != "":
 	case w.Workflow.Resume != "":
+	case w.Workflow.CallAgent != "":
 	default:
 		ret = true
 	}

--- a/pkg/workflow/session.go
+++ b/pkg/workflow/session.go
@@ -110,9 +110,6 @@ type Session struct {
 	Cancelled bool
 	// CancelReason captures optional user-provided cancellation reason.
 	CancelReason string
-	// AgentLockID holds the agent_session_id whose stream lock is currently held by this root session.
-	// Persisted so the lock can be released after intermediate function calls reload the session.
-	AgentLockID string
 	// AsyncChildren tracks detached async child session IDs created by this frame.
 	AsyncChildren map[string]bool
 	// PendingMessages is a queue of messages received in paused state.
@@ -351,6 +348,7 @@ func (w *Session) checkIsNoop() bool {
 	case w.Workflow.Switch != "":
 	case w.Workflow.Resume != "":
 	case w.Workflow.CallAgent != "":
+	case w.Workflow.WaitAgent != "":
 	default:
 		ret = true
 	}

--- a/pkg/workflow/session_init.go
+++ b/pkg/workflow/session_init.go
@@ -268,6 +268,8 @@ func (w *Session) interpolateWorkflow() {
 	ret.Resume = dipper.InterpolateStr("session", v.Resume, envData)
 	ret.CacheKey = dipper.InterpolateStr("session", v.CacheKey, envData)
 	ret.CacheTTL = dipper.InterpolateStr("session", v.CacheTTL, envData)
+	ret.CallAgent = dipper.InterpolateStr("session", v.CallAgent, envData)
+	ret.WaitAgent = dipper.InterpolateStr("session", v.WaitAgent, envData)
 
 	ret.Iterate = dipper.Interpolate("session", v.Iterate, envData)
 	if ret.Iterate == nil && v.Iterate != nil {

--- a/pkg/workflow/session_init.go
+++ b/pkg/workflow/session_init.go
@@ -81,6 +81,10 @@ func (w *Session) injectMsg(msg *dipper.Message) {
 			w.Event = map[string]interface{}{}
 		}
 		w.EventID = msg.Labels["eventID"]
+		w.OriginLabels = make(map[string]string, len(msg.Labels))
+		for k, v := range msg.Labels {
+			w.OriginLabels[k] = v
+		}
 	}
 	if w.EventID != "" {
 		w.CurrentMsg.Labels["eventID"] = w.EventID
@@ -222,7 +226,7 @@ func (w *Session) initCTX(eventCtx map[string]interface{}, rerunCtx map[string]i
 
 // injects the workflow local context data.
 func (w *Session) injectLocalCTX() {
-	if w.Workflow.Local != nil && w.Workflow.CallDriver == "" {
+	if w.Workflow.Local != nil {
 		layers, ok := w.Workflow.Local.([]interface{})
 		if !ok {
 			layers = []interface{}{w.Workflow.Local}

--- a/pkg/workflow/session_init_test.go
+++ b/pkg/workflow/session_init_test.go
@@ -369,13 +369,13 @@ func TestInjectLocalCTX(t *testing.T) {
 	if s.Ctx["a"] != "b" {
 		t.Error("local ctx not merged from slice")
 	}
-	// skip when there is callDriver
+	// local context (with) is always merged even when callDriver is set; use parameters field for driver params
 	s.Workflow.CallDriver = "drv"
 	s.Ctx = map[string]interface{}{}
 	s.Workflow.Local = map[string]interface{}{"foo": "baz"}
 	s.injectLocalCTX()
-	if _, ok := s.Ctx["foo"]; ok {
-		t.Error("should not merge when callDriver is set")
+	if s.Ctx["foo"] != "baz" {
+		t.Error("should still merge local ctx when callDriver is set")
 	}
 }
 

--- a/pkg/workflow/store.go
+++ b/pkg/workflow/store.go
@@ -26,6 +26,8 @@ const (
 	StoreSessionPrefix = "stack:"
 	// StoreEvenPrefix is the prefix for mapping events to persisted session stacks.
 	StoreEventPrefix = "event:"
+	// StoreAgentLockPrefix is the prefix for per-agent-session streaming locks.
+	StoreAgentLockPrefix = "agent-stream:"
 	// StoreSessionIdWrap is the number when reached causes the session ID counter to reset.
 	StoreSessionIDWrap = 10000000000
 	// StoreSessionIdBatch is the number of IDs to reserve each time.

--- a/pkg/workflow/store.go
+++ b/pkg/workflow/store.go
@@ -26,8 +26,6 @@ const (
 	StoreSessionPrefix = "stack:"
 	// StoreEvenPrefix is the prefix for mapping events to persisted session stacks.
 	StoreEventPrefix = "event:"
-	// StoreAgentLockPrefix is the prefix for per-agent-session streaming locks.
-	StoreAgentLockPrefix = "agent-stream:"
 	// StoreSessionIdWrap is the number when reached causes the session ID counter to reset.
 	StoreSessionIDWrap = 10000000000
 	// StoreSessionIdBatch is the number of IDs to reserve each time.


### PR DESCRIPTION
This PR adds a feature to track multiple agent sessions into a single conversation object. 

### Changes:
- Created `internal/agent/conversation.go` to define the `Conversation` model and tracking logic.
- Updated `internal/agent/agent_session.go` to call `trackSessionInConversation` during the `persist` lifecycle.
- Uses Redis via RPC calls to store the conversation mapping, ensuring all turns are grouped by `convo_id` for easy retrieval.
- Follows the existing project convention and uses the `feat/agent_v3` branch as a base.