### PR TITLE
fix: protect daemon.Emitters map from concurrent access

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -27,8 +27,34 @@ var ShuttingDown bool
 // Children keeps track of the child go routines in the daemon.
 var Children = &sync.WaitGroup{}
 
+// emittersLock protects concurrent access to the Emitters map.
+var emittersLock sync.Mutex
+
 // Emitters contains a group of metrics emitter for sending metrics to external monitoring systems.
 var Emitters = map[string]Emitter{}
+
+// GetEmitter safely retrieves an emitter from the Emitters map.
+func GetEmitter(name string) (Emitter, bool) {
+	emittersLock.Lock()
+	defer emittersLock.Unlock()
+	emitter, ok := Emitters[name]
+
+	return emitter, ok
+}
+
+// SetEmitter safely sets an emitter in the Emitters map.
+func SetEmitter(name string, emitter Emitter) {
+	emittersLock.Lock()
+	defer emittersLock.Unlock()
+	Emitters[name] = emitter
+}
+
+// DeleteEmitter safely deletes an emitter from the Emitters map.
+func DeleteEmitter(name string) {
+	emittersLock.Lock()
+	defer emittersLock.Unlock()
+	delete(Emitters, name)
+}
 
 // OnStart will be called when the daemon starts after config is loaded.
 var OnStart func()

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -112,7 +112,7 @@ func (runtime *Runtime) SendOptions() {
 // SendMessage sends a dipper message to the driver child process.
 func (runtime *Runtime) SendMessage(msg *dipper.Message) {
 	if runtime.Feature != "emitter" {
-		if emitter, ok := daemon.Emitters[runtime.Service]; ok {
+		if emitter, ok := daemon.GetEmitter(runtime.Service); ok {
 			emitter.CounterIncr("honey.honeydipper.local.message", []string{
 				"service:" + runtime.Service,
 				"driver:" + runtime.Handler.Meta().Name,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -267,7 +267,7 @@ func (s *Service) coldReload(driverRuntime *driver.Runtime, oldRuntime *driver.R
 		s.checkDeleteDriverRuntime(driverRuntime.Feature, nil)
 		if driverRuntime.Feature == FeatureEmitter {
 			// emitter is being replaced
-			delete(daemon.Emitters, s.name)
+			daemon.DeleteEmitter(s.name)
 		}
 		go func(runtime *driver.Runtime) {
 			defer dipper.SafeExitOnError("[%s] runtime %s being replaced output is already closed", s.name, runtime.Handler.Meta().Name)
@@ -352,7 +352,7 @@ func (s *Service) removeUnusedFeatures(featureList map[string]bool) {
 		if _, ok := featureList[feature]; !ok {
 			if feature == FeatureEmitter {
 				// emitter is removed
-				delete(daemon.Emitters, s.name)
+				daemon.DeleteEmitter(s.name)
 			}
 			s.checkDeleteDriverRuntime(feature, nil)
 			go func(runtime *driver.Runtime) {
@@ -390,7 +390,7 @@ func (s *Service) loadRequiredFeatures(featureList map[string]bool, boot bool) {
 					s.driverRuntimes[feature].State = driver.DriverAlive
 					if feature == FeatureEmitter {
 						// emitter is loaded
-						daemon.Emitters[s.name] = s
+						daemon.SetEmitter(s.name, s)
 					}
 				},
 				DriverReadyTimeout*time.Second,
@@ -431,7 +431,7 @@ func (s *Service) loadAdditionalFeatures(featureList map[string]bool) {
 							s.driverRuntimes[feature].State = driver.DriverAlive
 							if feature == FeatureEmitter {
 								// emitter is loaded
-								daemon.Emitters[s.name] = s
+								daemon.SetEmitter(s.name, s)
 							}
 						},
 						DriverReadyTimeout*time.Second,
@@ -493,7 +493,7 @@ func (s *Service) serviceLoop() {
 				runtime := orderedRuntimes[chosen]
 				msg := value.Interface().(*dipper.Message)
 				if runtime.Feature != FeatureEmitter {
-					if emitter, ok := daemon.Emitters[s.name]; ok {
+					if emitter, ok := daemon.GetEmitter(s.name); ok {
 						emitter.CounterIncr("honey.honeydipper.local.message", []string{
 							"service:" + s.name,
 							"driver:" + runtime.Handler.Meta().Name,
@@ -514,7 +514,7 @@ func (s *Service) serviceLoop() {
 
 			if orderedRuntimes[chosen].Feature == FeatureEmitter {
 				// emitter has crashed
-				delete(daemon.Emitters, s.name)
+				daemon.DeleteEmitter(s.name)
 			}
 			if d := orderedRuntimes[chosen]; d.State == driver.DriverAlive && s.drainingGroup == nil {
 				// only reload drivers that used to be in DriveAlive state
@@ -620,7 +620,7 @@ func loadFailedDriverRuntime(d *driver.Runtime, count int) {
 	s := Services[d.Service]
 	d.State = driver.DriverFailed
 	driverName := d.Handler.Meta().Name
-	if emitter, ok := daemon.Emitters[s.name]; ok {
+	if emitter, ok := daemon.GetEmitter(s.name); ok {
 		emitter.CounterIncr("honey.honeydipper.driver.recovery_attempt", []string{
 			"service:" + s.name,
 			"driver:" + driverName,
@@ -647,7 +647,7 @@ func loadFailedDriverRuntime(d *driver.Runtime, count int) {
 				s.driverRuntimes[d.Feature].State = driver.DriverAlive
 				if d.Feature == FeatureEmitter {
 					// emitter is loaded
-					daemon.Emitters[s.name] = s
+					daemon.SetEmitter(s.name, s)
 				}
 			},
 			DriverReadyTimeout*time.Second,

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -175,7 +175,7 @@ func TestServiceRemoveEmitter(t *testing.T) {
 			return nil
 		},
 	}
-	daemon.Emitters["testsvc"] = svc
+	daemon.SetEmitter("testsvc", svc)
 
 	daemon.ShuttingDown = false
 	go func() {
@@ -269,7 +269,7 @@ func TestServiceEmitterCrashing(t *testing.T) {
 			return nil
 		},
 	}
-	daemon.Emitters["testsvc"] = svc
+	daemon.SetEmitter("testsvc", svc)
 
 	daemon.ShuttingDown = false
 	go func() {
@@ -344,7 +344,7 @@ func TestServiceReplaceEmitter(t *testing.T) {
 			return nil
 		},
 	}
-	daemon.Emitters["testsvc"] = svc
+	daemon.SetEmitter("testsvc", svc)
 
 	daemon.ShuttingDown = false
 	go func() {


### PR DESCRIPTION
## Problem
The `daemon.Emitters` map was being accessed from multiple goroutines without synchronization, causing concurrent map write panics at line 517 and other locations.

## Root Cause
The `daemon.Emitters` map is a package-level variable that is:
- Written to (insert/delete) from multiple goroutines in service.go and callbacks
- Read from multiple goroutines in service.go and driver.go

Without proper synchronization, this causes the "concurrent map write" panic.

## Solution
Added thread-safe access to the `Emitters` map:

1. Added `emittersLock` mutex to protect the map
2. Created three helper functions:
   - `GetEmitter(name)` - safely retrieves an emitter
   - `SetEmitter(name, emitter)` - safely sets an emitter
   - `DeleteEmitter(name)` - safely deletes an emitter
3. Updated all access points to use these thread-safe helpers

## Files Changed
- `internal/daemon/daemon.go` - Added mutex and helper functions
- `internal/service/service.go` - Updated 8 access points to use helpers
- `internal/driver/driver.go` - Updated 1 access point to use helpers
- `internal/service/service_test.go` - Updated 3 test cases to use helpers

## Testing
- All existing tests pass
- Linter passes with no issues
- The fix addresses the concurrent map write at line 517 and prevents similar issues at other access points