### PR TITLE
docs: Phase 2 - Update core documentation files (configuration.md, workflow.md, developer.md)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,8 +8,10 @@
 - [Drivers](#drivers)
   * [Daemon configuration](#daemon-configuration)
 - [Systems](#systems)
+- [Agents](#agents)
 - [Workflows](#workflows)
 - [Rules](#rules)
+- [Contexts](#contexts)
 - [Config check](#config-check)
 - [References](#references)
 
@@ -48,6 +50,7 @@ type DataSet struct {
 	Repos     []RepoInfo             `json:"repos,omitempty"`
 	Workflows map[string]Workflow    `json:"workflows,omitempty"`
 	Contexts  map[string]interface{} `json:"contexts,omitempty"`
+	Agents    map[string]Agent       `json:"agents,omitempty"`
 }
 ```
 
@@ -251,9 +254,180 @@ rules:
       call_workflow: my_team_slashcommands
 ```
 
+## Agents
+
+Agents define AI model integrations that can be invoked from workflows using `call_agent` and `wait_agent` actions. Each agent maps to an
+AI backend driver and configures its behavior including system prompts, tool access, and conversation management.
+
+```go
+// Agent defines an AI agent that can be invoked from workflows.
+type Agent struct {
+	Driver              string   `json:"driver,omitempty"`
+	Engine              string   `json:"engine,omitempty"`
+	SystemPrompt        string   `json:"system_prompt,omitempty"`
+	InferencePrompt     string   `json:"inference_prompt,omitempty"`
+	ShouldEmitThoughts  bool     `json:"should_emit_thoughts,omitempty"`
+	ShouldStream        bool     `json:"should_stream,omitempty"`
+	MaxHistoryLen       int      `json:"max_history_len,omitempty"`
+	CompactionPolicy    CompactionPolicy `json:"compaction_policy,omitempty"`
+	Tools               []string `json:"tools,omitempty"`
+	ModelData           map[string]interface{} `json:"model_data,omitempty"`
+}
+```
+
+### Agent Fields
+
+| Field | Description |
+|---|---|
+| `driver` | The AI driver backend to use (e.g., `openai`, `gemini`, `ollama`) |
+| `engine` | The model engine/name (e.g., `gpt-4`, `gemini-pro`) |
+| `system_prompt` | The system prompt that defines the agent's role and behavior |
+| `inference_prompt` | An optional additional prompt prepended at inference time |
+| `should_emit_thoughts` | If true, the agent emits intermediate thinking/reasoning content |
+| `should_stream` | If true, the response is streamed back as it is generated |
+| `max_history_len` | Maximum number of messages to retain in conversation history (default: unlimited) |
+| `compaction_policy` | Policy for compacting conversation history when it gets too long (see below) |
+| `tools` | List of tools the agent can use. Tools are built from system functions (`sys_`), workflows (`wf_`), sub-agents (`ag_`), and MCP servers (`mcp_`) |
+| `model_data` | Additional model-specific parameters (temperature, top_p, etc.) passed to the AI driver |
+
+### Compaction Policy
+
+When a conversation grows beyond token or history limits, the compaction policy controls how older messages are summarized to stay within bounds.
+
+```go
+type CompactionPolicy struct {
+	Strategy            string `json:"strategy,omitempty"`
+	Threshold           int    `json:"threshold,omitempty"`
+	ThresholdType       string `json:"threshold_type,omitempty"`
+	PreserveRecent      int    `json:"preserve_recent,omitempty"`
+	SummarizationAgent  string `json:"summarization_agent,omitempty"`
+	SummarizationPrompt string `json:"summarization_prompt,omitempty"`
+}
+```
+
+| Field | Description |
+|---|---|
+| `strategy` | Compaction strategy, currently `"summarize"` — uses an LLM to condense older messages |
+| `threshold` | When history length or token count exceeds this value, compaction is triggered |
+| `threshold_type` | Either `"history_len"` (number of messages) or `"tokens"` (total token count) |
+| `preserve_recent` | Number of recent messages to keep verbatim without summarization |
+| `summarization_agent` | Name of another agent to use for summarization (defaults to the current agent) |
+| `summarization_prompt` | Custom prompt for the summarization step |
+
+### Example Agent Configuration
+
+```yaml
+---
+agents:
+  sre_assistant:
+    driver: openai
+    engine: gpt-4
+    system_prompt: |
+      You are an SRE assistant helping with incident response.
+      Analyze the situation, suggest remediation steps, and be concise.
+    should_stream: true
+    max_history_len: 20
+    compaction_policy:
+      strategy: summarize
+      threshold_type: history_len
+      threshold: 20
+      preserve_recent: 4
+    model_data:
+      temperature: 0.3
+      max_tokens: 2000
+```
+
+### Using Agents in Workflows
+
+See the [Workflow Composing Guide](./workflow.md) for details on `call_agent` and `wait_agent` actions. In summary:
+
+* `call_agent: agent_name` — Invokes an agent and **waits** for its response. Use `with:` to pass `text` and other context.
+* `wait_agent: session_id` — Waits for a previously invoked agent session response. Used when the agent was called in a detached context.
+* `resume: resume_key` — Resumes a paused workflow session (e.g., paused by `wait_agent`).
+
+For example, invoking an agent within a workflow:
+
+```yaml
+---
+workflows:
+  ask_sre:
+    call_agent: sre_assistant
+    with:
+      text: "We have an alert for high CPU on production. What should I check?"
+```
+
+### Agent Tool Building
+
+Agents can use tools from four sources. When tools are configured for an agent, Honeydipper automatically builds and registers them:
+
+| Prefix | Source | Example |
+|---|---|---|
+| `sys_` | System functions | `sys_kubernetes__get_pod_status` |
+| `wf_` | Named workflows | `wf_run_kubernetes` |
+| `ag_` | Sub-agents (nested agent calls) | `ag_security_checker` |
+| `mcp_` | MCP (Model Context Protocol) server tools | `mcp_filesystem__read_file` |
+
+### Agent Session State
+
+Agent conversation state is persisted to the cache (Redis-backed) with a default TTL of 72 hours. Each session tracks:
+
+| State Field | Description |
+|---|---|
+| `history_len` | Number of messages in the conversation |
+| `total_tokens` | Total tokens consumed so far |
+| `convo_id` | Unique conversation identifier |
+
+Sessions can be cancelled through the API (`/convos/:convoID/cancel`), and polling for responses uses a 9-second timeout per poll cycle.
+
+### Agent Environment Variables
+
+| Env Var | Purpose |
+|---|---|
+| `OPENAI_API_KEY` | API key for OpenAI driver |
+| `GOOGLE_API_KEY` | API key for Gemini driver |
+| `OLLAMA_BASE_URL` | Base URL for Ollama driver |
+
+(Actual environment variables depend on the specific AI driver being used.)
+
 ## Workflows
 
-See [Workflow Composing Guide](./workflow.md) for details on workflows.
+See [Workflow Composing Guide](./workflow.md) for comprehensive workflow documentation.
+
+A workflow definition supports the following additional fields documented here for reference:
+
+### Export Control
+
+| Field | Description |
+|---|---|
+| `export` | Data to export at end of workflow (always evaluated) |
+| `export_on_success` | Data exported only when workflow succeeds |
+| `export_on_failure` | Data exported only when workflow fails |
+| `export_on_error` | Data exported only when workflow encounters an error |
+| `no_export` | List of keys to block from export (`"*"` blocks all) |
+
+The `*` suffix on export keys marks data that should be cached. For example, `cache-data*` is recognized as cacheable data.
+
+### Error Handling on Steps and Threads
+
+When using `steps` or `threads`, use these fields to control failure behavior:
+
+| Field | Values | Default | Description |
+|---|---|---|---|
+| `on_failure` | `continue`, `exit` | `continue` | On step/thread failure |
+| `on_error` | `continue`, `exit` | `exit` | On step/thread error |
+
+For `threads`, `exit` means the workflow returns immediately without waiting for other threads to complete.
+
+### Additional Simple Actions
+
+These simple actions extend the set documented in the [Workflow Composing Guide](./workflow.md):
+
+| Action | Value | Description |
+|---|---|---|
+| `call_agent` | Agent name | Invoke an AI agent and wait for its response |
+| `wait_agent` | Session ID | Wait for a previously invoked agent session's response |
+| `resume` | Resume key | Resume a paused workflow session |
+| `detach` | Any value | Fire-and-forget; marks the child session as detached |
 
 ## Rules
 
@@ -269,34 +443,116 @@ type Rule struct {
 
 Refer to the Systems section for the definition of `Trigger`, and see [Workflow Composing Guide](./workflow.md) for workflows.
 
+## Contexts
+
+Contexts are named collections of key-value pairs that are injected into workflows at runtime. They are defined in the `contexts` section of a
+`DataSet` and can be applied globally, per-system, per-trigger, or per-workflow.
+
+### Built-in Contexts
+
+| Context | Description |
+|---|---|
+| `_default` | Applied to all workflows unconditionally. Used for default configuration values. |
+| `_event` | Applied dynamically based on the triggering event's system, driver, and raw event name (e.g., `_events.mySystem.myTrigger`). Used for hook definitions. |
+
+### Custom Contexts
+
+Custom contexts are user-defined and can contain any data, including hooks, default values, and configuration overrides. A workflow can use
+the `context` field (single context name) or `contexts` field (list of context names) to apply them.
+
+How contexts are resolved:
+
+1. **Rule-level**: A rule can specify `context:` or `contexts:` in its `do` section
+2. **Workflow-level**: A workflow can specify `context:` or `contexts:` directly
+3. **Global hook contexts**: Contexts matching `_events.*` are applied based on event source
+
+### Context Example
+
+```yaml
+---
+contexts:
+  # Applied to all workflows by default
+  _default:
+    chat_system: slack_bot
+    notify:
+      - "#ops-team"
+
+  # Applied based on event source
+  _events:
+    opsgenie:
+      alert:
+        hooks:
+          - on_success:
+              - snooze_alert
+          - on_failure:
+              - escalate_alert
+
+  # Custom context for production operations
+  production_ops:
+    allowed_channels:
+      - "#production"
+    require_approval: true
+    context: opsgenie  # contexts can reference other contexts
+
+rules:
+  - when:
+      source:
+        system: opsgenie
+        trigger: alert
+    do:
+      context: production_ops
+      call_workflow: handle_incident
+```
+
+### Context Inheritance with Extends
+
+Systems that use `extends` to inherit from parent systems also inherit context configurations. The child system's context values override
+parent values. Context data is deeply merged for maps, replaced for other types (unless type-inconsistent, in which case the original data
+is preserved).
+
+### Context Data in Workflows
+
+Context variables are available in the `ctx` namespace for interpolation within workflows:
+
+```yaml
+---
+workflows:
+  my_workflow:
+    call_function: slack.say
+    with:
+      message: "Running in {{ .ctx.notify_pipeline | default 'default' }} mode"
+```
+
+For a complete list of contextual data sources and interpolation methods, see the [Workflow Composing Guide](./workflow.md#contextual-data).
+
 ## Config check
 
-Honeydipper 0.1.8 and above comes with a configcheck functionality that can help checking configuration validity before any updates
+Honeydipper comes with a configcheck functionality that can help checking configuration validity before any updates
 are committed or pushed to the git repos. It can also be used in the CI/CD pipelines to ensure the quality of the configuration files.
 
 You can follow the [installation guide](./INSTALL.md) to install the Honeydipper binary or docker image, then use below commands to check
 the local configuration files.
 
 ```bash
-REPO=</path/to/local/files> honeydipper configcheck
+REPO=<path/to/local/files> honeydipper configcheck
 ```
 
-If using a docker image
+If using a docker image:
 
 ```bash
-docker run -it -v </path/to/config>:/config -e REPO=/config honeydipper/honeydipper:x.x.x configcheck
+docker run -it -v <path/to/config>:/config -e REPO=/config honeydipper/honeydipper configcheck
 ```
 
 If your local config loads remote git repos and you want to validate them too, use `CHECK_REMOTE` environment variable.
 
 ```bash
-REPO=</path/to/config> CHECK_REMOTE=1 honeydipper configcheck
+REPO=<path/to/config> CHECK_REMOTE=1 honeydipper configcheck
 ```
 
-If using docker image
+If using docker image:
 
 ```bash
-docker run -it -v </path/to/config>:/config -e REPO=/config -e CHECK_REMOTE=1 honeydipper/honeydipper:x.x.x configcheck
+docker run -it -v <path/to/config>:/config -e REPO=/config -e CHECK_REMOTE=1 honeydipper/honeydipper configcheck
 ```
 
 You can also use `-h` option to see a full list of supported environment variables.
@@ -306,4 +562,3 @@ You can also use `-h` option to see a full list of supported environment variabl
 For a list of available drivers, systems, and workflows that you can take advantage of immediately, see the reference here.
 
  * [Honeydipper config essentials](../essentials.html)
-

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,7 +1,7 @@
 # Driver Developer's Guide
 
 This document is intended for Honeydipper driver developers. Some programming experience is expected. Theoretically, we can use any
-programming language, even bash, to develop a driver for honeydipper. For now, there is a go library named honeydipper/dipper that makes it
+programming language, even bash, to develop a driver for honeydipper. For now, there is a go library named `github.com/honeydipper/honeydipper/v4/pkg/dipper` that makes it
 easier to do this in golang.
 
 <!-- toc -->
@@ -9,8 +9,11 @@ easier to do this in golang.
 - [Basics](#basics)
 - [By Example](#by-example)
 - [Driver lifecycle and states](#driver-lifecycle-and-states)
+- [Wire Protocol](#wire-protocol)
 - [Messages](#messages)
 - [RPC](#rpc)
+  * [RPC Call Variants](#rpc-call-variants)
+  * [Interruptible Handlers](#interruptible-handlers)
 - [Driver Options](#driver-options)
 - [Collapsed Events](#collapsed-events)
 - [Provide Commands](#provide-commands)
@@ -32,7 +35,7 @@ package main
 
 import (
   "flag"
-  "github.com/honeydipper/honeydipper/pkg/dipper"
+  "github.com/honeydipper/honeydipper/v4/pkg/dipper"
   "os"
   "time"
 )
@@ -68,7 +71,7 @@ Following that, the driver creates a helper object with *dipper.NewDriver*.  The
 functions to be executed at various stage in the life cycle of the driver. A call to the *Run()* method will start the event loop to receive
 communication from the daemon.
 
-There are 4 types of hooks offered by the driver helper objects.
+There are 4 types of hooks offered by the helper objects.
  * Lifecycle events
  * Message handler
  * RPC handler 
@@ -88,29 +91,127 @@ it can be restarted.
 
 ## Driver lifecycle and states
 
-The driver will be in "loaded" state initially. When the *Run()* method is invoked, it will start fetching messages from the daemon. The
-first message is always "command:options" which carries the data and configuration required by the driver to perform its job. The helper
-object has a built-in handler for this and will dump the data into a structure which can later be queried using *driver.GetOption* or
-*driver.GetOptionStr* method.
+The driver transitions through the following states during its lifecycle:
 
-Following the "command:options" is the "command:start" message. The helper object also has a built-in handler for the "command:start"
-message. It will first call the *Start hook* function, if defined, then change the driver state to "alive" then report the state back to
-daemon with *Ping* method. One important thing here is that if the daemon doesn't receive the "alive" state within 10 seconds, it will
-consider the driver failed to start and kill the process by closing the stdin/stdout channels. You can see why the Start hook has to return
-immediately.
+```
+loaded → alive → draining → drained
+                 → stopping → completed
+```
 
-When the daemon loads an updated version of the config, it will use "command:options" and "command:start" again to signal the driver to
-reload. Instead of calling *Start hook*, it will call *Reload hook* for reloading. If *Reload hook* is not defined, it will report to the
-daemon with "cold" state to demand a cold restart.
+### State Descriptions
 
-There is a handler for "command:stop" which calls the *Stop hook* for gracefully shutting down the driver. Although this is not needed most
-of time, assuming the driver is stateless, it does have some uses if the driver uses some resources that cannot be released gracefully by
-exiting.
+| State | Description |
+|---|---|
+| `loaded` | Initial state when the driver binary is known but not yet started |
+| `alive` | The driver is running and actively processing messages. Reached after successful `command:start` |
+| `draining` | The driver is being asked to finish in-flight work before shutting down (e.g., during config reload). The daemon waits for `drained` |
+| `drained` | The driver has finished all in-flight work and acknowledged the drain request. The daemon can now safely stop the driver |
+| `stopping` | The driver is shutting down. Reached after `command:stop` is received |
+| `completed` | The driver process has exited gracefully |
+
+### State Transitions
+
+1. **loaded → alive**: After `command:start` is sent, the `Start` hook runs (if defined). The driver has 10 seconds to report `alive` or it is killed.
+2. **alive → draining**: During a config change where the driver binary stays the same (hot reload), the daemon sends `command:options` with new config. The driver should drain gracefully.
+3. **alive → stopping**: When the daemon decides to stop the driver (cold reload or shutdown), it sends `command:stop`. The `Stop` hook runs if defined.
+4. **draining → drained**: The driver signals it has finished in-flight work.
+5. **draining / stopping → completed**: The driver process exits.
+
+### Configuration Reload States
+
+| Scenario | Behavior |
+|---|---|
+| **Hot reload** (same metadata, driver alive) | Only `command:options` is sent with new options. No state change. |
+| **Cold reload** (different metadata or driver dead) | Old driver is gracefully stopped (`draining → drained → completed`). New driver is started fresh. |
+| **Crash recovery** | Up to 3 retries with 30-second backoff. All services must report `drained` or `completed` before new config is applied. |
+| **Graceful shutdown** | Drain (15s timeout) → Stop (5s timeout) → Process exit |
+
+### Example: Handling State Transitions
+
+```go
+driver.Start = func(msg *dipper.Message) {
+  go func() {
+    // Set up connections, listeners, etc.
+    driver.State = "alive"
+    driver.Ping(msg)
+    
+    // Main event loop
+    for {
+      select {
+      case <-driver.Done():
+        // Clean up resources
+        driver.State = "completed"
+        return
+      }
+    }
+  }()
+}
+
+driver.Reload = func(msg *dipper.Message) {
+  // Reload configuration without full restart
+  loadNewOptions(msg)
+  // No state change required for hot reload
+}
+```
+
+## Wire Protocol
+
+Drivers communicate with the daemon through stdin/stdout using a binary wire protocol. Each message consists of a text header followed by binary labels and payload.
+
+### Message Format
+
+```
+{channel} {subject} {numLabels} {payloadSize}\n
+  label1 {len1}\n{value1}
+  label2 {len2}\n{value2}
+  ...
+  {payload bytes}
+```
+
+### Envelope Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `channel` | String | The message channel (e.g., `eventbus`, `rpc`, `state`, `command`) |
+| `subject` | String | The message subject (e.g., `message`, `call`, `return`, `start`, `stop`) |
+| `numLabels` | Integer | Number of labels attached to this message |
+| `payloadSize` | Integer | Size of the payload in bytes |
+
+### Label Format
+
+Each label is encoded as a label definition line followed by the label value bytes:
+
+```
+{labelName} {labelSize}\n
+{labelValueBytes}
+```
+
+### Raw Message Example
+
+A complete raw message on the wire might look like this (shown in pseudo-format):
+
+```
+eventbus message 2 47\n
+  label1 6\nvalue1
+  status 7\nsuccess
+  {"data": ["line 1", "line 2"]}
+```
+
+### Channels and Subjects
+
+Currently, the protocol uses these channels:
+
+| Channel | Subjects | Usage |
+|---|---|---|
+| `eventbus` | `message`, `command`, `return`, `return_interrupted`, `agent_command`, `agent_continue`, `agent_response`, `agent_workflow` | Engine workflow processing |
+| `rpc` | `call`, `return` | Inter-driver RPC calls |
+| `state` | `cold`, `alive`, `draining`, `drained`, `completed` | Driver lifecycle management |
+| `command` | `options`, `start`, `stop` | Daemon-to-driver commands |
 
 ## Messages
 
 Every message has an envelope, a list of labels and a payload. The envelope is a string ends with a newline, with fields separated by
-space(s). An valid envelope has following fields in the exact order:
+space(s). A valid envelope has following fields in the exact order:
  * Channel
  * Subject
  * Number of labels
@@ -130,7 +231,7 @@ driver.SendMessage(&dipper.Message{
   Labels: map[string]string{
     "label1": "value1",
   },
-  Payload: map[string]interface{}{"data": []string{"line 1", "line 2"},
+  Payload: map[string]interface{}{"data": []string{"line 1", "line 2"}},
   IsRaw: false, # default
 })
 ```
@@ -145,10 +246,24 @@ struct with raw bytes as payload. You can call *dipper.DeserializeContent* which
 the byte array, and you can also use *dipper.DeserializePayload* which accepts a \*dipper.Message and place the
 decoded payload right back into the message.
 
-Currently, we are categorizing the messages into 3 different channels:
- * eventbus: messages that are used by *engine* service for workflow processing, subject could be `message`, `command` or `return`
- * RPC: messages that invoke another driver to run some function, subject could be `call` or `return`
- * state: the local messages between driver and daemon to manage the lifecycle of drivers
+Currently, we are categorizing the messages into 4 different channels:
+ * **eventbus**: messages that are used by *engine* service for workflow processing, subject could be `message`, `command` or `return`
+ * **rpc**: messages that invoke another driver to run some function, subject could be `call` or `return`
+ * **state**: the local messages between driver and daemon to manage the lifecycle of drivers
+ * **command**: messages from daemon to driver for sending options (`options`), starting (`start`), and stopping (`stop`) the driver
+
+### Key Eventbus Subjects
+
+| Subject | Direction | Description |
+|---|---|---|
+| `message` | Driver → Daemon | Incoming event from a driver receiver |
+| `command` | Daemon → Driver | Function execution request (from operator) |
+| `return` | Driver → Daemon | Function execution result |
+| `return_interrupted` | Daemon → Driver | Interrupted function (re-queued by operator) |
+| `agent_command` | Daemon → Driver | Agent tool call execution request |
+| `agent_continue` | Driver → Daemon | Agent response for session |
+| `agent_response` | Driver → Daemon | Agent streaming response |
+| `agent_workflow` | Driver → Daemon | Agent-triggered workflow event |
 
 ## RPC
 
@@ -161,20 +276,25 @@ outsourced to the vendor drivers, such as `gcloud-gke`, through a RPC call `getK
 encrypted content. Honeydipper supports `eyaml` style of encrypted content in configurations, and the cipher text is prefixed with a
 driver name. The decryption driver, `gcloud-kms` as an example, must offer a RPC call `decrypt`.
 
-To make a RPC Call, use `Call` or `CallRaw` method, Both method block for return with 10 seconds timeout. The timeout is not
-tunable at this time. Each of them take three parameters:
- * feature name - an abstract feature name, or a driver name with `driver:` prefix
- * method name - the name of the RPC method
- * parameters - payload of the dipper message constructed for the RPC call, a map or raw bytes
+### RPC Call Variants
 
-For example, calling the `gcloud-kms` driver for decryption
+The driver helper provides several RPC call methods with different behaviors:
+
+| Method | Parameters | Returns | Blocking | Use Case |
+|---|---|---|---|---|
+| `Call(feature, method, params)` | feature, method, map params | Yes | Yes (10s timeout) | Standard synchronous RPC |
+| `CallNoWait(feature, method, params)` | feature, method, map params | No | No | Fire-and-forget notifications |
+| `CallRaw(feature, method, rawBytes)` | feature, method, raw bytes | Yes | Yes (10s timeout) | Raw binary data transfer |
+| `CallRawNoWait(feature, method, rawBytes)` | feature, method, raw bytes | No | No | Raw fire-and-forget |
+| `CallWithMessage(msg)` | Pre-built `*dipper.Message` | Yes | Yes (10s timeout) | Full control over message format |
+
+For example, calling the `gcloud-kms` driver for decryption:
 
 ```go
 decrypted, err := driver.CallRaw("driver:gcloud-kms", "decrypt", encrypted)
 ```
 
-There are also two non-blocking methods in the driver, `CallNoWait` or `CallRawNoWait`, to make RPC calls without waiting for any
-return. For example, making a call to emit a metric to a metrics collecting system, e.g. datadog.
+Non-blocking call to emit a metric:
 
 ```go
 err := driver.CallNoWait("emitter", "counter_increment", map[string]interface{}{
@@ -185,8 +305,16 @@ err := driver.CallNoWait("emitter", "counter_increment", map[string]interface{}{
 })
 ```
 
+Using raw data transfer:
+
+```go
+rawResult, err := driver.CallRaw("driver:image-processor", "compress", imageBytes)
+```
+
+### Offering RPC Methods
+
 To offer a RPC method for the system to call, create the function that accept a single parameter `*dipper.Message`. Add the method
-to `RPCHandlers` map, for example
+to `RPCHandlers` map, for example:
 
 ```go
 driver.RPCHandler["mymethod"] = MyFunc
@@ -210,6 +338,44 @@ func MyFunc(m *dipper.Message) {
   }
 }
 ```
+
+### Interruptible Handlers
+
+RPC handlers can be marked as **interruptible** to support long-running operations that may be cancelled (e.g., when a workflow is
+cancelled or a driver is being drained). When an interruptible handler's context is cancelled instead of completing normally, it sends a
+`return/interrupted` response instead of a normal `return`.
+
+**Use case**: A driver implements a long-running data sync operation via RPC. If the operator service is restarting or the workflow was
+cancelled, the handler can be interrupted gracefully:
+
+```go
+// Mark a handler as interruptible through the interruptible handler map
+driver.RPCHandler["long_running_sync"] = handleSync
+driver.RPCHandler["interruptible:long_running_sync"] = handleSync
+
+func handleSync(m *dipper.Message) {
+  ctx := driver.GetContext() // Get the cancellable context
+  
+  for _, item := range items {
+    select {
+    case <-ctx.Done():
+      // Context cancelled — send interrupted response
+      m.Reply <- dipper.Message{
+        Labels: map[string]string{"error": "interrupted"},
+      }
+      return
+    default:
+      processItem(item)
+    }
+  }
+  
+  m.Reply <- dipper.Message{
+    Payload: map[string]interface{}{"status": "completed"},
+  }
+}
+```
+
+When the operator receives a `return/interrupted` message, it re-queues the command so it can be retried later when the system is healthy.
 
 ## Driver Options
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -10,6 +10,7 @@
   * [Conditions](#conditions)
   * [Looping](#looping)
   * [Hooks](#hooks)
+  * [Export Control](#export-control)
 - [Contextual Data](#contextual-data)
   * [Sources](#sources)
   * [Interpolation](#interpolation)
@@ -85,9 +86,10 @@ There are several types of simple actions that a workflow can perform. Simple ac
  - `call_driver`: calling a `rawAction` offered by a driver, taking a string in the form of `driver.rawAction`
  - `send_event`: send a message to `eventbus:message` so the engine can match it against rules and start new sessions. The value is a map containing an `events` list (event names) and an optional `data` map. A fresh `eventID` is generated automatically.
  - `wait`: wait for the specified amount of time or receive a wake-up request with a matching token. The time should be formatted according to the requirement for function [ParseDuration](https://golang.org/pkg/time/#ParseDuration). A unit suffix is required.
- - `call_agent`: invoke an AI agent for inference. The value is the agent name. The workflow will wait for the agent response.
+ - `call_agent`: invoke an AI agent for inference. The value is the agent name. The workflow will wait for the agent response. See [Agents](../configuration.md#agents) for agent configuration.
  - `wait_agent`: wait for a response from a previously invoked agent session. The value is the agent session ID.
  - `resume`: resume a paused workflow session by sending a wake-up message. The value is the resume key.
+ - `detach`: fire-and-forget; marks the child session as detached so it runs independently.
 
 A workflow can also have no action at all. `{}` is a perfectly legit no-op workflow.
 
@@ -120,13 +122,74 @@ Complex actions are groups of multiple `workflows` organized together to do some
 
  - `steps`: an array of child workflows that are executed in sequence
  - `threads`: an array of child workflows that are executed in parallel
- - `switch/cases/default`: taking a piece of contextual data specified in `switch`, chose and execute from a map of child workflows defined in `cases` or execute the child workflow defined in `default` if no branch matches
+ - `switch/cases/default`: taking a piece of contextual data specified in `switch`, choose and execute from a map of child workflows defined in `cases` or execute the child workflow defined in `default` if no branch matches
  - `iterate`: execute the action multiple times with different values from a list, sequentially
  - `iterate_parallel`: execute the action multiple times with different values from a list, in parallel (with configurable pool size via `iterate_pool`)
 
 These can not be combined with each other or with any of the simple actions.
 
 When using `steps` or `threads`, you can control the behaviour of the workflow upon `failure` or `error` status through fields `on_failure` or `on_error`.  The allowed values are `continue` and `exit`. By default, `on_failure` is set to `continue` while `on_error` is set to `exit`. When using `threads`, `exit` means that when one thread returns error, the workflow returns without waiting for other threads to return.
+
+#### Switch/Cases/Default
+
+The `switch/cases/default` action provides conditional branching within a workflow. The `switch` field specifies a contextual data path (interpolated at runtime). The `cases` field is a map where keys are possible values of the switch expression, and values are the child workflows to execute. The `default` field specifies the workflow to execute when no case matches.
+
+```yaml
+---
+workflows:
+  route_by_environment:
+    switch: $ctx.environment
+    cases:
+      production:
+        call_workflow: handle_production
+      staging:
+        call_workflow: handle_staging
+      development:
+        call_workflow: handle_development
+    default:
+      call_workflow: handle_unknown
+```
+
+The switch expression supports interpolation, so you can use go templates or path interpolation:
+
+```yaml
+---
+workflows:
+  route_by_severity:
+    switch: '{{ .labels.status }}'
+    cases:
+      critical:
+        steps:
+          - call_workflow: page_oncall
+          - call_workflow: create_incident
+      warning:
+        call_workflow: send_slack_alert
+    default:
+      call_workflow: log_only
+```
+
+You can nest `switch` within `steps` or other complex actions for multi-level branching:
+
+```yaml
+---
+workflows:
+  multi_level_routing:
+    steps:
+      - call_workflow: classify_event
+      - switch: $ctx.classification
+        cases:
+          security:
+            switch: $ctx.severity
+            cases:
+              high:
+                call_workflow: escalate_security
+              low:
+                call_workflow: log_security_event
+          infrastructure:
+            call_workflow: handle_infra
+        default:
+          call_workflow: default_handler
+```
 
 ### Caching
 Workflows can cache their results to avoid redundant execution. When a workflow is defined with a `cache_key` and the key is found in the cache, the cached data will be loaded directly without executing the defined work. This is useful for workflows that are expensive or time-consuming.
@@ -178,6 +241,7 @@ workflows:
     steps:
       - call_workflow: notify_cached_result
 ```
+
 ### Iterations
 Any of the actions can be combined with an `iterate` or `iterate_parallel` field to be executed multiple times with different values from a list. The current element of the list will be stored in a local contextual data item named `current`. Optionally, you can also customize the name of contextual data item using `iterate_as`. The elements of the lists to be iterated don't have to be simple strings, it can be a map or other complex data structures.
 
@@ -258,7 +322,6 @@ workflows:
     if_match:
       git_repo: myorg/myrepo
       git_ref!: ":regex:^refs/tags/" # except tags
-    ...
 
   alert_unauthorized_access:
     if_match:
@@ -347,7 +410,7 @@ workflows:
 <!-- {% endraw %} -->
 
 ### Hooks
-Hooks are child workflows executed at a specified moments in the parent workflow's lifecycle. It is a great way to separate auxiliary work, such as sending heartbeat, sending slack messages, making an announcement, clean up, data preparation etc., from the actual work. Hooks are defined through context data, so it can be pulled in through predefined contexts, which makes the actual workflow seems less cluttered.
+Hooks are child workflows executed at specified moments in the parent workflow's lifecycle. They are a great way to separate auxiliary work, such as sending heartbeats, sending slack messages, making announcements, cleanup, data preparation, etc., from the actual work. Hooks are defined through context data, so they can be pulled in through predefined contexts, which makes the actual workflow less cluttered.
 
 For example,
 ```yaml
@@ -380,16 +443,161 @@ rules:
 ```
 In the above example, although not specifically spelled out in the rules, both events will trigger the execution of `workflow_announcement` workflow before executing the first action. And if the workflow responding to the `opsgenie.alert` event is successful, `snooze_alert` workflow will be executed.
 
-The supported hooks:
+#### Supported Hooks
 
- * on_session: when a workflow session is created, even `{}` no-op session will trigger this hook
- * on_first_action: before a workflow performs first simple action
- * on_action: before performs each simple action in `steps`
- * on_item: before execute each iteration
- * on_success: before workflow exit, and when the workflow is successful
- * on_failure: before workflow exit, and when the workflow is failed
- * on_error: before workflow exit, and when the workflow ran into error
- * on_exit: before workflow exit
+| Hook | When It Fires | Notes |
+|---|---|---|
+| `on_session` | When a workflow session is created | Fires even for `{}` no-op sessions |
+| `on_first_round` | Before the first iteration round in a loop | Only fires once at loop start |
+| `on_round` | Before each iteration round in a loop | Fires at the beginning of every round |
+| `on_first_item` | Before the first item in an iteration | Only fires once at iteration start |
+| `on_item` | Before each item in an iteration | Fires for every item |
+| `on_first_action` | Before a workflow performs its first simple action | Commonly used for announcements |
+| `on_action` | Before each simple action in `steps` | Fires for every step |
+| `on_update` | After a workflow state update | Fires after the workflow processes a return message |
+| `on_success` | Before workflow exit, when successful | Workflow completed without errors or failures |
+| `on_failure` | Before workflow exit, when failed | A step or action returned a failure status |
+| `on_error` | Before workflow exit, on error | An unexpected error occurred during execution |
+| `on_exit` | Before workflow exit, regardless of outcome | Always fires last, regardless of success/failure/error |
+
+#### Hook Execution Order
+
+For a typical successful workflow with steps:
+
+```
+on_session → on_first_action → on_action (step 1) → on_action (step 2) → ... → on_success → on_exit
+```
+
+For a looping workflow:
+
+```
+on_session → on_first_round → on_first_item → on_item → on_round → on_item → ... → on_success → on_exit
+```
+
+For a failed workflow:
+
+```
+on_session → on_first_action → on_action (step 1) → on_failure → on_exit
+```
+
+#### Hook Definition Syntax
+
+Hooks can be defined as a single workflow or a list of workflows. When a list is provided, the workflows are executed in order.
+
+```yaml
+contexts:
+  my_context:
+    hooks:
+      - on_first_action: announce_workflow_start
+      - on_success:
+          - send_success_notification
+          - update_dashboard
+      - on_failure:
+          - send_failure_alert
+          - create_incident
+      - on_exit: cleanup_resources
+```
+
+Hooks can also be defined directly in a workflow using the `hooks` field:
+
+```yaml
+---
+workflows:
+  my_workflow:
+    hooks:
+      - on_first_action: log_start
+      - on_success: log_success
+      - on_failure: log_failure
+    steps:
+      - call_function: do_work
+```
+
+#### Hook Context
+
+Hook workflows receive the same contextual data as the parent workflow. They can read and modify the parent's context, but changes are scoped to the current workflow session. Exported data from hooks follows the same export rules as regular workflows.
+
+### Export Control
+
+Workflows can export data back to the parent context or to the triggering event's context. Export control fields allow you to specify exactly what data is exported and under what conditions.
+
+#### Export Fields
+
+| Field | When It Is Evaluated | Description |
+|---|---|---|
+| `export` | Always, at end of workflow | Data listed here is always exported regardless of outcome |
+| `export_on_success` | Only when workflow succeeds | Additional data exported on success |
+| `export_on_failure` | Only when workflow fails | Additional data exported on failure |
+| `export_on_error` | Only on unexpected errors | Additional data exported on error |
+| `no_export` | Always | List of keys to block from export (`"*"` blocks all) |
+
+#### Export Examples
+
+```yaml
+---
+workflows:
+  deploy_with_status:
+    steps:
+      - call_function: kubernetes.deploy
+      - export:
+          deployment_id: $ctx.deployment_id
+          timestamp: '{{ now }}'
+      - export_on_success:
+          status: "deployed"
+          health_check_url: $ctx.health_url
+      - export_on_failure:
+          status: "failed"
+          rollback_available: true
+      - export_on_error:
+          status: "error"
+          error_detail: $ctx.error
+```
+
+#### Blocking Exports
+
+Use `no_export` to prevent sensitive or temporary data from leaking to parent contexts:
+
+```yaml
+---
+workflows:
+  process_secret:
+    steps:
+      - call_function: vault.get_token
+      - export:
+          result: $ctx.result
+      - no_export:
+          - vault_token
+          - temp_credential
+```
+
+Use `no_export: ["*"]` to block all exports from a workflow:
+
+```yaml
+---
+workflows:
+  internal_only:
+    no_export:
+      - "*"
+    steps:
+      - call_function: internal_operation
+```
+
+#### Cache Data Export
+
+The `*` suffix on export keys marks data that should be cached. When a cached workflow executes, data in keys ending with `*` is stored in the cache:
+
+```yaml
+---
+workflows:
+  cached_lookup:
+    cache_key: "myapp:data:{{ .ctx.key }}"
+    cache_ttl: "1h"
+    steps:
+      - call_function: fetch_data
+      - export:
+          result*: $ctx.fetched_data
+```
+
+When the cache is hit, the cached data is exported with the `*` suffix, and the `from_cache` label is set to `"true"`.
 
 ## Contextual Data
 Contextual data is the key to stitch different events, functions, drivers and workflows together.
@@ -685,7 +893,7 @@ workflows:
             - name: REPO
               value: https://github.com/honeydipper/honeydipper
             - name: BRANCH
-              value: DipperCL
+              value: v4
         - ...
 ```
 


### PR DESCRIPTION
## Summary

This PR updates the three core documentation files identified as high-priority gaps in Phase 1 of the documentation review.

## Changes

### `docs/configuration.md` (+273 lines)
- **New: Agents section** — Comprehensive documentation of the Agent configuration structure including Driver, Engine, SystemPrompt, Tools, CompactionPolicy, and ModelData fields
- **Agent subsections**: field reference table, compaction policy details, example configuration, tool building from sys_/wf_/ag_/mcp_ sources, session state tracking, and environment variables
- **New: Contexts section** — Documents built-in contexts (_default, _event), custom contexts, context inheritance with extends, and context data interpolation in workflows
- **Workflow reference fields**: Export control (export_on_success, export_on_failure, export_on_error, no_export with wildcard blocking), error handling defaults for steps/threads, and additional simple actions (call_agent, wait_agent, resume, detach)
- Updated DataSet struct to include Agents field

### `docs/workflow.md` (+193 lines)
- **New: Switch/Cases/Default** — Full documentation with examples including nested switches and template-based switch expressions
- **Expanded Hooks section** — Complete hook reference table (12 hooks: on_session, on_first_round, on_round, on_first_item, on_item, on_update, on_first_action, on_action, on_success, on_failure, on_error, on_exit), hook execution order diagrams, hook definition syntax, and hook context scoping rules
- **New: Export Control section** — Documents export, export_on_success, export_on_failure, export_on_error, no_export, wildcard blocking, and cache data export with the `*` suffix
- Added `detach` to simple actions list

### `docs/developer.md` (+163 lines)
- **Updated driver state machine** — Added draining and drained states with complete state transition diagram (loaded → alive → draining → drained, alive → stopping → completed)
- **New: Configuration Reload States table** — Documents hot reload, cold reload, crash recovery (3 retries, 30s backoff), and graceful shutdown behavior
- **New: Wire Protocol section** — Full protocol documentation with message format, envelope fields, label format, raw message example, and channels/subjects reference
- **New: RPC Call Variants table** — Documents all 5 RPC methods (Call, CallNoWait, CallRaw, CallRawNoWait, CallWithMessage)
- **New: Interruptible Handlers section** — Documents interruptible RPC handlers with example code for graceful cancellation
- **Updated module path** — All import paths now reference `github.com/honeydipper/honeydipper/v4/pkg/dipper`
- **New: Key Eventbus Subjects table** — Reference for all eventbus message subjects (message, command, return, return_interrupted, agent_command, agent_continue, agent_response, agent_workflow)

## Correlation to Phase 1 Findings

Addresses the following gaps identified in Phase 1:
- Agent system completely undocumented (CONTEXT.md §6)
- No Contexts documentation (CONTEXT.md §4.2)
- Incomplete workflow action/hook coverage
- Driver lifecycle missing draining/dracked states (CONTEXT.md §7)
- Outdated module paths
- Missing wire protocol details (CONTEXT.md §7.5)
- Missing RPC call variant documentation (CONTEXT.md §8)
- No export control documentation