### PR TITLE
feat: embed archived conversation ID in compaction summary

### DIFF
--- a/internal/agent/agent_compaction.go
+++ b/internal/agent/agent_compaction.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -86,6 +87,12 @@ func (s *AgentSession) handleCompactionResult(c AgentToolCall, toolResults []map
 				preserve = n
 			}
 		}
+	}
+
+	// Append archived conversation marker to summary text for UI navigation.
+	// This allows the UI to provide a direct link to the archived conversation.
+	if compactID != "" {
+		summaryText += fmt.Sprintf("\n<!-- archived_convo: %s -->", compactID)
 	}
 
 	// Build the new history: summary as a system message, then the preserved tail messages.


### PR DESCRIPTION
## Summary
When a conversation is compacted, append a structured HTML comment marker to the summary system message containing the archived conversation ID. This enables the UI to render a direct navigation link to the archived conversation from the summary message card.

## Changes
- `internal/agent/agent_compaction.go`: In `handleCompactionResult()`, after building `summaryText` and before creating `newHistory`, append `\n<!-- archived_convo: compactID -->` when `compactID` is non-empty.
- Added `fmt` import for `Sprintf` formatting.

## Testing
- All existing tests pass
- Linting passes with no issues

Part of Phase 1: Backend changes for compaction navigation enhancement.