### PR TITLE
feat(agent): cache MCP tool list to improve chat turn performance

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -20,6 +20,7 @@ const (
 	AgentSessionTypeChatTurn       = agentpkg.SessionTypeChatTurn
 	AgentKeyPrefix                 = "agent_session:"
 	ConvoHistoryKeyPrefix          = "convo_history:"
+	MCPToolsCachePrefix            = "mcp_tools:"
 	AgentSessionDefaultTTL         = "72h"
 	AgentSessionDefaultTimeout     = "1h"
 	AgentSessionDefaultPollTimeout = time.Second * 9

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -23,6 +23,7 @@ const (
 	MCPToolsCachePrefix            = "mcp_tools:"
 	AgentSessionDefaultTTL         = "72h"
 	AgentSessionDefaultTimeout     = "1h"
+	MCPToolsCacheDefaultTTL        = "1h"
 	AgentSessionDefaultPollTimeout = time.Second * 9
 	MinPollInterval                = time.Second * 2
 

--- a/internal/agent/tool_call.go
+++ b/internal/agent/tool_call.go
@@ -178,26 +178,83 @@ func (s *AgentSession) addAgentTool(tools map[string]AgentTool, toolDef config.A
 // addMCPTool registers all tools exposed by a named remote MCP server as callable tools.
 // It calls the MCP driver's list_tools RPC synchronously and creates one AgentTool per
 // remote tool, named mcp__<serverName>__<toolName>.
+// addMCPTool registers all tools exposed by a named remote MCP server as callable tools.
+// It calls the MCP driver's list_tools RPC synchronously and creates one AgentTool per
+// remote tool, named mcp__<serverName>__<toolName>.
+// Results are cached to avoid slow chat turns on repeated calls.
 func (s *AgentSession) addMCPTool(tools map[string]AgentTool, toolDef config.AgentToolDef) {
 	prefix := "mcp__" + toolDef.Name + "__"
+	cacheKey := MCPToolsCachePrefix + toolDef.Name
 
+	// Try to load from cache first
+	raw, err := s.tryCacheMCPTools(cacheKey)
+	if err != nil {
+		if log := s.log(); log != nil {
+			log.Warningf("[agent] session [%s] failed to load cached tools for MCP server %q: %v",
+				s.ID, toolDef.Name, err)
+		}
+		// Fall through to fetch from MCP driver
+		raw, err = s.fetchMCPTools(toolDef.Name, cacheKey)
+		if err != nil {
+			return
+		}
+	}
+
+	s.processMCPToolList(tools, toolDef.Name, prefix, raw)
+}
+
+// tryCacheMCPTools attempts to load cached MCP tool list from cache.
+// Returns the raw bytes if found, or an error if not cached or on cache error.
+func (s *AgentSession) tryCacheMCPTools(cacheKey string) ([]byte, error) {
+	raw, err := s.store.Call("cache", "load", map[string]interface{}{
+		"key": cacheKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to load cached MCP tools: %w", err)
+	}
+
+	return raw, nil
+}
+
+// fetchMCPTools calls the MCP driver to list tools and caches the result.
+// Returns the raw bytes from the MCP driver response.
+func (s *AgentSession) fetchMCPTools(serverName string, cacheKey string) ([]byte, error) {
 	raw, err := s.store.Call("driver:mcp", "list_tools", map[string]interface{}{
-		"server": toolDef.Name,
+		"server": serverName,
 	})
 	if err != nil {
 		if log := s.log(); log != nil {
 			log.Errorf("[agent] session [%s] failed to list tools for MCP server %q: %v",
-				s.ID, toolDef.Name, err)
+				s.ID, serverName, err)
 		}
 
-		return
+		return nil, fmt.Errorf("failed to fetch MCP tools from driver: %w", err)
 	}
 
+	// Cache the result for future use (TTL: 1 hour)
+	// Use a goroutine to avoid blocking the tool call
+	go func() {
+		if _, err := s.store.Call("cache", "save", map[string]interface{}{
+			"key":   cacheKey,
+			"value": string(raw),
+			"ttl":   "1h",
+		}); err != nil {
+			if log := s.log(); log != nil {
+				log.Warningf("[agent] failed to cache tools for MCP server %q: %v", serverName, err)
+			}
+		}
+	}()
+
+	return raw, nil
+}
+
+// processMCPToolList processes the raw tool list response and registers tools.
+func (s *AgentSession) processMCPToolList(tools map[string]AgentTool, serverName, prefix string, raw []byte) {
 	var payload map[string]interface{}
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		if log := s.log(); log != nil {
 			log.Errorf("[agent] session [%s] failed to decode list_tools response for %q: %v",
-				s.ID, toolDef.Name, err)
+				s.ID, serverName, err)
 		}
 
 		return
@@ -232,8 +289,6 @@ func (s *AgentSession) addMCPTool(tools map[string]AgentTool, toolDef config.Age
 	}
 }
 
-// coerceToolCallParams fixes parameter values where the declared type is "object"
-// or "array" but the LLM sent them as a JSON-encoded string. Only parameters with
 // a clear type mismatch are coerced; everything else is left unchanged.
 func (s *AgentSession) coerceToolCallParams(toolCalls []AgentToolCall) {
 	tools := s.BuildTools()

--- a/internal/agent/tool_call.go
+++ b/internal/agent/tool_call.go
@@ -207,24 +207,16 @@ func (s *AgentSession) addMCPTool(tools map[string]AgentTool, toolDef config.Age
 // tryCacheMCPTools attempts to load cached MCP tool list from cache.
 // Returns the raw bytes if found, or an error if not cached or on cache error.
 // getMCPToolsCacheTTL returns the configured TTL for MCP tools cache.
-// It reads the TTL from driver data (path: mcp.tools_cache_ttl) and falls back to the default if not configured.
+// It reads the TTL from agent service config (daemon.services.agent.tools_cache_ttl) and falls back to the default if not configured.
 func (s *AgentSession) getMCPToolsCacheTTL() string {
-	config := s.store.GetConfig()
-	if config == nil || config.DataSet == nil {
+	cfg := s.store.GetConfig()
+	if cfg == nil || cfg.DataSet == nil {
 		return MCPToolsCacheDefaultTTL
 	}
 
-	ttl, ok := config.GetDriverData("mcp.tools_cache_ttl")
-	if !ok {
-		return MCPToolsCacheDefaultTTL
-	}
-
-	ttlStr, ok := ttl.(string)
+	serviceCfg, _ := dipper.GetMapData(cfg.DataSet.Drivers, "daemon.services.agent")
+	ttlStr, ok := dipper.GetMapDataStr(serviceCfg, "tools_cache_ttl")
 	if !ok || ttlStr == "" {
-		if log := s.log(); log != nil {
-			log.Warningf("[agent] session [%s] invalid mcp.tools_cache_ttl value, using default %s", s.ID, MCPToolsCacheDefaultTTL)
-		}
-
 		return MCPToolsCacheDefaultTTL
 	}
 
@@ -232,7 +224,7 @@ func (s *AgentSession) getMCPToolsCacheTTL() string {
 	if _, err := time.ParseDuration(ttlStr); err != nil {
 		if log := s.log(); log != nil {
 			log.Warningf(
-				"[agent] session [%s] invalid mcp.tools_cache_ttl duration %q, using default %s",
+				"[agent] session [%s] invalid tools_cache_ttl duration %q, using default %s",
 				s.ID, ttlStr, MCPToolsCacheDefaultTTL,
 			)
 		}

--- a/internal/agent/tool_call.go
+++ b/internal/agent/tool_call.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/honeydipper/honeydipper/v4/internal/config"
 	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
@@ -205,6 +206,43 @@ func (s *AgentSession) addMCPTool(tools map[string]AgentTool, toolDef config.Age
 
 // tryCacheMCPTools attempts to load cached MCP tool list from cache.
 // Returns the raw bytes if found, or an error if not cached or on cache error.
+// getMCPToolsCacheTTL returns the configured TTL for MCP tools cache.
+// It reads the TTL from driver data (path: mcp.tools_cache_ttl) and falls back to the default if not configured.
+func (s *AgentSession) getMCPToolsCacheTTL() string {
+	config := s.store.GetConfig()
+	if config == nil || config.DataSet == nil {
+		return MCPToolsCacheDefaultTTL
+	}
+
+	ttl, ok := config.GetDriverData("mcp.tools_cache_ttl")
+	if !ok {
+		return MCPToolsCacheDefaultTTL
+	}
+
+	ttlStr, ok := ttl.(string)
+	if !ok || ttlStr == "" {
+		if log := s.log(); log != nil {
+			log.Warningf("[agent] session [%s] invalid mcp.tools_cache_ttl value, using default %s", s.ID, MCPToolsCacheDefaultTTL)
+		}
+
+		return MCPToolsCacheDefaultTTL
+	}
+
+	// Validate the TTL is a valid duration
+	if _, err := time.ParseDuration(ttlStr); err != nil {
+		if log := s.log(); log != nil {
+			log.Warningf(
+				"[agent] session [%s] invalid mcp.tools_cache_ttl duration %q, using default %s",
+				s.ID, ttlStr, MCPToolsCacheDefaultTTL,
+			)
+		}
+
+		return MCPToolsCacheDefaultTTL
+	}
+
+	return ttlStr
+}
+
 func (s *AgentSession) tryCacheMCPTools(cacheKey string) ([]byte, error) {
 	raw, err := s.store.Call("cache", "load", map[string]interface{}{
 		"key": cacheKey,
@@ -237,7 +275,7 @@ func (s *AgentSession) fetchMCPTools(serverName string, cacheKey string) ([]byte
 		if _, err := s.store.Call("cache", "save", map[string]interface{}{
 			"key":   cacheKey,
 			"value": string(raw),
-			"ttl":   "1h",
+			"ttl":   s.getMCPToolsCacheTTL(),
 		}); err != nil {
 			if log := s.log(); log != nil {
 				log.Warningf("[agent] failed to cache tools for MCP server %q: %v", serverName, err)

--- a/internal/agent/tool_call_test.go
+++ b/internal/agent/tool_call_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// getMCPToolsCacheTTL
+// ---------------------------------------------------------------------------
+
+func TestGetMCPToolsCacheTTL_DefaultWhenConfigNil(t *testing.T) {
+	store := newMockStore(nil)
+	// Override cfg to nil to simulate missing config
+	store.cfg = nil
+
+	s := &AgentSession{store: store, ID: "test-session"}
+	ttl := s.getMCPToolsCacheTTL()
+
+	assert.Equal(t, MCPToolsCacheDefaultTTL, ttl)
+}
+
+func TestGetMCPToolsCacheTTL_DefaultWhenDataSetNil(t *testing.T) {
+	store := newMockStore(&config.Config{})
+	// Config has no DataSet
+
+	s := &AgentSession{store: store, ID: "test-session"}
+	ttl := s.getMCPToolsCacheTTL()
+
+	assert.Equal(t, MCPToolsCacheDefaultTTL, ttl)
+}
+
+func TestGetMCPToolsCacheTTL_DefaultWhenDriverDataMissing(t *testing.T) {
+	store := newMockStore(&config.Config{
+		DataSet: &config.DataSet{
+			Drivers: map[string]interface{}{},
+		},
+	})
+
+	s := &AgentSession{store: store, ID: "test-session"}
+	ttl := s.getMCPToolsCacheTTL()
+
+	assert.Equal(t, MCPToolsCacheDefaultTTL, ttl)
+}
+
+func TestGetMCPToolsCacheTTL_CustomTTL(t *testing.T) {
+	store := newMockStore(&config.Config{
+		DataSet: &config.DataSet{
+			Drivers: map[string]interface{}{
+				"mcp": map[string]interface{}{
+					"tools_cache_ttl": "30m",
+				},
+			},
+		},
+	})
+
+	s := &AgentSession{store: store, ID: "test-session"}
+	ttl := s.getMCPToolsCacheTTL()
+
+	assert.Equal(t, "30m", ttl)
+}
+
+func TestGetMCPToolsCacheTTL_InvalidType(t *testing.T) {
+	store := newMockStore(&config.Config{
+		DataSet: &config.DataSet{
+			Drivers: map[string]interface{}{
+				"mcp": map[string]interface{}{
+					"tools_cache_ttl": 12345, // invalid type, should be string
+				},
+			},
+		},
+	})
+
+	s := &AgentSession{store: store, ID: "test-session"}
+	ttl := s.getMCPToolsCacheTTL()
+
+	assert.Equal(t, MCPToolsCacheDefaultTTL, ttl)
+}
+
+func TestGetMCPToolsCacheTTL_InvalidDuration(t *testing.T) {
+	store := newMockStore(&config.Config{
+		DataSet: &config.DataSet{
+			Drivers: map[string]interface{}{
+				"mcp": map[string]interface{}{
+					"tools_cache_ttl": "invalid-duration",
+				},
+			},
+		},
+	})
+
+	s := &AgentSession{store: store, ID: "test-session"}
+	ttl := s.getMCPToolsCacheTTL()
+
+	assert.Equal(t, MCPToolsCacheDefaultTTL, ttl)
+}
+
+func TestGetMCPToolsCacheTTL_EmptyString(t *testing.T) {
+	store := newMockStore(&config.Config{
+		DataSet: &config.DataSet{
+			Drivers: map[string]interface{}{
+				"mcp": map[string]interface{}{
+					"tools_cache_ttl": "",
+				},
+			},
+		},
+	})
+
+	s := &AgentSession{store: store, ID: "test-session"}
+	ttl := s.getMCPToolsCacheTTL()
+
+	assert.Equal(t, MCPToolsCacheDefaultTTL, ttl)
+}
+
+func TestGetMCPToolsCacheTTL_TwoHours(t *testing.T) {
+	store := newMockStore(&config.Config{
+		DataSet: &config.DataSet{
+			Drivers: map[string]interface{}{
+				"mcp": map[string]interface{}{
+					"tools_cache_ttl": "2h",
+				},
+			},
+		},
+	})
+
+	s := &AgentSession{store: store, ID: "test-session"}
+	ttl := s.getMCPToolsCacheTTL()
+
+	assert.Equal(t, "2h", ttl)
+}
+
+func TestGetMCPToolsCacheTTL_30Minutes(t *testing.T) {
+	store := newMockStore(&config.Config{
+		DataSet: &config.DataSet{
+			Drivers: map[string]interface{}{
+				"mcp": map[string]interface{}{
+					"tools_cache_ttl": "30m",
+				},
+			},
+		},
+	})
+
+	s := &AgentSession{store: store, ID: "test-session"}
+	ttl := s.getMCPToolsCacheTTL()
+
+	assert.Equal(t, "30m", ttl)
+}
+
+func TestGetMCPToolsCacheTTL_15Seconds(t *testing.T) {
+	store := newMockStore(&config.Config{
+		DataSet: &config.DataSet{
+			Drivers: map[string]interface{}{
+				"mcp": map[string]interface{}{
+					"tools_cache_ttl": "15s",
+				},
+			},
+		},
+	})
+
+	s := &AgentSession{store: store, ID: "test-session"}
+	ttl := s.getMCPToolsCacheTTL()
+
+	assert.Equal(t, "15s", ttl)
+}

--- a/internal/agent/tool_call_test.go
+++ b/internal/agent/tool_call_test.go
@@ -58,8 +58,12 @@ func TestGetMCPToolsCacheTTL_CustomTTL(t *testing.T) {
 	store := newMockStore(&config.Config{
 		DataSet: &config.DataSet{
 			Drivers: map[string]interface{}{
-				"mcp": map[string]interface{}{
-					"tools_cache_ttl": "30m",
+				"daemon": map[string]interface{}{
+					"services": map[string]interface{}{
+						"agent": map[string]interface{}{
+							"tools_cache_ttl": "30m",
+						},
+					},
 				},
 			},
 		},
@@ -75,8 +79,12 @@ func TestGetMCPToolsCacheTTL_InvalidType(t *testing.T) {
 	store := newMockStore(&config.Config{
 		DataSet: &config.DataSet{
 			Drivers: map[string]interface{}{
-				"mcp": map[string]interface{}{
-					"tools_cache_ttl": 12345, // invalid type, should be string
+				"daemon": map[string]interface{}{
+					"services": map[string]interface{}{
+						"agent": map[string]interface{}{
+							"tools_cache_ttl": 12345, // invalid type, should be string
+						},
+					},
 				},
 			},
 		},
@@ -92,8 +100,12 @@ func TestGetMCPToolsCacheTTL_InvalidDuration(t *testing.T) {
 	store := newMockStore(&config.Config{
 		DataSet: &config.DataSet{
 			Drivers: map[string]interface{}{
-				"mcp": map[string]interface{}{
-					"tools_cache_ttl": "invalid-duration",
+				"daemon": map[string]interface{}{
+					"services": map[string]interface{}{
+						"agent": map[string]interface{}{
+							"tools_cache_ttl": "invalid-duration",
+						},
+					},
 				},
 			},
 		},
@@ -109,8 +121,12 @@ func TestGetMCPToolsCacheTTL_EmptyString(t *testing.T) {
 	store := newMockStore(&config.Config{
 		DataSet: &config.DataSet{
 			Drivers: map[string]interface{}{
-				"mcp": map[string]interface{}{
-					"tools_cache_ttl": "",
+				"daemon": map[string]interface{}{
+					"services": map[string]interface{}{
+						"agent": map[string]interface{}{
+							"tools_cache_ttl": "",
+						},
+					},
 				},
 			},
 		},
@@ -126,8 +142,12 @@ func TestGetMCPToolsCacheTTL_TwoHours(t *testing.T) {
 	store := newMockStore(&config.Config{
 		DataSet: &config.DataSet{
 			Drivers: map[string]interface{}{
-				"mcp": map[string]interface{}{
-					"tools_cache_ttl": "2h",
+				"daemon": map[string]interface{}{
+					"services": map[string]interface{}{
+						"agent": map[string]interface{}{
+							"tools_cache_ttl": "2h",
+						},
+					},
 				},
 			},
 		},
@@ -143,8 +163,12 @@ func TestGetMCPToolsCacheTTL_30Minutes(t *testing.T) {
 	store := newMockStore(&config.Config{
 		DataSet: &config.DataSet{
 			Drivers: map[string]interface{}{
-				"mcp": map[string]interface{}{
-					"tools_cache_ttl": "30m",
+				"daemon": map[string]interface{}{
+					"services": map[string]interface{}{
+						"agent": map[string]interface{}{
+							"tools_cache_ttl": "30m",
+						},
+					},
 				},
 			},
 		},
@@ -160,8 +184,12 @@ func TestGetMCPToolsCacheTTL_15Seconds(t *testing.T) {
 	store := newMockStore(&config.Config{
 		DataSet: &config.DataSet{
 			Drivers: map[string]interface{}{
-				"mcp": map[string]interface{}{
-					"tools_cache_ttl": "15s",
+				"daemon": map[string]interface{}{
+					"services": map[string]interface{}{
+						"agent": map[string]interface{}{
+							"tools_cache_ttl": "15s",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
This PR implements caching for the MCP tool list in the Honeydipper agent to improve chat turn performance.

## Problem
The `addMCPTool` function in `internal/agent/tool_call.go` was calling the MCP driver's `list_tools` RPC on every chat turn, causing slow response times.

## Solution
Added caching mechanism for MCP tool lists:

1. **Added cache key prefix constant** (`MCPToolsCachePrefix`) in `agent_session.go`
2. **Modified `addMCPTool` function** to:
   - First check cache using `tryCacheMCPTools()`
   - If cache miss, fetch from MCP driver via `fetchMCPTools()`
   - Cache the result asynchronously (1 hour TTL) to avoid blocking
3. **Added helper functions**:
   - `tryCacheMCPTools()` - loads cached tool list
   - `fetchMCPTools()` - fetches from MCP driver and caches result
   - `processMCPToolList()` - processes tool list response (extracted for reusability)

## Changes
- `internal/agent/agent_session.go`: Added `MCPToolsCachePrefix` constant
- `internal/agent/tool_call.go`: 
  - Modified `addMCPTool` to use cache
  - Added `tryCacheMCPTools`, `fetchMCPTools`, `processMCPToolList` functions

## Testing
- All existing tests pass
- Code compiles successfully
- Linting passes (golangci-lint)

## Performance Impact
- Eliminates repeated `list_tools` RPC calls to MCP drivers
- Reduces chat turn latency when MCP servers are configured
- Cache TTL of 1 hour balances freshness with performance