### PR TITLE
fix(pkg): fail config processing on lookup RPC errors

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -270,14 +270,7 @@ func (s *Service) start() {
 func (s *Service) Reload() {
 	defer func() {
 		if r := recover(); r != nil {
-			s.healthy = false
-			if errors.Is(r.(error), config.ErrConfigRollback) {
-				dipper.Logger.Errorf("[%s] reverting config initiated outside of the service", s.name)
-
-				return
-			}
-			dipper.Logger.Errorf("[%s] reverting config due to fatal failure %v", s.name, r)
-			s.config.RollBack()
+			s.recoverReloadPanic(r)
 		}
 	}()
 	dipper.Logger.Infof("[%s] reloading service", s.name)
@@ -292,6 +285,17 @@ func (s *Service) Reload() {
 	}
 	s.healthy = true
 	s.removeUnusedFeatures(featureList)
+}
+
+func (s *Service) recoverReloadPanic(r interface{}) {
+	s.healthy = false
+	if err, ok := r.(error); ok && errors.Is(err, config.ErrConfigRollback) {
+		dipper.Logger.Errorf("[%s] reverting config initiated outside of the service", s.name)
+
+		return
+	}
+	dipper.Logger.Errorf("[%s] reverting config due to fatal failure %v", s.name, r)
+	s.config.RollBack()
 }
 
 func (s *Service) getFeatureList() map[string]bool {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -141,6 +141,25 @@ func TestServiceLoopCatchError(t *testing.T) {
 	daemon.ShuttingDown = false
 }
 
+func TestRecoverReloadPanicHandlesNonErrorPanic(t *testing.T) {
+	if dipper.Logger == nil {
+		f, _ := os.OpenFile(os.DevNull, os.O_APPEND, 0o777)
+		defer f.Close()
+		dipper.GetLogger("test service", "DEBUG", f, f)
+	}
+
+	svc := &Service{
+		name:    "testsvc",
+		config:  &config.Config{},
+		healthy: true,
+	}
+
+	assert.NotPanics(t, func() {
+		svc.recoverReloadPanic("non-error panic")
+	}, "service reload recovery should handle non-error panic values")
+	assert.False(t, svc.healthy, "service should be unhealthy after reload panic")
+}
+
 func TestServiceRemoveEmitter(t *testing.T) {
 	if dipper.Logger == nil {
 		f, _ := os.OpenFile(os.DevNull, os.O_APPEND, 0o777)

--- a/pkg/dipper/encryption.go
+++ b/pkg/dipper/encryption.go
@@ -8,8 +8,43 @@ package dipper
 
 import (
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"strings"
 )
+
+// ErrConfigProcessing indicates config decryption or lookup processing failed.
+var ErrConfigProcessing = errors.New("config processing failed")
+
+func panicConfigProcessingError(err error) {
+	Logger.Error(err)
+	panic(err)
+}
+
+func splitConfigRef(rpc RPCCaller, key string, refType string, ref string, prefixLen int) []string {
+	if len(ref) <= prefixLen || !strings.HasSuffix(ref, "]") {
+		panicConfigProcessingError(
+			fmt.Errorf(
+				"%w: [%s] invalid %s config value for key %s",
+				ErrConfigProcessing,
+				rpc.GetName(), refType, key,
+			),
+		)
+	}
+
+	parts := strings.SplitN(ref[prefixLen:len(ref)-1], ",", 2)
+	if len(parts) != 2 {
+		panicConfigProcessingError(
+			fmt.Errorf(
+				"%w: [%s] invalid %s config value for key %s",
+				ErrConfigProcessing,
+				rpc.GetName(), refType, key,
+			),
+		)
+	}
+
+	return parts
+}
 
 // GetDecryptFunc returns a function used in recursive decryption.
 func GetDecryptFunc(rpc RPCCaller) ItemProcessor {
@@ -23,26 +58,50 @@ func GetDecryptFunc(rpc RPCCaller) ItemProcessor {
 		switch {
 		case strings.HasPrefix(str, "ENC["):
 			//nolint:gomnd
-			parts := strings.SplitN(str[4:len(str)-1], ",", 2)
+			parts := splitConfigRef(rpc, key, "ENC", str, 4)
 			encDriver := parts[0]
 			if encDriver == "deferred" {
 				return "ENC[" + parts[1] + "]", true
 			}
 			decoded, err := base64.StdEncoding.DecodeString(parts[1])
 			if err != nil {
-				Logger.Panicf("encrypted data should be base64 encoded")
+				panicConfigProcessingError(
+					fmt.Errorf(
+						"%w: [%s] encrypted config value for key %s should be base64 encoded: %w",
+						ErrConfigProcessing,
+						rpc.GetName(), key, err,
+					),
+				)
 			}
-			decrypted, _ := rpc.CallRaw("driver:"+encDriver, "decrypt", decoded)
+			decrypted, err := rpc.CallRaw("driver:"+encDriver, "decrypt", decoded)
+			if err != nil {
+				panicConfigProcessingError(
+					fmt.Errorf(
+						"%w: [%s] failed to decrypt config key %s using driver %s: %w",
+						ErrConfigProcessing,
+						rpc.GetName(), key, encDriver, err,
+					),
+				)
+			}
 
 			return string(decrypted), true
 		case strings.HasPrefix(str, "LOOKUP["):
 			//nolint:gomnd
-			parts := strings.SplitN(str[7:len(str)-1], ",", 2)
+			parts := splitConfigRef(rpc, key, "LOOKUP", str, 7)
 			lookupDriver := parts[0]
 			if lookupDriver == "deferred" {
 				return "LOOKUP[" + parts[1] + "]", true
 			}
-			lookupValue, _ := rpc.CallRaw("driver:"+lookupDriver, "lookup", []byte(parts[1]))
+			lookupValue, err := rpc.CallRaw("driver:"+lookupDriver, "lookup", []byte(parts[1]))
+			if err != nil {
+				panicConfigProcessingError(
+					fmt.Errorf(
+						"%w: [%s] failed to resolve LOOKUP using driver %s for config key %s: %w",
+						ErrConfigProcessing,
+						rpc.GetName(), lookupDriver, key, err,
+					),
+				)
+			}
 
 			return string(lookupValue), true
 		}

--- a/pkg/dipper/encryption_test.go
+++ b/pkg/dipper/encryption_test.go
@@ -42,6 +42,28 @@ func wrapDecryptAll(t *testing.T, doc string, expect []MessageReceiver, c *RPCCa
 	return data
 }
 
+func errorReturnReceiver(t *testing.T, c *RPCCallerBase, want Message, reason string) MessageReceiver {
+	t.Helper()
+
+	return &NullReceiver{
+		SendMessageFunc: func(msg *Message) {
+			assert.Equalf(t, want, *msg, "should make expected rpc call")
+			labels := map[string]string{}
+			for key, value := range want.Labels {
+				labels[key] = value
+			}
+			labels["error"] = reason
+
+			c.HandleReturn(&Message{
+				Channel: "rpc",
+				Subject: "return",
+				IsRaw:   true,
+				Labels:  labels,
+			})
+		},
+	}
+}
+
 func TestDecryptAll(t *testing.T) {
 	doc := `
 data:
@@ -93,6 +115,80 @@ data:
 	assert.Equal(t, "not encrypted", MustGetMapDataStr(data, "data.item1"), "data.item1 should remain unchanged")
 }
 
+func TestDecryptAllPanicsOnDecryptError(t *testing.T) {
+	doc := `
+data:
+  item1: not encrypted
+  item2: ENC[noexist,YWFiYmNjZGQ=]
+`
+
+	c := &RPCCallerBase{}
+
+	expect := []MessageReceiver{
+		errorReturnReceiver(
+			t,
+			c,
+			Message{
+				Channel: "rpc",
+				Subject: "call",
+				IsRaw:   true,
+				Payload: []byte("aabbccdd"),
+				Labels: map[string]string{
+					"caller":  "-",
+					"feature": "driver:noexist",
+					"method":  "decrypt",
+					"rpcID":   "0",
+				},
+			},
+			"failed to decrypt",
+		),
+	}
+
+	assert.PanicsWithError(t,
+		"config processing failed: [mockCaller] failed to decrypt config key data.item2 using driver noexist: rpc error: reason: failed to decrypt",
+		func() {
+			wrapDecryptAll(t, doc, expect, c)
+		},
+		"decrypt errors should fail config processing",
+	)
+}
+
+func TestDecryptAllPanicsOnInvalidEncryptedData(t *testing.T) {
+	doc := `
+data:
+  item1: not encrypted
+  item2: ENC[noexist,!!!!]
+`
+
+	c := &RPCCallerBase{}
+
+	assert.PanicsWithError(t,
+		"config processing failed: [mockCaller] encrypted config value for key data.item2 should be base64 encoded: illegal base64 data at input byte 0",
+		func() {
+			wrapDecryptAll(t, doc, nil, c)
+		},
+		"invalid base64 values should fail config processing",
+	)
+}
+
+func TestDecryptAllPanicsOnInvalidEncryptedReference(t *testing.T) {
+	doc := `
+data:
+  item1: not encrypted
+  item2: ENC[noexist]
+`
+
+	c := &RPCCallerBase{}
+
+	assert.PanicsWithError(t,
+		"config processing failed: [mockCaller] invalid ENC config value for key data.item2",
+		func() {
+			wrapDecryptAll(t, doc, nil, c)
+		},
+		"malformed encrypted references should fail config processing",
+	)
+}
+
 func TestDecryptAllWithDeferred(t *testing.T) {
 	doc := `
 data:
@@ -114,6 +210,44 @@ data:
 	data := wrapDecryptAll(t, doc, expect, c)
 	assert.Equal(t, "ENC[driver1,YWFiYmNjZGQ=]", MustGetMapDataStr(data, "data.item3.item4"), "item4 should be stripped off one deferred flag")
 	assert.Equal(t, "not encrypted", MustGetMapDataStr(data, "data.item1"), "data.item1 should remain unchanged")
+}
+
+func TestDecryptAllPanicsOnLookUpError(t *testing.T) {
+	doc := `
+data:
+  item1: not encrypted
+  item2: LOOKUP[kvstore,secret/path]
+`
+
+	c := &RPCCallerBase{}
+
+	expect := []MessageReceiver{
+		errorReturnReceiver(
+			t,
+			c,
+			Message{
+				Channel: "rpc",
+				Subject: "call",
+				IsRaw:   true,
+				Payload: []byte("secret/path"),
+				Labels: map[string]string{
+					"caller":  "-",
+					"feature": "driver:kvstore",
+					"method":  "lookup",
+					"rpcID":   "0",
+				},
+			},
+			"failed to lookup",
+		),
+	}
+
+	assert.PanicsWithError(t,
+		"config processing failed: [mockCaller] failed to resolve LOOKUP using driver kvstore for config key data.item2: rpc error: reason: failed to lookup",
+		func() {
+			wrapDecryptAll(t, doc, expect, c)
+		},
+		"lookup errors should fail config processing",
+	)
 }
 
 func TestDecryptAllWithLookUp(t *testing.T) {


### PR DESCRIPTION
## Summary

- fail config processing when ENC/LOOKUP RPC calls return errors instead of replacing values with empty strings
- log the failing config key and driver before panicking with an error value so reload rollback can handle it
- add regression tests for decrypt and lookup RPC failures

## Why

A transient gcloud-secret lookup failure can otherwise resolve LOOKUP[...] to an empty string and apply broken webhook signing-secret config on one replica.

## Tests

- GOMODCACHE=/private/tmp/codex-gomodcache-honeydipper GOPROXY=direct go test ./pkg/dipper
- GOMODCACHE=/private/tmp/codex-gomodcache-honeydipper GOPROXY=direct go test ./internal/service