### PR TITLE
feat(agent): native agent chat support

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -222,11 +222,18 @@ func (s *AgentSession) initNewSession(id string, msg *dipper.Message, store Agen
 	// Register this session in the shared conversation state so that it can be
 	// queried for display and subject to controls such as cancellation.
 	agentName := msg.Labels["agent_name"]
+	firstTurn, _ := dipper.GetMapDataStr(msg.Payload, "text")
+	if len(firstTurn) > 200 {
+		firstTurn = firstTurn[:200]
+	}
 	lockedConvoStateUpdate(s.ConvoID, s.store, func(cs *ConvoState) {
 		if cs.TTL == "" {
 			cs.TTL = ConvoStreamTTL
 		}
 		cs.UnifiedConvoID = s.UnifiedConvoID
+		if cs.FirstTurn == "" && s.Type == AgentSessionTypeChatTurn && firstTurn != "" {
+			cs.FirstTurn = firstTurn
+		}
 		cs.registerSession(s.ID, agentName, s.Type)
 	})
 	// Also register in the unified convo state when it spans multiple convo IDs
@@ -835,9 +842,10 @@ func (s *AgentSession) processToolResult(msg *dipper.Message) {
 	}
 
 	result := map[string]interface{}{
-		"status": msg.Labels["status"],
-		"reason": msg.Labels["reason"],
-		"data":   data,
+		"status":    msg.Labels["status"],
+		"reason":    msg.Labels["reason"],
+		"data":      data,
+		"func_name": c.FuncName,
 	}
 
 	s.ToolResults = append(s.ToolResults, result)

--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -25,6 +25,9 @@ type AgentStore interface {
 	// StartTurn fires a new chat turn on an existing conversation without a
 	// return path back to a workflow. It is used by the UI-initiated turn API.
 	StartTurn(convoID, text, user string)
+	// StartNewConvo starts a brand-new conversation for the named agent and
+	// returns the generated convo_id synchronously. The session runs asynchronously.
+	StartNewConvo(agentName, text, user string) string
 
 	GetAgent(name string) *config.Agent
 	GetSystem(name string) *config.System
@@ -213,28 +216,51 @@ func (p *PersistentAgentStore) StartTurn(convoID, text, user string) {
 			return
 		}
 
-		msg := &dipper.Message{
-			Labels: map[string]string{
-				"agent_name": agentName,
-			},
-			Payload: map[string]interface{}{
-				"text":     text,
-				"user":     user,
-				"convo_id": convoID,
-			},
-		}
-
 		p.Infof("[agent] StartTurn convo=%s agent=%s", convoID, agentName)
-		s := &AgentSession{}
-		s.setup(msg, p, true)
-		defer s.persist(true)
-		defer dipper.SafeExitOnError("[agent] error running StartTurn for convo "+convoID, func(r interface{}) {
-			if s.ErrorReason == "" {
-				s.ErrorReason = fmt.Sprintf("%v", r)
-			}
-		})
-		s.run()
+		p.runTurn(agentName, convoID, text, user)
 	}()
+}
+
+// StartNewConvo starts a brand-new conversation for the named agent and returns
+// the generated convo_id synchronously. The session runs asynchronously.
+func (p *PersistentAgentStore) StartNewConvo(agentName, text, user string) string {
+	convoID := dipper.NewUUID()
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		defer dipper.SafeExitOnError("[agent] error in StartNewConvo")
+
+		p.Infof("[agent] StartNewConvo convo=%s agent=%s", convoID, agentName)
+		p.runTurn(agentName, convoID, text, user)
+	}()
+
+	return convoID
+}
+
+// runTurn creates and runs a single chat-turn session for the given agent and
+// conversation. It must be called from within a goroutine that has already
+// incremented p.wg; it does NOT add/done the WaitGroup itself.
+func (p *PersistentAgentStore) runTurn(agentName, convoID, text, user string) {
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name": agentName,
+		},
+		Payload: map[string]interface{}{
+			"text":     text,
+			"user":     user,
+			"convo_id": convoID,
+		},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, p, true)
+	defer s.persist(true)
+	defer dipper.SafeExitOnError("[agent] error running turn for convo "+convoID, func(r interface{}) {
+		if s.ErrorReason == "" {
+			s.ErrorReason = fmt.Sprintf("%v", r)
+		}
+	})
+	s.run()
 }
 
 // NewAgentStore creates an AgentStore backed by the provided StoreHelper.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -150,14 +150,15 @@ func (m *mockStore) CallRawNoWait(feature, method string, params []byte, rpcID s
 
 func (m *mockStore) GetName() string { return "mock-store" }
 
-func (m *mockStore) StartInference(msg *dipper.Message)    {}
-func (m *mockStore) ContinueInference(msg *dipper.Message) {}
-func (m *mockStore) ReceiveInference(msg *dipper.Message)  {}
-func (m *mockStore) PollInference(msg *dipper.Message)     {}
-func (m *mockStore) StartAgentCall(msg *dipper.Message)    {}
-func (m *mockStore) StartMCPCall(msg *dipper.Message)      {}
-func (m *mockStore) CancelConvo(msg *dipper.Message)       {}
-func (m *mockStore) StartTurn(convoID, text, user string)  {}
+func (m *mockStore) StartInference(msg *dipper.Message)                {}
+func (m *mockStore) ContinueInference(msg *dipper.Message)             {}
+func (m *mockStore) ReceiveInference(msg *dipper.Message)              {}
+func (m *mockStore) PollInference(msg *dipper.Message)                 {}
+func (m *mockStore) StartAgentCall(msg *dipper.Message)                {}
+func (m *mockStore) StartMCPCall(msg *dipper.Message)                  {}
+func (m *mockStore) CancelConvo(msg *dipper.Message)                   {}
+func (m *mockStore) StartTurn(convoID, text, user string)              {}
+func (m *mockStore) StartNewConvo(agentName, text, user string) string { return "" }
 
 func (m *mockStore) GetAgent(name string) *config.Agent {
 	a := m.cfg.DataSet.Agents[name]

--- a/internal/agent/convo_state.go
+++ b/internal/agent/convo_state.go
@@ -45,6 +45,7 @@ type ConvoSessionRef struct {
 type ConvoState struct {
 	ConvoID        string            `json:"convo_id"`
 	UnifiedConvoID string            `json:"unified_convo_id,omitempty"`
+	FirstTurn      string            `json:"first_turn,omitempty"`
 	Sessions       []ConvoSessionRef `json:"sessions"`
 	Cancelled      bool              `json:"cancelled"`
 	TTL            string            `json:"ttl"`

--- a/internal/api/def.go
+++ b/internal/api/def.go
@@ -49,7 +49,11 @@ const (
 func agentDefs() map[string]map[string]Def {
 	return map[string]map[string]Def{
 		"convos": {
-			http.MethodGet: {Object: "convo", Name: "convoList", ReqType: TypeFirst, Service: "agent"},
+			http.MethodGet:  {Object: "convo", Name: "convoList", ReqType: TypeFirst, Service: "agent"},
+			http.MethodPost: {Object: "convo", Name: "convoNew", AttachPrincipalUser: true, ReqType: TypeFirst, Service: "agent"},
+		},
+		"agents": {
+			http.MethodGet: {Object: "agent", Name: "agentList", ReqType: TypeFirst, Service: "agent"},
 		},
 		"convos/:convoID/history": {
 			http.MethodGet: {Object: "convo", Name: "convoHistory", ReqType: TypeFirst, Service: "agent"},
@@ -58,7 +62,7 @@ func agentDefs() map[string]map[string]Def {
 			http.MethodPost: {Object: "convo", Name: "convoCancel", ReqType: TypeFirst, Service: "agent"},
 		},
 		"convos/:convoID/turn": {
-			http.MethodPost: {Object: "convo", Name: "convoTurn", ReqType: TypeFirst, Service: "agent"},
+			http.MethodPost: {Object: "convo", Name: "convoTurn", AttachPrincipalUser: true, ReqType: TypeFirst, Service: "agent"},
 		},
 	}
 }

--- a/internal/api/request.go
+++ b/internal/api/request.go
@@ -70,6 +70,9 @@ func (a *Request) Dispatch() {
 		if user := a.getPrincipalUser(); user != "" {
 			labels["user"] = user
 		}
+		if provider := a.getPrincipalProvider(); provider != "" {
+			labels["user_provider"] = provider
+		}
 	}
 
 	dipper.Must(a.store.caller.Call("api-broadcast", "send", map[string]interface{}{
@@ -127,6 +130,20 @@ func (a *Request) getPrincipalUser() string {
 	}
 
 	return strings.TrimSpace(principal.Subject)
+}
+
+func (a *Request) getPrincipalProvider() string {
+	p, ok := a.ctx.Get("principal")
+	if !ok {
+		return ""
+	}
+
+	principal, ok := p.(Principal)
+	if !ok {
+		return ""
+	}
+
+	return strings.TrimSpace(principal.Provider)
 }
 
 func (a *Request) dispatchLocal() {

--- a/internal/service/agent_apis.go
+++ b/internal/service/agent_apis.go
@@ -8,6 +8,7 @@ package service
 
 import (
 	"encoding/json"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -21,6 +22,23 @@ func setupAgentAPIs() {
 	agentSvc.APIs["convoHistory"] = handleConvoHistory
 	agentSvc.APIs["convoCancel"] = handleConvoCancelAPI
 	agentSvc.APIs["convoTurn"] = handleConvoTurnAPI
+	agentSvc.APIs["convoNew"] = handleConvoNewAPI
+	agentSvc.APIs["agentList"] = handleAgentListAPI
+}
+
+// buildUserTag combines the authenticated user name and provider into a tag like "user@provider".
+// If either is empty the other is returned as-is; if both are empty the empty string is returned.
+func buildUserTag(user, provider string) string {
+	user = strings.TrimSpace(user)
+	provider = strings.TrimSpace(provider)
+	switch {
+	case user != "" && provider != "":
+		return user + "@" + provider
+	case user != "":
+		return user
+	default:
+		return provider
+	}
 }
 
 // handleConvoList returns a stream_hvals snapshot of recent convo_stream_ blocks.
@@ -86,13 +104,49 @@ func handleConvoTurnAPI(resp *api.Response) {
 	// POST body arrives as a JSON string under payload["body"].
 	var body struct {
 		Text string `json:"text"`
-		User string `json:"user"`
 	}
 	if bodyStr, ok := dipper.GetMapDataStr(resp.Request.Payload, "body"); ok && bodyStr != "" {
 		_ = json.Unmarshal([]byte(bodyStr), &body)
 	}
 
-	agentStore.StartTurn(convoID, body.Text, body.User)
+	user := buildUserTag(resp.Request.Labels["user"], resp.Request.Labels["user_provider"])
+	agentStore.StartTurn(convoID, body.Text, user)
 
 	resp.Return([]byte(`{"ok":true}`))
+}
+
+// handleConvoNewAPI starts a brand-new conversation from the UI without an
+// existing convo ID. The agent name, user message text, and optional user are
+// supplied in the request body. The generated convo_id is returned synchronously
+// so the UI can navigate directly to the new conversation.
+func handleConvoNewAPI(resp *api.Response) {
+	resp.Request = dipper.DeserializePayload(resp.Request)
+
+	var body struct {
+		Agent string `json:"agent"`
+		Text  string `json:"text"`
+	}
+	if bodyStr, ok := dipper.GetMapDataStr(resp.Request.Payload, "body"); ok && bodyStr != "" {
+		_ = json.Unmarshal([]byte(bodyStr), &body)
+	}
+
+	user := buildUserTag(resp.Request.Labels["user"], resp.Request.Labels["user_provider"])
+	convoID := agentStore.StartNewConvo(body.Agent, body.Text, user)
+
+	data := dipper.Must(json.Marshal(map[string]string{"convo_id": convoID})).([]byte)
+	resp.Return(data)
+}
+
+// handleAgentListAPI returns a sorted JSON array of agent names from the current
+// configuration. The UI uses this to populate the agent-selection dropdown.
+func handleAgentListAPI(resp *api.Response) {
+	agents := agentStore.GetConfig().DataSet.Agents
+	names := make([]string, 0, len(agents))
+	for name := range agents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	data := dipper.Must(json.Marshal(names)).([]byte)
+	resp.Return(data)
 }

--- a/internal/service/agent_svc_test.go
+++ b/internal/service/agent_svc_test.go
@@ -56,6 +56,7 @@ func (m *mockAgentStore) StartAgentCall(_ *dipper.Message)    { m.record("agent_
 func (m *mockAgentStore) StartMCPCall(_ *dipper.Message)      { m.record("mcp_call") }
 func (m *mockAgentStore) CancelConvo(_ *dipper.Message)       { m.record("cancel_convo") }
 func (m *mockAgentStore) StartTurn(_, _, _ string)            { m.record("start_turn") }
+func (m *mockAgentStore) StartNewConvo(_, _, _ string) string { m.record("start_new_convo"); return "" } //nolint:nlreturn
 func (m *mockAgentStore) Stop()                               {}
 func (m *mockAgentStore) Wait()                               {}
 


### PR DESCRIPTION
Adds feature to start and continue conversation with agents from Honeydipper UI natively. No longer need slack or other UI to trigger and present the conversation.

<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
