### PR TITLE
fix(mcp-driver): add timeout handling to prevent hanging connections

### DIFF
--- a/drivers/cmd/hd-driver-mcp/main.go
+++ b/drivers/cmd/hd-driver-mcp/main.go
@@ -26,10 +26,16 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
 	"github.com/mitchellh/mapstructure"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	// defaultTimeout is the default timeout for MCP server requests.
+	defaultTimeout = 30 * time.Second
 )
 
 // serverConfig holds the configuration for a single remote MCP server.
@@ -37,6 +43,7 @@ type serverConfig struct {
 	URL       string            `mapstructure:"url"`
 	Transport string            `mapstructure:"transport"` // "streamable" (default) or "sse"
 	Headers   map[string]string `mapstructure:"headers"`
+	Timeout   string            `mapstructure:"timeout"` // optional timeout duration string (e.g. "45s")
 }
 
 var driver *dipper.Driver
@@ -69,6 +76,19 @@ func getServerConfig(name string) serverConfig {
 	}
 
 	return cfg
+}
+
+// parseTimeout parses the timeout string from config or returns the default.
+func parseTimeout(cfg serverConfig) time.Duration {
+	if cfg.Timeout != "" {
+		if d, err := time.ParseDuration(cfg.Timeout); err == nil {
+			return d
+		} else {
+			dipper.Logger.Warningf("[mcp] invalid timeout %q for server, using default: %v", cfg.Timeout, err)
+		}
+	}
+
+	return defaultTimeout
 }
 
 // headerRoundTripper injects static HTTP headers into every outbound request.
@@ -146,7 +166,10 @@ func listTools(msg *dipper.Message) {
 	serverName := dipper.MustGetMapDataStr(msg.Payload, "server")
 	cfg := getServerConfig(serverName)
 
-	ctx := context.Background()
+	// Create context with timeout
+	timeout := parseTimeout(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 
 	session := connectToServer(ctx, serverName, cfg)
 	defer func() { _ = session.Close() }()
@@ -206,7 +229,10 @@ func callTool(msg *dipper.Message) {
 		}
 	}
 
-	ctx := context.Background()
+	// Create context with timeout
+	timeout := parseTimeout(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 
 	session := connectToServer(ctx, serverName, cfg)
 	defer func() { _ = session.Close() }()


### PR DESCRIPTION
## Problem

The MCP driver (`drivers/cmd/hd-driver-mcp`) was experiencing timeout errors at line 156 in the `listTools()` function. The root cause was that:

1. **No timeout on context**: The code used `context.Background()` which has no deadline or timeout
2. **No HTTP client timeout**: When no custom headers are configured, `buildHTTPClient()` returns `nil`, causing the MCP SDK to use Go's default HTTP client which has no timeout set
3. **Operations could hang indefinitely**: Calls to `session.ListTools()` and `session.CallTool()` could block forever if the MCP server was slow or unresponsive

## Solution

This PR adds proper timeout handling to prevent hanging connections:

### Changes Made

1. **Added default timeout constant**: Set to 30 seconds for all MCP server requests
2. **Added per-server timeout configuration**: Supports `data.servers.<name>.timeout` in driver options (e.g., `"60s"`, `"2m"`)
3. **Context with timeout**: Both `listTools()` and `callTool()` now create context with timeout using `context.WithTimeout()`
4. **Proper context cancellation**: Context is properly cancelled after operations complete using `defer cancel()`
5. **Extended serverConfig struct**: Added `Timeout` field for optional per-server timeout configuration

### Configuration Example

```yaml
data:
  servers:
    my-server:
      url: https://example.com/mcp
      transport: streamable
      timeout: "45s"  # Optional: override default 30s timeout
      headers:
        Authorization: "Bearer <token>"
```

## Testing

- ✅ Code compiles successfully
- ✅ All linting checks pass (golangci-lint)
- ✅ Binary builds correctly

## Impact

- Prevents indefinite hanging when MCP servers are slow or unresponsive
- Allows users to configure appropriate timeouts for their use cases
- Maintains backward compatibility (uses sensible default of 30s)

Fixes #<issue-number> (if applicable)