### PR TITLE
feat: add util__hd_get_convo_url built-in tool for conversation URLs

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -86,6 +86,19 @@ func (s *AgentSession) unlock() {
 	}))
 }
 
+// buildConvoURLs constructs the conversation page URL and focus page URL for the
+// current conversation. It returns an error if the UI URL is not configured.
+func (s *AgentSession) buildConvoURLs() (string, string, error) {
+	base := strings.TrimRight(s.store.GetUIURL(), "/")
+	if base == "" {
+		return "", "", fmt.Errorf("%w: HD_UI_URL env var is not set, cannot construct conversation URL", ErrToolCall)
+	}
+	convoURL := fmt.Sprintf("%s/conversations/%s", base, s.ConvoID)
+	focusURL := fmt.Sprintf("%s/focus/%s", base, s.ConvoID)
+
+	return convoURL, focusURL, nil
+}
+
 // persist serialises the session and writes it to the cache.
 // When unlocking is true the session lock is released and, if the session
 // has reached a terminal state, the shared ConvoState is updated too.

--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -34,6 +34,7 @@ type AgentStore interface {
 	GetWorkflow(name string) *config.Workflow
 	EmitMessage(msg dipper.Message)
 	GetConfig() *config.Config
+	GetUIURL() string
 
 	// Stop signals the store to stop accepting new sessions and returns immediately.
 	// Call Wait to block until all in-flight sessions have drained.
@@ -62,11 +63,17 @@ type PersistentAgentStore struct {
 	*logging.Logger
 	wg      sync.WaitGroup
 	stopped atomic.Bool
+	uiURL   string
 }
 
 // GetLogger returns the logger used by the agent store and sessions.
 func (p *PersistentAgentStore) GetLogger() *logging.Logger {
 	return p.Logger
+}
+
+// GetUIURL returns the base URL for the Honeydipper UI.
+func (p *PersistentAgentStore) GetUIURL() string {
+	return p.uiURL
 }
 
 // emitErrorResponse sends an agent_response with status=error back to the workflow
@@ -270,10 +277,11 @@ func (p *PersistentAgentStore) runTurn(agentName, convoID, text, user string) {
 }
 
 // NewAgentStore creates an AgentStore backed by the provided StoreHelper.
-func NewAgentStore(helper StoreHelper) AgentStore {
+func NewAgentStore(helper StoreHelper, uiURL string) AgentStore {
 	return &PersistentAgentStore{
 		StoreHelper: helper,
 		Logger:      dipper.GetLogger("agent", "INFO"),
+		uiURL:       uiURL,
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -51,6 +51,7 @@ type mockStore struct {
 	cfg          *config.Config
 	logger       *logging.Logger
 	noWaitParams map[string]map[string]interface{}
+	uiURL        string
 }
 
 func newMockStore(cfg *config.Config) *mockStore {
@@ -203,6 +204,7 @@ func (m *mockStore) Stop() {}
 func (m *mockStore) Wait() {}
 
 func (m *mockStore) GetLogger() *logging.Logger { return m.logger }
+func (m *mockStore) GetUIURL() string           { return m.uiURL }
 
 // ---------------------------------------------------------------------------
 // mockStoreHelper – implements StoreHelper for PersistentAgentStore tests
@@ -779,7 +781,7 @@ func TestBuildTools_DuplicateSystemToolSkipped(t *testing.T) {
 	tools := s.BuildTools()
 
 	// Only one entry despite duplicate tool defs.
-	assert.Len(t, tools, 1)
+	assert.Len(t, tools, 2)
 }
 
 func TestBuildTools_DuplicateWorkflowToolSkipped(t *testing.T) {
@@ -802,7 +804,7 @@ func TestBuildTools_DuplicateWorkflowToolSkipped(t *testing.T) {
 
 	tools := s.BuildTools()
 
-	assert.Len(t, tools, 1)
+	assert.Len(t, tools, 2)
 }
 
 func TestBuildTools_ParamTypeDefaultsToString(t *testing.T) {
@@ -863,7 +865,7 @@ func TestBuildTools_Mixed(t *testing.T) {
 	}
 	tools := s.BuildTools()
 
-	assert.Len(t, tools, 3)
+	assert.Len(t, tools, 4)
 	assert.Contains(t, tools, "sys_s1__fn1")
 	assert.Contains(t, tools, "sys_s2__fn2")
 	assert.Contains(t, tools, "wf__wf1")
@@ -1569,7 +1571,7 @@ func TestNewAgentStore_CreatesValidStore(t *testing.T) {
 		mockStore: *newMockStore(nil),
 	}
 
-	store := NewAgentStore(helper)
+	store := NewAgentStore(helper, "")
 	assert.NotNil(t, store)
 
 	pas, ok := store.(*PersistentAgentStore)
@@ -1581,7 +1583,7 @@ func TestPersistentAgentStore_GetLogger(t *testing.T) {
 	helper := &mockStoreHelper{
 		mockStore: *newMockStore(nil),
 	}
-	store := NewAgentStore(helper).(*PersistentAgentStore)
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
 	assert.NotNil(t, store.GetLogger())
 	assert.Equal(t, store.Logger, store.GetLogger())
 }
@@ -1595,7 +1597,7 @@ func TestPersistentAgentStore_GetAgent(t *testing.T) {
 		Workflows: map[string]config.Workflow{},
 	}}
 	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
-	store := NewAgentStore(helper).(*PersistentAgentStore)
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
 
 	agent := store.GetAgent("bot")
 	assert.Equal(t, "bot", agent.Name)
@@ -1610,7 +1612,7 @@ func TestPersistentAgentStore_GetSystem(t *testing.T) {
 		Workflows: map[string]config.Workflow{},
 	}}
 	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
-	store := NewAgentStore(helper).(*PersistentAgentStore)
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
 
 	s := store.GetSystem("s1")
 	require.Contains(t, s.Functions, "fn1")
@@ -1624,7 +1626,7 @@ func TestPersistentAgentStore_GetWorkflow(t *testing.T) {
 		Workflows: map[string]config.Workflow{"wf1": wf},
 	}}
 	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
-	store := NewAgentStore(helper).(*PersistentAgentStore)
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
 
 	w := store.GetWorkflow("wf1")
 	assert.Equal(t, "my workflow", w.Description)
@@ -1632,7 +1634,7 @@ func TestPersistentAgentStore_GetWorkflow(t *testing.T) {
 
 func TestPersistentAgentStore_StopAndWait(t *testing.T) {
 	helper := &mockStoreHelper{mockStore: *newMockStore(nil)}
-	store := NewAgentStore(helper).(*PersistentAgentStore)
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
 
 	// Before Stop, stopped flag is false.
 	assert.False(t, store.stopped.Load())
@@ -1663,7 +1665,7 @@ func TestPersistentAgentStore_StartInference(t *testing.T) {
 		Workflows: map[string]config.Workflow{},
 	}}
 	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
-	store := NewAgentStore(helper).(*PersistentAgentStore)
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
 
 	msg := &dipper.Message{
 		Labels:  map[string]string{"agent_name": "bot"},
@@ -1698,7 +1700,7 @@ func TestPersistentAgentStore_ReceiveInference(t *testing.T) {
 	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
 	helper.resp["cache:load:"+AgentKeyPrefix+"rcv-session"] = mustMarshalJSON(existing)
 
-	store := NewAgentStore(helper).(*PersistentAgentStore)
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
 
 	agentMsg := AgentMessage{Role: RoleAgent, Content: "response!"}
 	msg := &dipper.Message{
@@ -1753,7 +1755,7 @@ func TestPersistentAgentStore_ContinueInference_ProcessResult(t *testing.T) {
 		{Role: RoleAgent, ToolCalls: toolCalls},
 	})
 
-	store := NewAgentStore(helper).(*PersistentAgentStore)
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
 
 	msg := &dipper.Message{
 		Subject: "agent_workflow_result",
@@ -1803,7 +1805,7 @@ func TestPersistentAgentStore_ContinueInference_Recover(t *testing.T) {
 		{Role: RoleSystem, Content: "sys"},
 	})
 
-	store := NewAgentStore(helper).(*PersistentAgentStore)
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
 
 	msg := &dipper.Message{
 		Labels: map[string]string{
@@ -1867,7 +1869,7 @@ func TestStartTurn_UsesParentAgentWhenLastSessionIsSubAgent(t *testing.T) {
 	// Return an empty history for the new turn's convo.
 	helper.resp["cache:lrange:"+ConvoHistoryKeyPrefix+convoID] = mustMarshalJSON([]AgentMessage{})
 
-	store := NewAgentStore(helper).(*PersistentAgentStore)
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
 
 	store.StartTurn(convoID, "hello again", "user1")
 	store.Wait()

--- a/internal/agent/pre_context_test.go
+++ b/internal/agent/pre_context_test.go
@@ -101,6 +101,7 @@ func (f *FakeStore) Stop()                                    {}
 func (f *FakeStore) Wait()                                    {}
 func (f *FakeStore) GetLogger() *logging.Logger               { return nil }
 
+func (f *FakeStore) GetUIURL() string { return "" }
 func TestHandleLoadSkillToolCall_Success(t *testing.T) {
 	convoID := "conv-test"
 	skillName := "my_skill"

--- a/internal/agent/tool_call.go
+++ b/internal/agent/tool_call.go
@@ -50,6 +50,13 @@ func (s *AgentSession) BuildTools() map[string]AgentTool {
 		}
 	}
 
+	tools["util__hd_get_convo_url"] = AgentTool{
+		Name: "util__hd_get_convo_url",
+		Description: "Get the conversation page URL and focus page URL for the current conversation. " +
+			"Use this to obtain URLs that can be sent to external systems like PagerDuty, Slack, etc.",
+		Params: map[string]interface{}{},
+	}
+
 	return tools
 }
 
@@ -416,9 +423,47 @@ func (s *AgentSession) nextToolCall() {
 		s.handleMCPToolCall(c, unifiedConvoID)
 	case c.FuncName == "hd_load_skill":
 		s.handleLoadSkillToolCall(c, unifiedConvoID)
+	case strings.HasPrefix(c.FuncName, "util__"):
+		s.handleUtilToolCall(c, unifiedConvoID)
 	default:
 		panic(fmt.Errorf("%w unknown tool call prefix: %s", ErrToolCall, c.FuncName))
 	}
+}
+
+func (s *AgentSession) handleUtilToolCall(c AgentToolCall, unifiedConvoID string) {
+	switch c.FuncName {
+	case "util__hd_get_convo_url":
+		s.handleGetConvoURL(c, unifiedConvoID)
+	default:
+		panic(fmt.Errorf("%w unknown util tool: %s", ErrToolCall, c.FuncName))
+	}
+}
+
+func (s *AgentSession) handleGetConvoURL(_ AgentToolCall, unifiedConvoID string) {
+	convoURL, focusURL, err := s.buildConvoURLs()
+	if err != nil {
+		panic(fmt.Errorf("%w: %w", ErrToolCall, err))
+	}
+
+	s.store.EmitMessage(dipper.Message{
+		Channel: dipper.ChannelEventbus,
+		Subject: dipper.EventbusAgentContinue,
+		Labels: map[string]string{
+			"agent_session_id": s.ID,
+			"turn_id":          strconv.Itoa(len(s.history)),
+			"tool_call_id":     strconv.Itoa(s.CurrentCall),
+			"unified_convo_id": unifiedConvoID,
+			"status":           "success",
+		},
+		Payload: map[string]interface{}{
+			"data": map[string]interface{}{
+				"output": map[string]interface{}{
+					"convo_url": convoURL,
+					"focus_url": focusURL,
+				},
+			},
+		},
+	})
 }
 
 func (s *AgentSession) handleSysToolCall(c AgentToolCall, unifiedConvoID string) {
@@ -597,6 +642,8 @@ func (s *AgentSession) processToolResult(msg *dipper.Message) {
 			cs.ActiveSession = cs.LastSession
 		})
 	case strings.HasPrefix(c.FuncName, "mcp__"):
+		data, _ = dipper.GetMapData(msg.Payload, "data.output")
+	case strings.HasPrefix(c.FuncName, "util__"):
 		data, _ = dipper.GetMapData(msg.Payload, "data.output")
 	}
 

--- a/internal/agent/tool_call_test.go
+++ b/internal/agent/tool_call_test.go
@@ -14,7 +14,9 @@ import (
 	"testing"
 
 	"github.com/honeydipper/honeydipper/v4/internal/config"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ---------------------------------------------------------------------------
@@ -267,7 +269,7 @@ func TestProcessMCPToolList_OnlyFilter(t *testing.T) {
 	s := &AgentSession{store: store, Agent: &agentA, ID: "test-only"}
 	tools := s.BuildTools()
 
-	assert.Len(t, tools, 2)
+	assert.Len(t, tools, 3)
 	assert.Contains(t, tools, "mcp__myserver__alpha")
 	assert.Contains(t, tools, "mcp__myserver__gamma")
 	assert.NotContains(t, tools, "mcp__myserver__beta")
@@ -292,7 +294,7 @@ func TestProcessMCPToolList_ExcludesFilter(t *testing.T) {
 	s := &AgentSession{store: store, Agent: &agentA, ID: "test-excludes"}
 	tools := s.BuildTools()
 
-	assert.Len(t, tools, 2)
+	assert.Len(t, tools, 3)
 	assert.Contains(t, tools, "mcp__myserver__alpha")
 	assert.Contains(t, tools, "mcp__myserver__gamma")
 	assert.NotContains(t, tools, "mcp__myserver__beta")
@@ -319,7 +321,7 @@ func TestProcessMCPToolList_BothOnlyAndExcludes(t *testing.T) {
 	tools := s.BuildTools()
 
 	// Only whitelist is applied first (alpha, beta, gamma), then Excludes removes beta.
-	assert.Len(t, tools, 2)
+	assert.Len(t, tools, 3)
 	assert.Contains(t, tools, "mcp__myserver__alpha")
 	assert.Contains(t, tools, "mcp__myserver__gamma")
 	assert.NotContains(t, tools, "mcp__myserver__beta")
@@ -345,7 +347,7 @@ func TestProcessMCPToolList_NoFilter(t *testing.T) {
 	tools := s.BuildTools()
 
 	// All tools should be present when no filter is specified.
-	assert.Len(t, tools, 2)
+	assert.Len(t, tools, 3)
 	assert.Contains(t, tools, "mcp__myserver__alpha")
 	assert.Contains(t, tools, "mcp__myserver__beta")
 }
@@ -369,7 +371,7 @@ func TestProcessMCPToolList_OnlyNonexistentAllExcluded(t *testing.T) {
 	tools := s.BuildTools()
 
 	// Only lists a tool that doesn't exist — nothing registered.
-	assert.Len(t, tools, 0)
+	assert.Len(t, tools, 1)
 }
 
 func TestProcessMCPToolList_ExcludesAll(t *testing.T) {
@@ -391,7 +393,7 @@ func TestProcessMCPToolList_ExcludesAll(t *testing.T) {
 	tools := s.BuildTools()
 
 	// All tools excluded — nothing registered.
-	assert.Len(t, tools, 0)
+	assert.Len(t, tools, 1)
 }
 
 func TestProcessMCPToolList_MixedToolTypes(t *testing.T) {
@@ -416,7 +418,7 @@ func TestProcessMCPToolList_MixedToolTypes(t *testing.T) {
 	s := &AgentSession{store: store, Agent: &agentA, ID: "test-mixed"}
 	tools := s.BuildTools()
 
-	assert.Len(t, tools, 3)
+	assert.Len(t, tools, 4)
 	assert.Contains(t, tools, "sys_s1__sys_fn")
 	assert.Contains(t, tools, "wf__wf1")
 	assert.Contains(t, tools, "mcp__myserver__mcp_tool_a")
@@ -446,6 +448,201 @@ func TestProcessMCPToolList_CacheHitWithFilter(t *testing.T) {
 	tools := s.BuildTools()
 
 	// Even though the cached data has all tools, the filter is applied on retrieval.
-	assert.Len(t, tools, 1)
+	assert.Len(t, tools, 2)
 	assert.Contains(t, tools, "mcp__myserver__beta")
+}
+
+// ---------------------------------------------------------------------------
+// util__hd_get_convo_url tool tests
+// ---------------------------------------------------------------------------
+
+func TestBuildTools_IncludesUtilGetConvoURL(t *testing.T) {
+	store := newMockStore(nil)
+	agentA := config.Agent{
+		Name:   "a",
+		Driver: "openai",
+		Tools:  []config.AgentToolDef{},
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{store: store, Agent: &agentA, ID: "test-util-tool"}
+	tools := s.BuildTools()
+
+	require.Contains(t, tools, "util__hd_get_convo_url")
+	tool := tools["util__hd_get_convo_url"]
+	assert.Equal(t, "util__hd_get_convo_url", tool.Name)
+	assert.Contains(t, tool.Description, "conversation page URL")
+	assert.Contains(t, tool.Description, "focus page URL")
+	assert.Empty(t, tool.Params)
+}
+
+func TestBuildTools_UtilGetConvoURL_AlwaysPresent(t *testing.T) {
+	// Even with no other tools, util__hd_get_convo_url should be present.
+	store := newMockStore(nil)
+	agentA := config.Agent{
+		Name:   "a",
+		Driver: "openai",
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{store: store, Agent: &agentA, ID: "test-util-always"}
+	tools := s.BuildTools()
+
+	require.Contains(t, tools, "util__hd_get_convo_url")
+	// Only the util tool should be present (no hd_load_skill without SkillsHeader)
+	assert.Len(t, tools, 1)
+}
+
+func TestNextToolCall_UtilGetConvoURLDispatch(t *testing.T) {
+	store := newMockStore(nil)
+	store.uiURL = "https://honeydipper.example.com"
+
+	s := &AgentSession{
+		store:       store,
+		Agent:       &config.Agent{Name: "test-agent", Driver: "openai"},
+		ID:          "util-dispatch-session",
+		ConvoID:     "convo-123",
+		CurrentCall: 0,
+		CurrentMsg:  &dipper.Message{Labels: map[string]string{}},
+		ToolCalls: []AgentToolCall{
+			{FuncName: "util__hd_get_convo_url", Params: map[string]interface{}{}},
+		},
+	}
+
+	s.nextToolCall()
+
+	emitted := store.getEmitted()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "agent_continue", emitted[0].Subject)
+	assert.Equal(t, "success", emitted[0].Labels["status"])
+	assert.Equal(t, s.ID, emitted[0].Labels["agent_session_id"])
+
+	// Verify the payload contains the URLs
+	output, ok := dipper.GetMapData(emitted[0].Payload, "data.output")
+	require.True(t, ok)
+	outputMap := output.(map[string]interface{})
+	assert.Equal(t, "https://honeydipper.example.com/conversations/convo-123", outputMap["convo_url"])
+	assert.Equal(t, "https://honeydipper.example.com/focus/convo-123", outputMap["focus_url"])
+}
+
+func TestNextToolCall_UtilGetConvoURL_TrimTrailingSlash(t *testing.T) {
+	store := newMockStore(nil)
+	store.uiURL = "https://honeydipper.example.com/"
+
+	s := &AgentSession{
+		store:       store,
+		Agent:       &config.Agent{Name: "test-agent", Driver: "openai"},
+		ID:          "util-slash-session",
+		ConvoID:     "convo-456",
+		CurrentCall: 0,
+		CurrentMsg:  &dipper.Message{Labels: map[string]string{}},
+		ToolCalls: []AgentToolCall{
+			{FuncName: "util__hd_get_convo_url", Params: map[string]interface{}{}},
+		},
+	}
+
+	s.nextToolCall()
+
+	emitted := store.getEmitted()
+	require.Len(t, emitted, 1)
+	output, _ := dipper.GetMapData(emitted[0].Payload, "data.output")
+	outputMap := output.(map[string]interface{})
+	assert.Equal(t, "https://honeydipper.example.com/conversations/convo-456", outputMap["convo_url"])
+	assert.Equal(t, "https://honeydipper.example.com/focus/convo-456", outputMap["focus_url"])
+}
+
+func TestNextToolCall_UtilGetConvoURL_MissingUIURL(t *testing.T) {
+	store := newMockStore(nil)
+	// uiURL is empty by default
+
+	s := &AgentSession{
+		store:       store,
+		Agent:       &config.Agent{Name: "test-agent", Driver: "openai"},
+		ID:          "util-no-url-session",
+		ConvoID:     "convo-789",
+		CurrentCall: 0,
+		CurrentMsg:  &dipper.Message{Labels: map[string]string{}},
+		ToolCalls: []AgentToolCall{
+			{FuncName: "util__hd_get_convo_url", Params: map[string]interface{}{}},
+		},
+	}
+
+	assert.Panics(t, func() {
+		s.nextToolCall()
+	})
+}
+
+func TestProcessToolResult_UtilToolResult(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Systems["s1"] = makeSystemWithFunc("fn1")
+
+	toolCalls := []AgentToolCall{
+		{FuncName: "util__hd_get_convo_url", Params: map[string]interface{}{}},
+		{FuncName: "sys_s1__fn1", Params: map[string]interface{}{"param1": "v"}},
+	}
+
+	s := &AgentSession{
+		store:       store,
+		Agent:       &config.Agent{Driver: "openai"},
+		ID:          "util-result-session",
+		CurrentCall: 0,
+		CurrentMsg:  &dipper.Message{Labels: map[string]string{}},
+		ToolCalls:   toolCalls,
+		history: []AgentMessage{
+			{Role: RoleAgent, ToolCalls: toolCalls},
+		},
+	}
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"turn_id":      "1",
+			"tool_call_id": "0",
+			"status":       "success",
+		},
+		Payload: map[string]interface{}{
+			"data": map[string]interface{}{
+				"output": map[string]interface{}{
+					"convo_url": "https://example.com/conversations/c1",
+					"focus_url": "https://example.com/focus/c1",
+				},
+			},
+		},
+	}
+
+	s.processToolResult(msg)
+
+	// The util result should be collected and the next tool dispatched.
+	require.Len(t, s.ToolResults, 1)
+	assert.Equal(t, "success", s.ToolResults[0]["status"])
+	assert.Equal(t, "util__hd_get_convo_url", s.ToolResults[0]["func_name"])
+
+	// Verify the data contains the output map
+	data := s.ToolResults[0]["data"].(map[string]interface{})
+	assert.Equal(t, "https://example.com/conversations/c1", data["convo_url"])
+	assert.Equal(t, "https://example.com/focus/c1", data["focus_url"])
+
+	// CurrentCall should be incremented and next tool dispatched.
+	assert.Equal(t, 1, s.CurrentCall)
+	emitted := store.getEmitted()
+	require.Len(t, emitted, 1)
+	assert.Equal(t, "agent_command", emitted[0].Subject)
+}
+
+func TestNextToolCall_UnknownUtilTool_Panics(t *testing.T) {
+	store := newMockStore(nil)
+
+	s := &AgentSession{
+		store:       store,
+		Agent:       &config.Agent{Name: "test-agent", Driver: "openai"},
+		ID:          "util-unknown-session",
+		CurrentCall: 0,
+		CurrentMsg:  &dipper.Message{Labels: map[string]string{}},
+		ToolCalls: []AgentToolCall{
+			{FuncName: "util__nonexistent_tool", Params: map[string]interface{}{}},
+		},
+	}
+
+	assert.Panics(t, func() {
+		s.nextToolCall()
+	})
 }

--- a/internal/service/agent_svc.go
+++ b/internal/service/agent_svc.go
@@ -7,6 +7,8 @@
 package service
 
 import (
+	"os"
+
 	"github.com/honeydipper/honeydipper/v4/internal/agent"
 	"github.com/honeydipper/honeydipper/v4/internal/config"
 	"github.com/honeydipper/honeydipper/v4/internal/daemon"
@@ -60,7 +62,12 @@ func StartAgent(cfg *config.Config) {
 
 	// Build the store before start() so the package-level var is set
 	// before any goroutine spawned by a responder can reference it.
-	agentStore = agent.NewAgentStore(agentSvc)
+	uiURL := os.Getenv("HD_UI_URL")
+	if uiURL == "" {
+		dipper.Logger.Errorf("agent service starting without HD_UI_URL env var; util__hd_get_convo_url will error")
+	}
+
+	agentStore = agent.NewAgentStore(agentSvc, uiURL)
 	setupAgentAPIs()
 	agentSvc.Drain = func() {
 		agentStore.Stop()

--- a/internal/service/agent_svc_test.go
+++ b/internal/service/agent_svc_test.go
@@ -66,6 +66,7 @@ func (m *mockAgentStore) GetWorkflow(_ string) *config.Workflow { return &config
 func (m *mockAgentStore) EmitMessage(_ dipper.Message)          {}
 func (m *mockAgentStore) GetConfig() *config.Config             { return &config.Config{} }
 func (m *mockAgentStore) GetLogger() *logging.Logger            { return nil }
+func (m *mockAgentStore) GetUIURL() string                      { return "" }
 func (m *mockAgentStore) GetName() string                       { return "mock-agent-store" }
 
 func (m *mockAgentStore) Call(_, _ string, _ interface{}, _ ...string) ([]byte, error) {


### PR DESCRIPTION
## Summary

This change introduces a new built-in tool type `util` to the honeydipper agent system. The `util__hd_get_convo_url` tool returns conversation page and focus page URLs for the current conversation, enabling AI models to send these URLs to external systems like PagerDuty or Slack.

## URL Patterns

- Conversation page: `{uiURL}/conversations/{convoID}`
- Focus page: `{uiURL}/focus/{convoID}`

## Changes

### Core Implementation

1. **`internal/agent/agent_store.go`**:
   - Added `GetUIURL() string` to the `AgentStore` interface
   - Added `uiURL` field to `PersistentAgentStore`
   - Implemented `GetUIURL()` method
   - Updated `NewAgentStore` to accept `uiURL` parameter

2. **`internal/agent/agent_session.go`**:
   - Added `buildConvoURLs()` helper method that constructs conversation and focus page URLs
   - Reads `uiURL` from store, trims trailing slash, returns error if empty

3. **`internal/agent/tool_call.go`**:
   - Registered `util__hd_get_convo_url` tool unconditionally in `BuildTools()` (after `hd_load_skill` block)
   - Added `util__` dispatch case in `nextToolCall()` that calls `handleUtilToolCall()` synchronously
   - Added `handleUtilToolCall()` method that dispatches based on specific util tool name
   - Added `handleGetConvoURL()` method that constructs URLs and emits a synthetic `agent_continue` message with URLs in the output data
   - Added `util__` case in `processToolResult()` to extract result data from message payload

4. **`internal/service/agent_svc.go`**:
   - Reads `HD_UI_URL` environment variable in `StartAgent()`
   - Logs an error if `HD_UI_URL` is not set
   - Passes `uiURL` to `NewAgentStore()`

### Tests & Mocks

5. **`internal/agent/tool_call_test.go`**:
   - `TestBuildTools_IncludesUtilGetConvoURL` — verifies tool is registered with correct name/description
   - `TestBuildTools_UtilGetConvoURL_AlwaysPresent` — verifies tool is always present even with no other tools
   - `TestNextToolCall_UtilGetConvoURLDispatch` — verifies dispatch emits agent_continue with correct URLs
   - `TestNextToolCall_UtilGetConvoURL_TrimTrailingSlash` — verifies trailing slash in UI_URL is handled
   - `TestNextToolCall_UtilGetConvoURL_MissingUIURL` — verifies panic when HD_UI_URL is empty
   - `TestProcessToolResult_UtilToolResult` — verifies result extraction from message payload
   - `TestNextToolCall_UnknownUtilTool_Panics` — verifies panic for unknown util tools
   - Updated existing test assertions to account for the new unconditional tool

6. **`internal/agent/agent_test.go`**:
   - Added `uiURL` field to `mockStore` struct
   - Added `GetUIURL()` method to `mockStore`
   - Updated all `NewAgentStore()` calls to pass `uiURL` parameter
   - Updated test assertions for new tool count

7. **`internal/agent/pre_context_test.go`**:
   - Added `GetUIURL()` method to `FakeStore`

8. **`internal/service/agent_svc_test.go`**:
   - Added `GetUIURL()` method to `mockAgentStore`

### Design Notes

- The `util__` prefix is dispatched synchronously within the agent session (no eventbus emission to operator/MCP)
- The tool is registered unconditionally, similar to how `hd_load_skill` is conditionally registered
- The `HD_UI_URL` environment variable is read once at service startup and stored in the agent store
- Error handling uses wrapped static errors (`ErrToolCall`) for proper error chain inspection