### PR TITLE
feat: embed sub-agent convo_id in ToolCall for UI navigation

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/honeydipper/honeydipper/v4/internal/config"
@@ -536,6 +537,18 @@ func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 		s.NewPendingContent = s.NewPendingContent || s.Agent.ShouldEmitThoughts && len(agentMsg.Thoughts) > 0
 
 		return
+	}
+
+	// Populate ConvoID on agent tool calls so the UI can render a
+	// "View Sub-Agent Conversation" link immediately when the tool call
+	// card appears, without waiting for the result.
+	for i, tc := range agentMsg.ToolCalls {
+		if strings.HasPrefix(tc.FuncName, "ag__") {
+			oneShot, _ := dipper.GetMapDataBool(tc.Params, "one_shot")
+			if !oneShot {
+				agentMsg.ToolCalls[i].ConvoID = fmt.Sprintf("%s-%s", s.ConvoID, tc.FuncName[len("ag__"):])
+			}
+		}
 	}
 
 	s.appendConvoHistory(*agentMsg)

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -47,6 +47,7 @@ type Tool struct {
 type ToolCall struct {
 	FuncName string
 	Params   map[string]interface{}
+	ConvoID  string // populated for agent tool calls (ag__*) to link to the sub-agent's conversation
 }
 
 // State reports the runtime state of an agent session at the end of a turn.


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->
Add ConvoID field to ToolCall struct so the sub-agent's conversation ID is embedded in the tool call data that flows through conversation history. This allows the UI to render a 'View Sub-Agent Conversation' link immediately when the tool call card appears, without waiting for the result.

Changes:
- pkg/agent/types.go: Add ConvoID string field to ToolCall struct
- internal/agent/agent_session.go: In processAgentMessage(), populate ConvoID on ag__ tool calls before appendConvoHistory() stores the message in Redis. Uses the same convo_id generation logic as StartAgentCall() (fmt.Sprintf('%s-%s', parentConvoID, subAgentName)). one_shot tool calls are skipped (empty ConvoID). Non-agent tool calls are unaffected.

#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
