### PR TITLE
Bubble AgentSession ErrorReason into ConvoState

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -132,6 +132,7 @@ func (s *AgentSession) syncConvoStateStatus() {
 				s.ID, s.ConvoID, status, lastIsComplete, s.ErrorReason, fs, ls)
 		}
 
+		cs.ErrorReason = s.ErrorReason
 		cs.updateSessionStatus(s.ID, status, s.InputTokens, s.OutputTokens, s.TotalTokens)
 	})
 }

--- a/internal/agent/convo_state.go
+++ b/internal/agent/convo_state.go
@@ -36,6 +36,7 @@ type ConvoSessionRef struct {
 	OutputTokens int       `json:"output_tokens,omitempty"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
+	ErrorReason  string    `json:"error_reason,omitempty"`
 }
 
 // ConvoState is the persisted, queryable view of a conversation.
@@ -140,6 +141,7 @@ func (cs *ConvoState) updateSessionStatus(sessionID, status string, inputTokens,
 		}
 		ref.InputTokens = inputTokens
 		ref.OutputTokens = outputTokens
+		ref.ErrorReason = ""
 		ref.UpdatedAt = now
 
 		if ref.Status != ConvoSessionStatusComplete && ref.Status != ConvoSessionStatusFailed {


### PR DESCRIPTION
## Summary

This change bubbles up the `ErrorReason` from `AgentSession` to `ConvoState`, making it available for UI display.

When an agent turn fails with an error, the `ErrorReason` is now:
1. Stored in the `ConvoSessionRef` struct in `ConvoState`
2. Bubbled up from `AgentSession` to `ConvoState` via `syncConvoStateStatus()`
3. Reset to empty string in `updateSessionStatus()` when the session status transitions to a non-terminated state

## Changes

### `internal/agent/convo_state.go`

- Added `ErrorReason string` field to `ConvoSessionRef` struct with JSON tag `error_reason,omitempty`
- Added `ref.ErrorReason = ""` in `updateSessionStatus()` to clear error reason when session status updates

### `internal/agent/agent_session.go`

- Added `cs.ErrorReason = s.ErrorReason` in `syncConvoStateStatus()` to copy the error reason from session to ConvoState

This allows the UI to display the error reason when a conversation has failed, rather than just showing the status as `failed` without knowing why.