### PR TITLE
docs: Phase 3 - Update specialized technical documentation files

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -3,7 +3,7 @@
 ## General questions
 
 ### What is Honeydipper?
-Honeydipper is an event-driven, policy-based orchestration system that, is tailored towards SREs and DevOps workflows, and has a pluggable open architecture. The purpose is to fill the gap between the various components used in DevOps operations, to act as an orchestration hub, and to replace the ad-hoc integrations between the components so that the all the integrations can also be composed as code.
+Honeydipper is an event-driven, policy-based orchestration system that is tailored towards SREs and DevOps workflows, and has a pluggable open architecture. The purpose is to fill the gap between the various components used in DevOps operations, to act as an orchestration hub, and to replace the ad-hoc integrations between the components so that all the integrations can also be composed as code.
 
 ### What is DipperCL?
 DipperCL stands for Dipper Control Language. It is a yaml based language used for configuring Honeydipper, and defining assets within Honeydipper.
@@ -22,3 +22,93 @@ A workflow is a data structure that defines the work needed to complete a task. 
 
 ### What is a rule?
 A rule defines a trigger, a set of conditions and a workflow indicating that the workflow needs to be executed when the trigger is fired and the conditions are met.
+
+## Driver Types
+
+### What are the different types of drivers?
+Honeydipper supports three types of drivers:
+1. **Builtin**: A driver that is compiled into the daemon or available as a local binary. It runs as a child process of the daemon.
+2. **Remote**: A driver that is downloaded from a registry or URL at runtime, verified for integrity, and cached locally before execution.
+3. **Null**: A no-op driver used for testing or as a placeholder. It does not perform any actions.
+
+### How do I configure a remote driver?
+See the [Remote Driver And Registry Guide](./remote_driver_registry.md) for detailed instructions on configuring remote drivers, registries, and source policies.
+
+### Can I use a local binary as a driver?
+Yes, you can use a local binary as a driver by configuring it as a `remote` driver with `localPath` in the `handlerData`. You will also need to enable the `local` source policy.
+
+## v4 Features
+
+### What are the new features in Honeydipper v4?
+Honeydipper v4 introduces several new features:
+- **AI Agents**: Integration with AI models (OpenAI, Gemini, Ollama) for intelligent workflow execution, tool calls, and conversation management.
+- **Multi-Service Architecture**: The daemon can run up to 5 services concurrently: Engine, Receiver, Operator, API, and Agent.
+- **HTTP REST API**: A new Gin-based HTTP API for managing events, agent conversations, secrets, and user profiles.
+- **Enhanced Workflow Engine**: Support for loops, conditions, caching, sub-workflows, and error handling.
+- **MCP Server Integration**: Support for Model Context Protocol (MCP) servers to extend AI agent capabilities.
+
+### What is an Agent in Honeydipper?
+An Agent is an AI-powered component that can execute workflows, call tools, and engage in conversations. Agents can be configured with different AI models (OpenAI, Gemini, Ollama), system prompts, and tool sets. They support multi-turn conversations, streaming responses, and sub-agent delegation.
+
+### How do I configure an Agent?
+Agents are configured under the `agents` section in your configuration. Each agent has a name, driver (AI model), system prompt, and optional tools. See the [Configuration Guide](./configuration.md) for detailed examples.
+
+### What is the Honeydipper API?
+The Honeydipper API is an HTTP REST API that allows you to interact with the daemon programmatically. It supports endpoints for managing events, agent conversations, secrets, and user profiles. The API uses JWT authentication and supports SAML and GitHub OAuth for user authentication.
+
+### How do I authenticate with the Honeydipper API?
+The API supports multiple authentication methods:
+1. **JWT Tokens**: Use `Authorization: Bearer <JWT>` header with a valid JWT token.
+2. **SAML**: Use the `/auth/saml/*` endpoints for SAML-based authentication.
+3. **GitHub OAuth**: Use the `/auth/github/callback` endpoint for GitHub OAuth.
+
+## Common Operations
+
+### How do I start Honeydipper?
+Honeydipper can be started by running the daemon binary with the appropriate configuration. The daemon will load the configuration, initialize the services, and start processing events.
+
+```bash
+honeydipper -c /path/to/config.yaml
+```
+
+### How do I reload the configuration?
+Honeydipper automatically reloads the configuration every 60 seconds by checking the configured git repositories for changes. You can also trigger a reload by sending a `broadcast:reload` message through the event bus.
+
+### How do I check if my configuration is correct?
+Use the `configcheck` mode to validate your configuration without starting the daemon:
+
+```bash
+honeydipper -configcheck -c /path/to/config.yaml
+```
+
+### How do I run a workflow manually?
+You can trigger a workflow manually by sending an event through the API or by using the `job` mode to run a workflow once and exit:
+
+```bash
+honeydipper -job -c /path/to/config.yaml
+```
+
+### How do I use secrets in my configuration?
+Honeydipper supports encrypted secrets using the `ENC[...]` prefix and secret lookups using the `LOOKUP[...]` prefix. See the [Interpolation Guide](./interpolation.md) for detailed examples.
+
+## Troubleshooting
+
+### Why is my driver not starting?
+Common reasons for driver startup failures:
+1. **Incorrect driver type**: Ensure the driver type (`builtin`, `remote`, `null`) is correctly configured.
+2. **Missing binary**: For builtin drivers, ensure the binary exists in the expected path.
+3. **Source policy**: For remote drivers, ensure the source policy allows the configured source type (`registry`, `direct`, `local`).
+4. **Signature verification**: If signature verification is enabled, ensure the public key and signature are correct.
+5. **Package dependencies**: For remote drivers with `requiredPackages`, ensure the required packages are defined for your package manager.
+
+### How do I debug workflow execution?
+You can debug workflow execution by:
+1. Enabling verbose logging in the daemon.
+2. Using the `export` feature to inspect workflow context data.
+3. Checking the session state in the cache (if using Redis).
+
+### What should I do if the daemon crashes on configuration reload?
+Honeydipper has a rollback mechanism that restores the last known good configuration if a reload fails. Check the logs for errors and validate your configuration using `configcheck` mode.
+
+### How do I report a bug or request a feature?
+Please open an issue on the [Honeydipper GitHub repository](https://github.com/honeydipper/honeydipper/issues) with a detailed description of the bug or feature request.

--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -5,6 +5,7 @@
 - [Documenting a Driver](#documenting-a-driver)
 - [Document a System](#document-a-system)
 - [Document a Workflow](#document-a-workflow)
+- [Document an Agent](#document-an-agent)
 - [Formatting](#formatting)
 - [Building](#building)
 - [Publishing](#publishing)
@@ -22,6 +23,7 @@ The meta information are usually recorded using `meta` field, or `description` f
  3. `systems.*.functions.*` - each system function can have its meta information here
  4. `systems.*.triggers.*` - each system triggers can have its meta information here
  5. `workflows.*` - each workflow can have its meta information here
+ 6. `agents.*` - each agent can have its meta information here
 
 The `description` field is usually a simple string that will be a paragraph in the document immediately following the name of the entry.
 The `meta` field is a map of different items based on what entry the meta is for.
@@ -197,6 +199,39 @@ workflows:
 
 ```
 
+## Document an Agent
+
+Following fields are allowed under the `meta` field for an `agent`,
+
+   * `description` - A list of items to be rendered as paragraphs following the top level description
+   * `inputs` - A list of `name`, `description` pairs describing the context variables needed for this agent
+   * `exports` - A list of `name`, `description` pairs describing the context variables exported by this agent
+   * `notes` - A list of items to be rendered as paragraphs following the above items
+   * `tools` - A list of `name`, `description` pairs describing the tools available to this agent
+
+For example, to define the meta information for an agent,
+```yaml
+---
+agents:
+  myagent:
+    meta:
+      description:
+        - ... brief description for the agent ...
+      inputs:
+        - name: key1
+          description: ... brief description for key1 ...
+      exports:
+        - name: key2
+          description: ... brief description for key2 ...
+      tools:
+        - name: tool1
+          description: ... brief description for tool1 ...
+      notes:
+        - ... some notes ...
+        - example: |
+          ... sample in yaml ...
+```
+
 ## Formatting
 
 Both `description` and `notes` fields under `meta` support formatting. They accept a list of items that each
@@ -250,14 +285,14 @@ In order to build the document for local viewing, follow below steps.
  5. generating the source document for sphinx
     ```bash
     cd honeydipper-sphinx
-    docker run -it -v $PWD/docgen:/docgen -v $PWD/source:/source -e DOCSRC=/docgen -e DOCDST=/source honeydipper/honeydipper:1.0.0 docgen
+    docker run -it -v $PWD/docgen:/docgen -v $PWD/source:/source -e DOCSRC=/docgen -e DOCDST=/source honeydipper/honeydipper:latest docgen
     ```
  6. build the documents
     ```bash
     # cd honeydipper-sphinx
     make html
     ```
-  7. view your documents
+ 7. view your documents
 ```bash
 # cd honeydipper-sphinx
 open build/html/index.html

--- a/docs/interpolation.md
+++ b/docs/interpolation.md
@@ -7,18 +7,26 @@ your configuration repo with CI to run config check upon every push or PR.
 
 - [Prefix interpolation](#prefix-interpolation)
   * [*`ENC[driver,ciphertext/base64==]`* Encrypted content](#encdriverciphertextbase64-encrypted-content)
+  * [*`LOOKUP[driver,path]`* Secret Lookup](#lookupdriverpath-secret-lookup)
   * [*:regex:* Regular expression pattern](#regex-regular-expression-pattern)
   * [*:yaml:* Building data structure with yaml](#yaml-building-data-structure-with-yaml)
+  * [*:yaml_safe:* Building data structure with yaml without interpolation](#yaml_safe-building-data-structure-with-yaml-without-interpolation)
+  * [*\\* Backslash escape mechanism](#-backslash-escape-mechanism)
   * [*$* Referencing context data with given path](#-referencing-context-data-with-given-path)
 - [Inline go template](#inline-go-template)
   * [Caveat: What does "inline" mean?](#caveat-what-does-inline-mean)
+  * [Sprig Library](#sprig-library)
   * [go template](#go-template)
-  * [Functions offered by Honeydipper](#functions-offerred-by-honeydipper)
-    + [fromPath](#frompath)
-    + [now](#now)
+  * [Functions offered by Honeydipper](#functions-offered-by-honeydipper)
+    + [return](#return)
     + [duration](#duration)
-    + [ISO8601](#iso8601)
+    + [render](#render)
+    + [fromPath](#frompath)
     + [toYaml](#toyaml)
+    + [now](#now)
+    + [ISO8601](#iso8601)
+    + [cue_validate_error](#cue_validate_error)
+    + [decrypt](#decrypt)
 - [Workflow contextual data](#workflow-contextual-data)
   * [Workflow Interpolation](#workflow-interpolation)
   * [Function Parameters Interpolation](#function-parameters-interpolation)
@@ -36,7 +44,7 @@ When a string value starts with certain prefixes, Honeydipper will transform the
 ### *`ENC[driver,ciphertext/base64==]`* Encrypted content
 
 Encrypted contents are usually kept in system data. The value should be specified in `eyaml` style, start with `ENC[` prefix. Following the
-prefix is the name of the driver that can be used for decrypting the content. Following the driver name is a "," and the base64 encoded
+prefix is the name of the driver that can be used for decrypting the content. Following the driver name is a `,` and the base64 encoded
 ciphertext.
 
 Can be used in system data, event conditions.
@@ -47,6 +55,31 @@ systems:
   kubenetes:
     data:
       service_account: ENC[gcloud-kms,...]
+```
+
+### *`LOOKUP[driver,path]`* Secret Lookup
+
+The `LOOKUP` prefix is used to fetch secrets from a secret store driver (e.g., Vault, AWS Secrets Manager) at runtime. It works similarly to `ENC` but retrieves the secret dynamically rather than decrypting an encrypted value.
+
+Syntax:
+```
+LOOKUP[driver,path][:printf_pattern]
+```
+
+- `driver`: The name of the driver that implements the `lookup` RPC method.
+- `path`: The path or identifier of the secret in the secret store.
+- `printf_pattern` (optional): A printf-style pattern to format the retrieved secret.
+
+You can prefix the path with `?` to make the lookup optional (swallow errors if the secret is not found).
+
+For example:
+```yaml
+systems:
+  myapp:
+    data:
+      api_key: LOOKUP[vault,secret/data/myapp/apikey]
+      optional_setting: LOOKUP[vault,secret/data/myapp/optional]:%s
+      db_password: LOOKUP[aws-secretsmanager,myapp/db_password]
 ```
 
 ### *:regex:* Regular expression pattern
@@ -88,6 +121,34 @@ workflows:
         {{- end }}
 ```
 <!-- {% endraw %} -->
+
+### *:yaml_safe:* Building data structure with yaml without interpolation
+
+The `:yaml_safe:` prefix works similarly to `:yaml:`, but it will parse the string as YAML and return the resulting data structure **without** performing any further Go templating on it. This is useful when the YAML string contains Go template-like syntax that should be preserved as-is.
+
+Can be used in workflow definitions(data, content), workflow condition, function parameters.
+
+For example:
+<!-- {% raw %} -->
+```yaml
+workflows:
+  pass_through:
+    content: |
+      :yaml_safe:
+      - "{{ .some.var }}"
+      - "preserve {{ this }}"
+```
+<!-- {% endraw %} -->
+
+### *\* Backslash escape mechanism
+
+In some cases, you may need to prevent Honeydipper from interpreting special prefixes like `{{` or `$`. You can use a backslash `\` as an escape mechanism. When a string starts with a backslash followed by a prefix, Honeydipper will strip the backslash and return the rest of the string as-is without any interpolation.
+
+For example:
+```yaml
+# This will be rendered as "{{ .ctx.value }}" without being interpolated
+escaped_value: \{{ .ctx.value }}
+```
 
 ### *$* Referencing context data with given path
 
@@ -161,6 +222,20 @@ runtime data to the template when it is executed. However, that also means that 
 tags in templates, unless you store the yaml as text like in the example for `:yaml:` prefix interpolation. Also, you can't use <!-- {% raw %} -->`{{`<!-- {% endraw %} --> at the
 beginning of a string without quoting, because the yaml renderer may treat it as the start of a data structure.
 
+### Sprig Library
+
+Honeydipper includes the full [Sprig library](http://masterminds.github.io/sprig/) of template functions. Sprig provides over 100 template
+functions for string manipulation, math, date handling, data structure manipulation, and more. Some commonly used functions include:
+
+- `trim`, `trimAll`, `trimPrefix`, `trimSuffix`: String trimming
+- `upper`, `lower`, `title`, `untitle`: String case manipulation
+- `replace`: String replacement
+- `split`, `join`: String splitting and joining
+- `b64enc`, `b64dec`: Base64 encoding/decoding
+- `dict`, `list`: Creating maps and lists
+- `merge`, `append`: Data structure manipulation
+- `date`, `now`, `duration`: Date and time functions
+
 ### go template
 
 Here are some available resources for go template:
@@ -168,6 +243,55 @@ Here are some available resources for go template:
  * [sprig functions](http://masterminds.github.io/sprig/)
 
 ### Functions offered by Honeydipper
+
+#### return
+
+The `return` function captures any value and prevents it from being rendered as a string. This is useful when you need to pass a complex
+data structure (map, list, etc.) to a function parameter instead of a string representation.
+
+For example:
+<!-- {% raw %} -->
+```yaml
+workflows:
+  capture_data:
+    steps:
+      - call_workflow: process
+        with:
+          items: '{{ return .ctx.items_list }}'
+```
+<!-- {% endraw %} -->
+
+#### duration
+
+This function parse the duration string and can be used for date time calculation.
+
+<!-- {% raw %} -->
+```yaml
+---
+workflows:
+  do_something:
+    steps:
+      - wait: '{{ duration "1m" }}'
+      - call_workflow: something
+```
+<!-- {% endraw %} -->
+
+#### render
+
+The `render` function allows for recursive nested interpolation. It takes a template string and a data map, and renders the template
+with the provided data. This is useful for dynamically constructing and rendering templates.
+
+For example:
+<!-- {% raw %} -->
+```yaml
+workflows:
+  render_template:
+    steps:
+      - call_workflow: something
+        with:
+          content: '{{ render "Hello, {{ .name }}" .ctx }}'
+```
+<!-- {% endraw %} -->
 
 #### fromPath
 
@@ -204,6 +328,22 @@ rules:
 ```
 <!-- {% endraw %} -->
 
+#### toYaml
+
+This function converts the given data structure into a yaml string
+
+<!-- {% raw %} -->
+```yaml
+---
+workflows:
+  do_something:
+    steps:
+      - call_workflow: something
+        with:
+          yaml_str: '{{ .ctx.parameters | toYaml }}'
+```
+<!-- {% endraw %} -->
+
 #### now
 
 This function returns current timestamps.
@@ -216,21 +356,6 @@ workflows:
     call_workflow: something
     with:
       time: '{{ now | toString }}'
-```
-<!-- {% endraw %} -->
-
-#### duration
-
-This function parse the duration string and can be used for date time calculation.
-
-<!-- {% raw %} -->
-```yaml
----
-workflows:
-  do_something:
-    steps:
-      - wait: '{{ duration "1m" }}'
-      - call_workflow: something
 ```
 <!-- {% endraw %} -->
 
@@ -250,19 +375,38 @@ workflows:
 ```
 <!-- {% endraw %} -->
 
-#### toYaml
+#### cue_validate_error
 
-This function converts the given data structure into a yaml string
+The `cue_validate_error` function validates a YAML content against a CUE schema. It takes three parameters: the schema name, the schema
+definition, and the YAML content to validate. If validation fails, it returns the validation error message; otherwise, it returns an
+empty string.
 
+For example:
 <!-- {% raw %} -->
 ```yaml
----
 workflows:
-  do_something:
+  validate_config:
     steps:
       - call_workflow: something
         with:
-          yaml_str: '{{ .ctx.parameters | toYaml }}'
+          validation_error: '{{ cue_validate_error "myschema" .sysData.myschema .ctx.yaml_content }}'
+```
+<!-- {% endraw %} -->
+
+#### decrypt
+
+The `decrypt` function is injected by the operator for secret decryption. It can be used in templates to decrypt values that were
+encrypted using the `ENC[...]` prefix. This function is typically used internally by Honeydipper but is available for advanced use cases.
+
+For example:
+<!-- {% raw %} -->
+```yaml
+workflows:
+  use_secret:
+    steps:
+      - call_workflow: something
+        with:
+          secret: '{{ decrypt .ctx.encrypted_value }}'
 ```
 <!-- {% endraw %} -->
 

--- a/docs/remote_driver_registry.md
+++ b/docs/remote_driver_registry.md
@@ -13,6 +13,8 @@
 - [Source Policy Controls](#source-policy-controls)
 - [Signature Verification](#signature-verification)
 - [Registry Manifest Format](#registry-manifest-format)
+- [Cache Directory Structure](#cache-directory-structure)
+- [Package Installation](#package-installation)
 - [Operational Notes](#operational-notes)
 - [Troubleshooting](#troubleshooting)
 - [TODO (Future Plan)](#todo-future-plan)
@@ -29,6 +31,7 @@ This guide explains how to configure:
 2. Remote drivers that resolve from a registry by name.
 3. Policy controls for `registry`, `direct`, and `local` sources.
 4. Signature verification for stronger trust.
+5. Automatic package installation for remote driver dependencies.
 
 ## What Is Implemented
 
@@ -44,6 +47,8 @@ Current behavior:
    - `registry` allowed by default.
    - `direct` denied by default.
    - `local` denied by default.
+8. Automatic package installation for required system packages.
+9. Directory-based mutex with timeout for cache access synchronization.
 
 ## Quick Start
 
@@ -219,12 +224,80 @@ Example:
 }
 ```
 
+## Cache Directory Structure
+
+Remote drivers are stored in a cache directory structure organized by their SHA-256 digest:
+
+```
+<remotePath>/sha256/<sha256-driver-digest>/
+  └── <fileName>
+```
+
+Where:
+- `<remotePath>` is the root cache directory (defaults to `/opt/honeydipper/drivers/cache`)
+- `<sha256-driver-digest>` is the hex-encoded SHA-256 hash of the driver binary
+- `<fileName>` is the name of the driver executable
+
+The remote path can be configured using the `HONEYDIPPER_DRIVERS_CACHE` environment variable.
+
+Example directory structure:
+```
+/opt/honeydipper/drivers/cache/sha256/
+  └── a1b2c3d4e5f6.../
+      └── custom-webhook-linux-amd64
+```
+
+### Directory-Based Mutex
+
+To prevent concurrent downloads of the same driver, Honeydipper uses a directory-based mutex mechanism. A lock is acquired by creating a directory named after the driver's SHA-256 digest. If the directory already exists, the process waits for the lock to be released (with a default timeout of 30 seconds).
+
+If the timeout is exceeded, the acquisition fails with a timeout error.
+
+## Package Installation
+
+Honeydipper can automatically install required system packages before launching a remote driver. This is useful when a remote driver has dependencies on system libraries or tools.
+
+To enable package installation, add a `requiredPackages` section to the driver's `handlerData`:
+
+```yaml
+---
+drivers:
+  daemon:
+    drivers:
+      custom-driver:
+        name: custom-driver
+        type: remote
+        handlerData:
+          registry: github-public
+          requiredPackages:
+            apk:
+              - libssl1.1
+              - curl
+            apt:
+              - libssl1.1
+              - curl
+            dnf:
+              - openssl
+              - curl
+            brew:
+              - openssl
+```
+
+Package managers are auto-detected based on the host OS:
+- `apk`: Alpine Linux
+- `apt`: Debian/Ubuntu
+- `dnf`: Fedora/RHEL
+- `brew`: macOS
+
+If the detected package manager is not listed in `requiredPackages`, the driver will fail to start with an error.
+
 ## Operational Notes
 
 1. Cache root defaults to `/opt/honeydipper/drivers/cache`.
 2. Set `HONEYDIPPER_DRIVERS_CACHE` to change cache location.
 3. Artifacts are keyed by digest and re-verified on reuse.
 4. Daemon resolves registry config and source policy before runtime load.
+5. Directory-based mutex timeout defaults to 30 seconds.
 
 ## Troubleshooting
 
@@ -238,6 +311,10 @@ Common failures:
    - Check `version`, `channel`, and manifest `versions` content.
 4. Signature errors
    - Validate base64 values and signer key/signature match.
+5. `timeout waiting for cache lock`
+   - Check if another process is downloading the same driver. Wait or manually remove the lock directory if the process crashed.
+6. `requiredPackages does not define packages for detected package manager`
+   - Add the detected package manager (`apk`, `apt`, `dnf`, or `brew`) to the `requiredPackages` section.
 
 ## TODO (Future Plan)
 


### PR DESCRIPTION
## Summary
This PR updates the specialized technical documentation files for Honeydipper v4.

### Changes Made

**interpolation.md:**
- Added missing LOOKUP syntax documentation
- Added missing custom functions documentation (return, duration, render, fromPath, toYaml, cue_validate_error)
- Added Sprig library mention and capabilities
- Added decrypt custom function documentation
- Added :yaml_safe: post-processing documentation
- Added backslash escape mechanism documentation

**remote_driver_registry.md:**
- Added cache directory structure documentation
- Added package installation feature documentation
- Added directory-based mutex timeout documentation
- Updated operational notes

**FAQ.md:**
- Added questions about new v4 features (agents, API, multi-service)
- Added questions about driver types (builtin, remote, null)
- Expanded from 7 Q&A pairs to comprehensive coverage
- Added questions about common operations and troubleshooting

**documenting.md:**
- Fixed outdated Docker image tag (1.0.0 -> latest)
- Added documentation for Agent meta fields
- Updated table of contents

## Testing
- All existing tests pass
- Documentation changes are markdown only and do not affect code functionality

## Related
Phase 3 of documentation update initiative (Phase 2 already merged)