### PR TITLE
fix: clear in-memory history after archiving in forget_history block

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -266,9 +266,18 @@ func (s *AgentSession) initNewSession(id string, msg *dipper.Message, store Agen
 		if len(s.history) > 0 {
 			forgetHistory, _ := dipper.GetMapDataBool(msg.Payload, "forget_history")
 			if forgetHistory {
-				dipper.Must(cs.archiveConvo(store))
+				archivedKey := dipper.Must(cs.archiveConvo(store)).(string)
+				s.history = nil
 				dipper.Must(s.store.Call("cache", "del", map[string]interface{}{
 					"key": ConvoHistoryKeyPrefix + s.ConvoID,
+				}))
+				markerMsg := AgentMessage{Role: RoleSystem, Content: fmt.Sprintf("<!-- archived_convo: %s -->", archivedKey)}
+				s.history = append(s.history, markerMsg)
+				convoTTL, _ := time.ParseDuration(ConvoStreamTTL)
+				dipper.Must(s.store.Call("cache", "rpush", map[string]interface{}{
+					"key":   ConvoHistoryKeyPrefix + s.ConvoID,
+					"value": string(dipper.SerializeContent(markerMsg)),
+					"ttl":   float64(convoTTL),
 				}))
 			}
 		}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -11,8 +11,10 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -2179,4 +2181,226 @@ func TestSetup_PanicsIfAgentMissing(t *testing.T) {
 	assert.Panics(t, func() {
 		s.setup(msg, store, false)
 	})
+}
+
+func TestSetup_ForgetHistory_ClearsMemory(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["someagent"] = config.Agent{Name: "someagent"}
+
+	// Pre-create a ConvoState with Generation=0 and Agent set
+	cs := &ConvoState{
+		ConvoID:    "convo-abc",
+		Generation: 0,
+		Agent:      &config.Agent{Name: "someagent"},
+	}
+	store.resp["cache:load:"+ConvoStateKeyPrefix+"convo-abc"] = mustMarshalJSON(cs)
+
+	// Pre-seed history so that s.history will be populated by loadConvoHistory
+	prevHistory := []AgentMessage{
+		{Role: RoleSystem, Content: "You are a helpful assistant"},
+		{Role: RoleUser, Content: "Hello"},
+		{Role: RoleAgent, Content: "Hi there!"},
+		{Role: RoleUser, Content: "What's the weather?"},
+	}
+	store.resp["cache:lrange:"+ConvoHistoryKeyPrefix+"convo-abc"] = mustMarshalJSON(prevHistory)
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name": "someagent",
+		},
+		Payload: map[string]interface{}{
+			"type":           AgentSessionTypeChatTurn,
+			"convo_id":       "convo-abc",
+			"forget_history": true,
+			"text":           "start fresh",
+		},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store, false)
+
+	// s.history should be cleared and contain ONLY the marker
+	assert.Len(t, s.history, 1, "history should contain only the marker message")
+	assert.Equal(t, RoleSystem, s.history[0].Role)
+	assert.Contains(t, s.history[0].Content, "archived_convo:")
+
+	// Verify the old messages are NOT in history
+	for _, m := range s.history {
+		assert.NotEqual(t, "Hello", m.Content, "old user message should not be in history")
+		assert.NotEqual(t, "Hi there!", m.Content, "old assistant message should not be in history")
+		assert.NotEqual(t, "What's the weather?", m.Content, "old user message should not be in history")
+	}
+
+	// Verify cache:del and cache:rpush were called
+	assert.True(t, store.hasCall("cache:del"), "cache:del should be called")
+	assert.True(t, store.hasCall("cache:rpush"), "cache:rpush should be called to persist the marker")
+}
+
+func TestSetup_ForgetHistory_InjectsMarker(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["someagent"] = config.Agent{Name: "someagent"}
+
+	cs := &ConvoState{
+		ConvoID:    "convo-xyz",
+		Generation: 0,
+		Agent:      &config.Agent{Name: "someagent"},
+	}
+	store.resp["cache:load:"+ConvoStateKeyPrefix+"convo-xyz"] = mustMarshalJSON(cs)
+
+	prevHistory := []AgentMessage{
+		{Role: RoleUser, Content: "previous message 1"},
+		{Role: RoleAgent, Content: "previous response 1"},
+	}
+	store.resp["cache:lrange:"+ConvoHistoryKeyPrefix+"convo-xyz"] = mustMarshalJSON(prevHistory)
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name": "someagent",
+		},
+		Payload: map[string]interface{}{
+			"type":           AgentSessionTypeChatTurn,
+			"convo_id":       "convo-xyz",
+			"forget_history": true,
+			"text":           "start fresh",
+		},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store, false)
+
+	// Only the marker should be in history
+	require.Len(t, s.history, 1)
+	assert.Equal(t, RoleSystem, s.history[0].Role)
+	assert.True(t, strings.HasPrefix(s.history[0].Content, "<!-- archived_convo: "))
+	assert.True(t, strings.HasSuffix(s.history[0].Content, " -->"))
+}
+
+func TestSetup_ForgetHistory_MarkerFormat(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["someagent"] = config.Agent{Name: "someagent"}
+
+	cs := &ConvoState{
+		ConvoID:    "convo-fmt",
+		Generation: 0,
+		Agent:      &config.Agent{Name: "someagent"},
+	}
+	store.resp["cache:load:"+ConvoStateKeyPrefix+"convo-fmt"] = mustMarshalJSON(cs)
+
+	prevHistory := []AgentMessage{
+		{Role: RoleUser, Content: "a message"},
+	}
+	store.resp["cache:lrange:"+ConvoHistoryKeyPrefix+"convo-fmt"] = mustMarshalJSON(prevHistory)
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name": "someagent",
+		},
+		Payload: map[string]interface{}{
+			"type":           AgentSessionTypeChatTurn,
+			"convo_id":       "convo-fmt",
+			"forget_history": true,
+			"text":           "start fresh",
+		},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store, false)
+
+	require.Len(t, s.history, 1)
+	content := s.history[0].Content
+
+	// Expected: <!-- archived_convo: convo-fmt_g1 -->
+	expected := fmt.Sprintf("<!-- archived_convo: %s_g%d -->", "convo-fmt", 1)
+	assert.Equal(t, expected, content)
+
+	// Also verify the generation number via parsing
+	parts := strings.Split(content, "_g")
+	require.Len(t, parts, 2)
+	genStr := strings.TrimSuffix(parts[1], " -->")
+	gen, err := strconv.Atoi(genStr)
+	require.NoError(t, err)
+	assert.Equal(t, 1, gen)
+}
+
+func TestSetup_ForgetHistory_MultipleGenerations(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["someagent"] = config.Agent{Name: "someagent"}
+
+	// Generation=1 means _g1 was already archived; next archive should be _g2
+	cs := &ConvoState{
+		ConvoID:    "convo-multi",
+		Generation: 1,
+		Agent:      &config.Agent{Name: "someagent"},
+	}
+	store.resp["cache:load:"+ConvoStateKeyPrefix+"convo-multi"] = mustMarshalJSON(cs)
+
+	prevHistory := []AgentMessage{
+		{Role: RoleUser, Content: "some old message"},
+		{Role: RoleAgent, Content: "some old response"},
+	}
+	store.resp["cache:lrange:"+ConvoHistoryKeyPrefix+"convo-multi"] = mustMarshalJSON(prevHistory)
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name": "someagent",
+		},
+		Payload: map[string]interface{}{
+			"type":           AgentSessionTypeChatTurn,
+			"convo_id":       "convo-multi",
+			"forget_history": true,
+			"text":           "start fresh",
+		},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store, false)
+
+	require.Len(t, s.history, 1)
+	content := s.history[0].Content
+
+	// Should be _g2 since Generation was already 1
+	expected := "<!-- archived_convo: convo-multi_g2 -->"
+	assert.Equal(t, expected, content)
+}
+
+func TestSetup_NoForgetHistory_NoMarker(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["someagent"] = config.Agent{Name: "someagent"}
+
+	cs := &ConvoState{
+		ConvoID:    "convo-noforget",
+		Generation: 0,
+		Agent:      &config.Agent{Name: "someagent"},
+	}
+	store.resp["cache:load:"+ConvoStateKeyPrefix+"convo-noforget"] = mustMarshalJSON(cs)
+
+	prevHistory := []AgentMessage{
+		{Role: RoleSystem, Content: "You are helpful"},
+		{Role: RoleUser, Content: "Hello"},
+		{Role: RoleAgent, Content: "Hi!"},
+	}
+	store.resp["cache:lrange:"+ConvoHistoryKeyPrefix+"convo-noforget"] = mustMarshalJSON(prevHistory)
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name": "someagent",
+		},
+		Payload: map[string]interface{}{
+			"type":     AgentSessionTypeChatTurn,
+			"convo_id": "convo-noforget",
+			"text":     "continue chat",
+			// No forget_history field
+		},
+	}
+
+	s := &AgentSession{}
+	s.setup(msg, store, false)
+
+	// History should be loaded as-is from cache without modification
+	assert.Len(t, s.history, 3)
+	assert.Equal(t, "Hello", s.history[1].Content)
+	assert.Equal(t, "Hi!", s.history[2].Content)
+
+	// No cache:del should be called
+	assert.False(t, store.hasCall("cache:del"), "cache:del should NOT be called without forget_history")
 }


### PR DESCRIPTION
## Bug

In `internal/agent/agent_session.go`, the `initNewSession` method's `forget_history` block had a bug: after calling `cs.archiveConvo(store)` and deleting the Redis history key, the in-memory `s.history` was NOT cleared. This meant sub-agents with `forget_history=true` still had access to the "forgotten" history during their first turn.

## Fix

In `internal/agent/agent_session.go`:
- Capture the archived key returned by `archiveConvo()`
- Set `s.history = nil` to clear in-memory history after archiving
- Inject a system marker message (`<!-- archived_convo: <key> -->`) so the conversation context preserves a reference to the archived history
- Persist the marker to the Redis cache

## Tests

Added 5 new tests in `internal/agent/agent_test.go`:
- `TestSetup_ForgetHistory_ClearsMemory` — verifies history is cleared and only marker remains
- `TestSetup_ForgetHistory_InjectsMarker` — verifies marker prefix/suffix format
- `TestSetup_ForgetHistory_MarkerFormat` — verifies exact marker format with generation number
- `TestSetup_ForgetHistory_MultipleGenerations` — verifies generation increment (_g2 after _g1)
- `TestSetup_NoForgetHistory_NoMarker` — verifies no clearing when forget_history is not set

All 93 tests pass. Linting clean.