### PR TITLE
feat(agent): add CompactionPolicy config data model

### DIFF
--- a/HONEYDIPPER_CONTEXT.md
+++ b/HONEYDIPPER_CONTEXT.md
@@ -79,7 +79,7 @@ type DataSet struct {
 - **Function**: `{Driver, RawAction, Parameters, Target (Action{System,Function}), Export, ExportOnSuccess/Failure}`
 - **System**: `{Data, Triggers map, Functions map (can be nested: "subsys.func"), Extends []string}`
 - **Workflow**: Rich step definition with conditions (`If/IfAny/Unless/UnlessAll/Match/UnlessMatch`), iteration (`Iterate/IterateParallel`), branching (`Switch/Cases/Default`), error handling (`OnError/OnFailure`), caching (`CacheKey/CacheTTL`), exports, sub-workflows, agent calls
-- **Agent**: `{Driver, Engine, SystemPrompt, InferencePrompt, ShouldEmitThoughts, ShouldStream, MaxHistoryLen, ModelData, Tools}`
+- **Agent**: `{Driver, Engine, SystemPrompt, InferencePrompt, ShouldEmitThoughts, ShouldStream, MaxHistoryLen, CompactionPolicy, Tools, ModelData}`
 - **RepoInfo**: `{Repo (URL/path), Branch, Path, InitFile, KeyFile (SSH), TokenSource (github), Username/PassEnv}`
 
 ### 4.3 Config Lifecycle (5 Stages)
@@ -240,6 +240,9 @@ User/Workflow ──► Agent Service ──► AgentSession ──► AI Driver
 - **Message**: `{Role, User, IsThinking, ToolCalls, ToolResult, Content, IsComplete, InputTokens, OutputTokens}`
 - **Tool**: `{Name, Description, Params (JSON Schema)}`
 - **ToolCall**: `{FuncName, Params}`
+- **CompactionPolicy**: `{Strategy, Threshold, ThresholdType, PreserveRecent, SummarizationAgent, SummarizationPrompt}` — controls when and how conversation history is compacted (summarized) to stay within token/history limits
+
+- **CompactionStrategy**: currently only `"summarize"` — uses an LLM agent to condense older messages while preserving recent ones verbatim
 - **State**: `{HistoryLen, TotalTokens, ConvoID}` — reported at end of turn
 
 ---

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -6,6 +6,10 @@
 
 package config
 
+import (
+	agentpkg "github.com/honeydipper/honeydipper/v4/pkg/agent"
+)
+
 // Event is the runtime data representation of an event.
 type Event struct {
 	System  string
@@ -171,6 +175,7 @@ type Agent struct {
 	ShouldEmitThoughts bool   `json:"should_emit_thoughts" mapstructure:"should_emit_thoughts"`
 	ShouldStream       bool   `json:"should_stream" mapstructure:"should_stream"`
 	MaxHistoryLen      int    `json:"max_history_len" mapstructure:"max_history_len"`
+	CompactionPolicy   *agentpkg.CompactionPolicy `json:"compaction_policy" mapstructure:"compaction_policy"`
 	Tools              []AgentToolDef
 	ModelData          map[string]interface{} `json:"model_data" mapstructure:"model_data"`
 	Description        string

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -170,11 +170,11 @@ type Agent struct {
 	Name               string
 	Driver             string
 	Engine             string
-	SystemPrompt       string `json:"system_prompt" mapstructure:"system_prompt"`
-	InferencePrompt    string `json:"inference_prompt" mapstructure:"inference_prompt"`
-	ShouldEmitThoughts bool   `json:"should_emit_thoughts" mapstructure:"should_emit_thoughts"`
-	ShouldStream       bool   `json:"should_stream" mapstructure:"should_stream"`
-	MaxHistoryLen      int    `json:"max_history_len" mapstructure:"max_history_len"`
+	SystemPrompt       string                     `json:"system_prompt" mapstructure:"system_prompt"`
+	InferencePrompt    string                     `json:"inference_prompt" mapstructure:"inference_prompt"`
+	ShouldEmitThoughts bool                       `json:"should_emit_thoughts" mapstructure:"should_emit_thoughts"`
+	ShouldStream       bool                       `json:"should_stream" mapstructure:"should_stream"`
+	MaxHistoryLen      int                        `json:"max_history_len" mapstructure:"max_history_len"`
 	CompactionPolicy   *agentpkg.CompactionPolicy `json:"compaction_policy" mapstructure:"compaction_policy"`
 	Tools              []AgentToolDef
 	ModelData          map[string]interface{} `json:"model_data" mapstructure:"model_data"`

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -56,3 +56,48 @@ type State struct {
 	TotalTokens int    `json:"total_tokens" mapstructure:"total_tokens"`
 	ConvoID     string `json:"convo_id" mapstructure:"convo_id"`
 }
+
+// CompactionStrategy defines how conversation history should be compacted
+// when it exceeds the configured threshold.
+type CompactionStrategy string
+
+const (
+	// CompactionStrategySummarize uses an LLM summarization agent to compress
+	// older conversation history into a concise summary, preserving the most
+	// recent messages verbatim.
+	CompactionStrategySummarize CompactionStrategy = "summarize"
+)
+
+// CompactionPolicy configures the automatic compaction behavior for an agent's
+// conversation history. Compaction is triggered lazily before sending history
+// to the model when the threshold is exceeded.
+type CompactionPolicy struct {
+	// Strategy selects the compaction method. Currently only "summarize" is supported.
+	Strategy CompactionStrategy `json:"strategy" mapstructure:"strategy"`
+
+	// Threshold is the value at which compaction triggers, interpreted according
+	// to ThresholdType. When the current value equals or exceeds Threshold,
+	// compaction runs before the next model invocation.
+	Threshold int `json:"threshold" mapstructure:"threshold"`
+
+	// ThresholdType specifies what metric Threshold refers to.
+	// Supported values:
+	//   - "history_len":   number of messages in the conversation history
+	//   - "total_tokens":  cumulative input + output tokens across the session
+	ThresholdType string `json:"threshold_type" mapstructure:"threshold_type"`
+
+	// PreserveRecent is the number of most recent conversation messages that
+	// should always be kept verbatim after compaction. The rest is summarized.
+	PreserveRecent int `json:"preserve_recent" mapstructure:"preserve_recent"`
+
+	// SummarizationAgent references the name of another Agent (defined in the
+	// same config) whose driver/model will be used to produce the summary.
+	// The referenced agent should be configured with a concise, fast model
+	// suitable for summarization tasks.
+	SummarizationAgent string `json:"summarization_agent" mapstructure:"summarization_agent"`
+
+	// SummarizationPrompt is an optional template used for the summarization
+	// request. If empty, a sensible default is used.
+	// The template receives the conversation history as formatted text.
+	SummarizationPrompt string `json:"summarization_prompt" mapstructure:"summarization_prompt"`
+}


### PR DESCRIPTION
## Summary

Introduce the `CompactionPolicy` and `CompactionStrategy` types in the shared `pkg/agent` package, and wire them into the `Agent` config struct. This is **PR #1** in a series to implement agent conversation history compaction.

### Changes

**`pkg/agent/types.go`**
- Add `CompactionStrategy` type with `'summarize'` constant
- Add `CompactionPolicy` struct with fields:
  - `Strategy` — selects compaction method
  - `Threshold` + `ThresholdType` — `"history_len"` or `"total_tokens"`
  - `PreserveRecent` — messages always kept verbatim after compaction
  - `SummarizationAgent` — references another agent for LLM summarization
  - `SummarizationPrompt` — optional custom prompt template

**`internal/config/schema.go`**
- Add `agentpkg` import
- Add `CompactionPolicy *agentpkg.CompactionPolicy` field to `Agent` struct
- `nil` means no compaction configured (backward compatible)

**`HONEYDIPPER_CONTEXT.md`**
- Update section 4.2 Agent field list
- Add section 6.5 documentation for `CompactionPolicy` and `CompactionStrategy`

### Verification
- ✅ `go build ./...`
- ✅ `go vet ./pkg/agent/ ./internal/config/`
- ✅ `go test ./internal/config/ -count=1 -v` — all 16 tests pass

### Next PRs
- PR #2: Generation tracking in ConvoState
- PR #3: Summarize compaction engine with archive to `_gN` generations
- (Optional) PR #4: Workflow/API integration