### PR TITLE
feat(config): add memory configuration schema for AI agents

### DIFF
--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -137,3 +137,24 @@ type DataSet struct {
 	Workflows map[string]Workflow
 	Contexts  map[string]interface{}
 }
+
+// ConvoMemory is the configuration for conversation memory (Redis-based).
+type ConvoMemory struct {
+	Enabled     bool   `json:"enabled" mapstructure:"enabled"`
+	TTL         string `json:"ttl" mapstructure:"ttl"`
+	MaxMemories int    `json:"max_memories" mapstructure:"max_memories"`
+}
+
+// FileMemory is the configuration for file-based memory.
+type FileMemory struct {
+	FileSpec string `json:"file_spec" mapstructure:"file_spec"`
+}
+
+// Agent is the configuration for an AI agent.
+type Agent struct {
+	Name         string       `json:"name" mapstructure:"name"`
+	Description  string       `json:"description" mapstructure:"description"`
+	ConvoMemory  *ConvoMemory `json:"convo_memory" mapstructure:"convo_memory"`
+	AgentMemory  *FileMemory  `json:"agent_memory" mapstructure:"agent_memory"`
+	GlobalMemory *FileMemory  `json:"global_memory" mapstructure:"global_memory"`
+}


### PR DESCRIPTION
## Summary

Adds memory configuration fields to the Agent struct in the configuration schema. This is Task 1 of the memory feature implementation plan.

## Changes

- **ConvoMemory struct**: Redis-based conversation memory configuration with `enabled`, `ttl`, and `max_memories` fields
- **FileMemory struct**: File-based memory configuration with `file_spec` field
- **Agent struct**: Three new optional pointer fields:
  - `ConvoMemory` - conversation memory configuration
  - `AgentMemory` - agent-specific file-based memory configuration
  - `GlobalMemory` - global shared file-based memory configuration

## Backward Compatibility

All new fields are pointer types, meaning `nil` = not configured. Existing configurations without these fields will continue to work without changes.

## Testing

- `go build ./...` passes
- `go test ./...` passes (all packages)
- `golangci-lint run --no-config internal/config/schema.go` reports 0 issues