### PR TITLE
feat: add Only/Excludes filtering for MCP tool definitions

### DIFF
--- a/internal/agent/tool_call.go
+++ b/internal/agent/tool_call.go
@@ -201,7 +201,7 @@ func (s *AgentSession) addMCPTool(tools map[string]AgentTool, toolDef config.Age
 		}
 	}
 
-	s.processMCPToolList(tools, toolDef.Name, prefix, raw)
+	s.processMCPToolList(tools, toolDef, prefix, raw)
 }
 
 // tryCacheMCPTools attempts to load cached MCP tool list from cache.
@@ -282,15 +282,28 @@ func (s *AgentSession) fetchMCPTools(serverName string, cacheKey string) ([]byte
 }
 
 // processMCPToolList processes the raw tool list response and registers tools.
-func (s *AgentSession) processMCPToolList(tools map[string]AgentTool, serverName, prefix string, raw []byte) {
+// processMCPToolList processes the raw tool list response and registers tools.
+// When toolDef.Only is set, only tools whose names appear in the list are registered.
+// When toolDef.Excludes is set, tools whose names appear in the list are skipped.
+func (s *AgentSession) processMCPToolList(tools map[string]AgentTool, toolDef config.AgentToolDef, prefix string, raw []byte) {
 	var payload map[string]interface{}
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		if log := s.log(); log != nil {
 			log.Errorf("[agent] session [%s] failed to decode list_tools response for %q: %v",
-				s.ID, serverName, err)
+				s.ID, toolDef.Name, err)
 		}
 
 		return
+	}
+
+	// Build lookup sets for efficient filtering.
+	onlySet := make(map[string]struct{}, len(toolDef.Only))
+	for _, n := range toolDef.Only {
+		onlySet[n] = struct{}{}
+	}
+	excludesSet := make(map[string]struct{}, len(toolDef.Excludes))
+	for _, n := range toolDef.Excludes {
+		excludesSet[n] = struct{}{}
 	}
 
 	toolList, _ := payload["tools"].([]interface{})
@@ -303,6 +316,18 @@ func (s *AgentSession) processMCPToolList(tools map[string]AgentTool, serverName
 		name, _ := def["name"].(string)
 		desc, _ := def["description"].(string)
 		if name == "" {
+			continue
+		}
+
+		// Apply Only filter: if specified, skip tools not in the list.
+		if len(onlySet) > 0 {
+			if _, allowed := onlySet[name]; !allowed {
+				continue
+			}
+		}
+
+		// Apply Excludes filter: skip tools in the excludes list.
+		if _, excluded := excludesSet[name]; excluded {
 			continue
 		}
 

--- a/internal/agent/tool_call_test.go
+++ b/internal/agent/tool_call_test.go
@@ -10,6 +10,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/honeydipper/honeydipper/v4/internal/config"
@@ -199,4 +200,252 @@ func TestGetMCPToolsCacheTTL_15Seconds(t *testing.T) {
 	ttl := s.getMCPToolsCacheTTL()
 
 	assert.Equal(t, "15s", ttl)
+}
+
+// ---------------------------------------------------------------------------
+// MCP tool filtering (Only / Excludes)
+// ---------------------------------------------------------------------------
+
+// helper to build a raw MCP list_tools response payload.
+func mcpToolListRaw(tools []map[string]interface{}) []byte {
+	payload := map[string]interface{}{"tools": tools}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		panic(err)
+	}
+
+	return b
+}
+
+// helper to build a minimal MCP tool definition entry.
+func mcpTool(name, desc string) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        name,
+		"description": desc,
+		"input_schema": map[string]interface{}{
+			"properties": map[string]interface{}{
+				"param1": map[string]interface{}{
+					"name":        "param1",
+					"type":        "string",
+					"description": "a param",
+				},
+			},
+		},
+	}
+}
+
+// setupMCPTestStore prepares a mock store for MCP tool tests.
+// It pre-sets the MCP driver response and ensures the cache load for
+// MCP tools returns empty so the code path goes through fetchMCPTools.
+func setupMCPTestStore(t *testing.T, raw []byte) *mockStore {
+	t.Helper()
+	store := newMockStore(nil)
+	store.resp["driver:mcp:list_tools"] = raw
+	// Ensure cache:load returns empty for the MCP tools cache key so
+	// tryCacheMCPTools fails and fetchMCPTools is called.
+	store.resp["cache:load:"+MCPToolsCachePrefix+"myserver"] = []byte("")
+
+	return store
+}
+
+func TestProcessMCPToolList_OnlyFilter(t *testing.T) {
+	raw := mcpToolListRaw([]map[string]interface{}{
+		mcpTool("alpha", "tool alpha"),
+		mcpTool("beta", "tool beta"),
+		mcpTool("gamma", "tool gamma"),
+	})
+	store := setupMCPTestStore(t, raw)
+
+	agentA := config.Agent{
+		Name: "a",
+		Tools: []config.AgentToolDef{
+			{Type: "mcp", Name: "myserver", Only: []string{"alpha", "gamma"}},
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{store: store, Agent: &agentA, ID: "test-only"}
+	tools := s.BuildTools()
+
+	assert.Len(t, tools, 2)
+	assert.Contains(t, tools, "mcp__myserver__alpha")
+	assert.Contains(t, tools, "mcp__myserver__gamma")
+	assert.NotContains(t, tools, "mcp__myserver__beta")
+}
+
+func TestProcessMCPToolList_ExcludesFilter(t *testing.T) {
+	raw := mcpToolListRaw([]map[string]interface{}{
+		mcpTool("alpha", "tool alpha"),
+		mcpTool("beta", "tool beta"),
+		mcpTool("gamma", "tool gamma"),
+	})
+	store := setupMCPTestStore(t, raw)
+
+	agentA := config.Agent{
+		Name: "a",
+		Tools: []config.AgentToolDef{
+			{Type: "mcp", Name: "myserver", Excludes: []string{"beta"}},
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{store: store, Agent: &agentA, ID: "test-excludes"}
+	tools := s.BuildTools()
+
+	assert.Len(t, tools, 2)
+	assert.Contains(t, tools, "mcp__myserver__alpha")
+	assert.Contains(t, tools, "mcp__myserver__gamma")
+	assert.NotContains(t, tools, "mcp__myserver__beta")
+}
+
+func TestProcessMCPToolList_BothOnlyAndExcludes(t *testing.T) {
+	raw := mcpToolListRaw([]map[string]interface{}{
+		mcpTool("alpha", "tool alpha"),
+		mcpTool("beta", "tool beta"),
+		mcpTool("gamma", "tool gamma"),
+		mcpTool("delta", "tool delta"),
+	})
+	store := setupMCPTestStore(t, raw)
+
+	agentA := config.Agent{
+		Name: "a",
+		Tools: []config.AgentToolDef{
+			{Type: "mcp", Name: "myserver", Only: []string{"alpha", "beta", "gamma"}, Excludes: []string{"beta"}},
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{store: store, Agent: &agentA, ID: "test-both"}
+	tools := s.BuildTools()
+
+	// Only whitelist is applied first (alpha, beta, gamma), then Excludes removes beta.
+	assert.Len(t, tools, 2)
+	assert.Contains(t, tools, "mcp__myserver__alpha")
+	assert.Contains(t, tools, "mcp__myserver__gamma")
+	assert.NotContains(t, tools, "mcp__myserver__beta")
+	assert.NotContains(t, tools, "mcp__myserver__delta")
+}
+
+func TestProcessMCPToolList_NoFilter(t *testing.T) {
+	raw := mcpToolListRaw([]map[string]interface{}{
+		mcpTool("alpha", "tool alpha"),
+		mcpTool("beta", "tool beta"),
+	})
+	store := setupMCPTestStore(t, raw)
+
+	agentA := config.Agent{
+		Name: "a",
+		Tools: []config.AgentToolDef{
+			{Type: "mcp", Name: "myserver"},
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{store: store, Agent: &agentA, ID: "test-nofilter"}
+	tools := s.BuildTools()
+
+	// All tools should be present when no filter is specified.
+	assert.Len(t, tools, 2)
+	assert.Contains(t, tools, "mcp__myserver__alpha")
+	assert.Contains(t, tools, "mcp__myserver__beta")
+}
+
+func TestProcessMCPToolList_OnlyNonexistentAllExcluded(t *testing.T) {
+	raw := mcpToolListRaw([]map[string]interface{}{
+		mcpTool("alpha", "tool alpha"),
+		mcpTool("beta", "tool beta"),
+	})
+	store := setupMCPTestStore(t, raw)
+
+	agentA := config.Agent{
+		Name: "a",
+		Tools: []config.AgentToolDef{
+			{Type: "mcp", Name: "myserver", Only: []string{"nonexistent"}},
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{store: store, Agent: &agentA, ID: "test-only-empty"}
+	tools := s.BuildTools()
+
+	// Only lists a tool that doesn't exist — nothing registered.
+	assert.Len(t, tools, 0)
+}
+
+func TestProcessMCPToolList_ExcludesAll(t *testing.T) {
+	raw := mcpToolListRaw([]map[string]interface{}{
+		mcpTool("alpha", "tool alpha"),
+		mcpTool("beta", "tool beta"),
+	})
+	store := setupMCPTestStore(t, raw)
+
+	agentA := config.Agent{
+		Name: "a",
+		Tools: []config.AgentToolDef{
+			{Type: "mcp", Name: "myserver", Excludes: []string{"alpha", "beta"}},
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{store: store, Agent: &agentA, ID: "test-excludes-all"}
+	tools := s.BuildTools()
+
+	// All tools excluded — nothing registered.
+	assert.Len(t, tools, 0)
+}
+
+func TestProcessMCPToolList_MixedToolTypes(t *testing.T) {
+	raw := mcpToolListRaw([]map[string]interface{}{
+		mcpTool("mcp_tool_a", "MCP tool A"),
+		mcpTool("mcp_tool_b", "MCP tool B"),
+	})
+	store := setupMCPTestStore(t, raw)
+	store.cfg.DataSet.Systems["s1"] = makeSystemWithFunc("sys_fn")
+	store.cfg.DataSet.Workflows["wf1"] = makeWorkflow("wf1", "workflow 1")
+
+	agentA := config.Agent{
+		Name: "a",
+		Tools: []config.AgentToolDef{
+			{Type: "system", Name: "s1"},
+			{Type: "workflow", Name: "wf1"},
+			{Type: "mcp", Name: "myserver", Only: []string{"mcp_tool_a"}},
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{store: store, Agent: &agentA, ID: "test-mixed"}
+	tools := s.BuildTools()
+
+	assert.Len(t, tools, 3)
+	assert.Contains(t, tools, "sys_s1__sys_fn")
+	assert.Contains(t, tools, "wf__wf1")
+	assert.Contains(t, tools, "mcp__myserver__mcp_tool_a")
+	assert.NotContains(t, tools, "mcp__myserver__mcp_tool_b")
+}
+
+func TestProcessMCPToolList_CacheHitWithFilter(t *testing.T) {
+	store := newMockStore(nil)
+	raw := mcpToolListRaw([]map[string]interface{}{
+		mcpTool("alpha", "tool alpha"),
+		mcpTool("beta", "tool beta"),
+		mcpTool("gamma", "tool gamma"),
+	})
+
+	// Pre-populate cache with the full tool list (no filter was applied when caching).
+	store.resp["cache:load:"+MCPToolsCachePrefix+"myserver"] = raw
+
+	agentA := config.Agent{
+		Name: "a",
+		Tools: []config.AgentToolDef{
+			{Type: "mcp", Name: "myserver", Only: []string{"beta"}},
+		},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{store: store, Agent: &agentA, ID: "test-cache-filter"}
+	tools := s.BuildTools()
+
+	// Even though the cached data has all tools, the filter is applied on retrieval.
+	assert.Len(t, tools, 1)
+	assert.Contains(t, tools, "mcp__myserver__beta")
 }

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -161,8 +161,10 @@ func (r RepoInfo) Key() RepoKey {
 
 // AgentToolDef defines if the workflow is a workflow or a system.
 type AgentToolDef struct {
-	Type string
-	Name string
+	Type     string
+	Name     string
+	Only     []string
+	Excludes []string
 }
 
 // Agent is a abstract data structure including AI driver, prompt and tools definitions for an agent session.


### PR DESCRIPTION
## Summary

This PR adds optional `Only` and `Excludes` fields to `AgentToolDef`, allowing users to filter which MCP tools are registered when mounting an MCP server as an agent tool. This helps combat tool bloat when an MCP server exposes many tools but only a subset are needed.

## Changes

### `internal/config/schema.go`
- Added `Only []string` and `Excludes []string` fields to `AgentToolDef`

### `internal/agent/tool_call.go`
- Updated `processMCPToolList` to accept `toolDef config.AgentToolDef` instead of `serverName string`
- Added filtering logic:
  - If `Only` is specified (non-empty), only tools whose names appear in the list are registered
  - If `Excludes` is specified (non-empty), tools whose names appear in the list are skipped
  - When both are specified, `Only` is applied first, then `Excludes`

### `internal/agent/tool_call_test.go`
- Added 8 test cases covering:
  - `OnlyFilter`: only whitelisted tools are registered
  - `ExcludesFilter`: excluded tools are skipped
  - `BothOnlyAndExcludes`: Only applied first, then Excludes
  - `NoFilter`: all tools registered when no filter is set
  - `OnlyNonexistentAllExcluded`: Only list with no matching tools yields empty
  - `ExcludesAll`: excluding all tools yields empty
  - `MixedToolTypes`: filtering MCP tools doesn't affect system/workflow tools
  - `CacheHitWithFilter`: filter is applied even when tools come from cache

## Configuration Example

```yaml
agents:
  my_agent:
    tools:
      - type: mcp
        name: my_mcp_server
        only:
          - read_file
          - write_file
```

Or to exclude specific tools:

```yaml
agents:
  my_agent:
    tools:
      - type: mcp
        name: my_mcp_server
        excludes:
          - dangerous_tool
```