### PR TITLE
fix(config): fail config processing on lookup RPC errors

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -304,14 +304,7 @@ func (s *Service) start() {
 func (s *Service) Reload() {
 	defer func() {
 		if r := recover(); r != nil {
-			s.healthy = false
-			if errors.Is(r.(error), config.ErrConfigRollback) {
-				dipper.Logger.Errorf("[%s] reverting config initiated outside of the service", s.name)
-
-				return
-			}
-			dipper.Logger.Errorf("[%s] reverting config due to fatal failure %v", s.name, r)
-			s.config.RollBack()
+			s.recoverReloadPanic(r)
 		}
 	}()
 	dipper.Logger.Infof("[%s] reloading service", s.name)
@@ -326,6 +319,17 @@ func (s *Service) Reload() {
 	}
 	s.healthy = true
 	s.removeUnusedFeatures(featureList)
+}
+
+func (s *Service) recoverReloadPanic(r interface{}) {
+	s.healthy = false
+	if err, ok := r.(error); ok && errors.Is(err, config.ErrConfigRollback) {
+		dipper.Logger.Errorf("[%s] reverting config initiated outside of the service", s.name)
+
+		return
+	}
+	dipper.Logger.Errorf("[%s] reverting config due to fatal failure %v", s.name, r)
+	s.config.RollBack()
 }
 
 func (s *Service) getFeatureList() map[string]bool {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -141,6 +141,25 @@ func TestServiceLoopCatchError(t *testing.T) {
 	daemon.ShuttingDown = false
 }
 
+func TestRecoverReloadPanicHandlesNonErrorPanic(t *testing.T) {
+	if dipper.Logger == nil {
+		f, _ := os.OpenFile(os.DevNull, os.O_APPEND, 0o777)
+		defer f.Close()
+		dipper.GetLogger("test service", "DEBUG", f, f)
+	}
+
+	svc := &Service{
+		name:    "testsvc",
+		config:  &config.Config{},
+		healthy: true,
+	}
+
+	assert.NotPanics(t, func() {
+		svc.recoverReloadPanic("non-error panic")
+	}, "service reload recovery should handle non-error panic values")
+	assert.False(t, svc.healthy, "service should be unhealthy after reload panic")
+}
+
 func TestServiceRemoveEmitter(t *testing.T) {
 	if dipper.Logger == nil {
 		f, _ := os.OpenFile(os.DevNull, os.O_APPEND, 0o777)

--- a/pkg/dipper/encryption.go
+++ b/pkg/dipper/encryption.go
@@ -8,9 +8,52 @@ package dipper
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 )
+
+var ErrConfigProcessing = errors.New("config processing failed")
+
+func panicConfigProcessingError(err error) {
+	Logger.Error(err)
+	panic(err)
+}
+
+func splitConfigRef(rpc RPCCaller, key, refType, ref string, prefixLen int) ([]string, string) {
+	closingIdx := strings.Index(ref, "]")
+	if closingIdx < prefixLen {
+		panicConfigProcessingError(
+			fmt.Errorf(
+				"%w: [%s] invalid %s config value for key %s",
+				ErrConfigProcessing,
+				rpc.GetName(),
+				refType,
+				key,
+			),
+		)
+	}
+
+	pattern := "%s"
+	if closingIdx < len(ref)-1 && ref[closingIdx+1] == ':' {
+		pattern = ref[closingIdx+2:]
+	}
+
+	parts := strings.SplitN(ref[prefixLen:closingIdx], ",", 2)
+	if len(parts) != 2 {
+		panicConfigProcessingError(
+			fmt.Errorf(
+				"%w: [%s] invalid %s config value for key %s",
+				ErrConfigProcessing,
+				rpc.GetName(),
+				refType,
+				key,
+			),
+		)
+	}
+
+	return parts, pattern
+}
 
 // DecryptString uses the appropriate driver to decrypt the given string.
 func DecryptString(rpc RPCCaller, key, str string) (string, bool) {
@@ -19,12 +62,7 @@ func DecryptString(rpc RPCCaller, key, str string) (string, bool) {
 	switch {
 	case strings.HasPrefix(str, "ENC["):
 		Logger.Debugf("[%s] decrypting %s", rpc.GetName(), key)
-		closingIdx := strings.Index(str, "]")
-		pattern := "%s"
-		if closingIdx < len(str)-1 && str[closingIdx+1] == ':' {
-			pattern = str[closingIdx+2:]
-		}
-		parts := strings.SplitN(str[4:closingIdx], ",", 2)
+		parts, pattern := splitConfigRef(rpc, key, "ENC", str, 4)
 		encDriver := parts[0]
 		if encDriver == "deferred" {
 			p := parts[1]
@@ -40,22 +78,34 @@ func DecryptString(rpc RPCCaller, key, str string) (string, bool) {
 		}
 		decoded, err := base64.StdEncoding.DecodeString(parts[1])
 		if err != nil {
-			Logger.Panicf("encrypted data should be base64 encoded")
+			panicConfigProcessingError(
+				fmt.Errorf(
+					"%w: [%s] encrypted config value for key %s should be base64 encoded: %w",
+					ErrConfigProcessing,
+					rpc.GetName(),
+					key,
+					err,
+				),
+			)
 		}
-		decrypted, e := rpc.CallRaw("driver:"+encDriver, "decrypt", decoded)
-		if !optional {
-			Must(e)
+		decrypted, err := rpc.CallRaw("driver:"+encDriver, "decrypt", decoded)
+		if err != nil && !optional {
+			panicConfigProcessingError(
+				fmt.Errorf(
+					"%w: [%s] failed to decrypt config key %s using driver %s: %w",
+					ErrConfigProcessing,
+					rpc.GetName(),
+					key,
+					encDriver,
+					err,
+				),
+			)
 		}
 
 		return fmt.Sprintf(pattern, string(decrypted)), true
 	case strings.HasPrefix(str, "LOOKUP["):
 		Logger.Debugf("[%s] looking up %s", rpc.GetName(), key)
-		closingIdx := strings.Index(str, "]")
-		pattern := "%s"
-		if closingIdx < len(str)-1 && str[closingIdx+1] == ':' {
-			pattern = str[closingIdx+2:]
-		}
-		parts := strings.SplitN(str[7:closingIdx], ",", 2)
+		parts, pattern := splitConfigRef(rpc, key, "LOOKUP", str, 7)
 		lookupDriver := parts[0]
 		if lookupDriver == "deferred" {
 			result := "LOOKUP[" + parts[1] + "]"
@@ -70,9 +120,18 @@ func DecryptString(rpc RPCCaller, key, str string) (string, bool) {
 			optional = true
 			p = parts[1][1:]
 		}
-		lookupValue, e := rpc.CallRaw("driver:"+lookupDriver, "lookup", []byte(p))
-		if !optional {
-			Must(e)
+		lookupValue, err := rpc.CallRaw("driver:"+lookupDriver, "lookup", []byte(p))
+		if err != nil && !optional {
+			panicConfigProcessingError(
+				fmt.Errorf(
+					"%w: [%s] failed to resolve LOOKUP using driver %s for config key %s: %w",
+					ErrConfigProcessing,
+					rpc.GetName(),
+					lookupDriver,
+					key,
+					err,
+				),
+			)
 		}
 
 		return fmt.Sprintf(pattern, string(lookupValue)), true

--- a/pkg/dipper/encryption_test.go
+++ b/pkg/dipper/encryption_test.go
@@ -93,6 +93,95 @@ data:
 	assert.Equal(t, "not encrypted", MustGetMapDataStr(data, "data.item1"), "data.item1 should remain unchanged")
 }
 
+func TestDecryptAllPanicsOnDecryptError(t *testing.T) {
+	doc := `
+data:
+  item1: not encrypted
+  item2: ENC[noexist,YWFiYmNjZGQ=]
+`
+
+	c := &RPCCallerBase{}
+
+	expect := []MessageReceiver{
+		&NullReceiver{
+			SendMessageFunc: func(msg *Message) {
+				assert.Equalf(t,
+					Message{
+						Channel: "rpc",
+						Subject: "call",
+						IsRaw:   true,
+						Payload: []byte("aabbccdd"),
+						Labels: map[string]string{
+							"caller":  "-",
+							"feature": "driver:noexist",
+							"method":  "decrypt",
+							"rpcID":   "0",
+						},
+					},
+					*msg,
+					"should make call to decrypt item2",
+				)
+				c.HandleReturn(&Message{
+					Channel: "rpc",
+					Subject: "return",
+					IsRaw:   true,
+					Labels: map[string]string{
+						"caller":  "-",
+						"feature": "driver:noexist",
+						"method":  "decrypt",
+						"rpcID":   "0",
+						"error":   "failed to decrypt",
+					},
+				})
+			},
+		},
+	}
+
+	assert.PanicsWithError(t,
+		"config processing failed: [mockCaller] failed to decrypt config key data.item2 using driver noexist: rpc error: reason: failed to decrypt",
+		func() {
+			wrapDecryptAll(t, doc, expect, c)
+		},
+		"decrypt errors should fail config processing",
+	)
+}
+
+func TestDecryptAllPanicsOnInvalidEncryptedData(t *testing.T) {
+	doc := `
+data:
+  item1: not encrypted
+  item2: ENC[noexist,!!!!]
+`
+
+	c := &RPCCallerBase{}
+
+	assert.PanicsWithError(t,
+		"config processing failed: [mockCaller] encrypted config value for key data.item2 should be base64 encoded: illegal base64 data at input byte 0",
+		func() {
+			wrapDecryptAll(t, doc, nil, c)
+		},
+		"invalid encrypted data should fail config processing",
+	)
+}
+
+func TestDecryptAllPanicsOnInvalidEncryptedReference(t *testing.T) {
+	doc := `
+data:
+  item1: not encrypted
+  item2: ENC[noexist]
+`
+
+	c := &RPCCallerBase{}
+
+	assert.PanicsWithError(t,
+		"config processing failed: [mockCaller] invalid ENC config value for key data.item2",
+		func() {
+			wrapDecryptAll(t, doc, nil, c)
+		},
+		"invalid encrypted references should fail config processing",
+	)
+}
+
 func TestDecryptAllWithDeferred(t *testing.T) {
 	doc := `
 data:
@@ -113,6 +202,126 @@ data:
 
 	data := wrapDecryptAll(t, doc, expect, c)
 	assert.Equal(t, "ENC[driver1,YWFiYmNjZGQ=]", MustGetMapDataStr(data, "data.item3.item4"), "item4 should be stripped off one deferred flag")
+	assert.Equal(t, "not encrypted", MustGetMapDataStr(data, "data.item1"), "data.item1 should remain unchanged")
+}
+
+func TestDecryptAllPanicsOnLookUpError(t *testing.T) {
+	doc := `
+data:
+  item1: not encrypted
+  item2: LOOKUP[kvstore,secret/path]
+`
+
+	c := &RPCCallerBase{}
+
+	expect := []MessageReceiver{
+		&NullReceiver{
+			SendMessageFunc: func(msg *Message) {
+				assert.Equalf(t,
+					Message{
+						Channel: "rpc",
+						Subject: "call",
+						IsRaw:   true,
+						Payload: []byte("secret/path"),
+						Labels: map[string]string{
+							"caller":  "-",
+							"feature": "driver:kvstore",
+							"method":  "lookup",
+							"rpcID":   "0",
+						},
+					},
+					*msg,
+					"should make call to lookup for item2",
+				)
+				c.HandleReturn(&Message{
+					Channel: "rpc",
+					Subject: "return",
+					IsRaw:   true,
+					Labels: map[string]string{
+						"caller":  "-",
+						"feature": "driver:kvstore",
+						"method":  "lookup",
+						"rpcID":   "0",
+						"error":   "failed to lookup",
+					},
+				})
+			},
+		},
+	}
+
+	assert.PanicsWithError(t,
+		"config processing failed: [mockCaller] failed to resolve LOOKUP using driver kvstore for config key data.item2: rpc error: reason: failed to lookup",
+		func() {
+			wrapDecryptAll(t, doc, expect, c)
+		},
+		"lookup errors should fail config processing",
+	)
+}
+
+func TestDecryptAllPanicsOnInvalidLookUpReference(t *testing.T) {
+	doc := `
+data:
+  item1: not encrypted
+  item2: LOOKUP[kvstore]
+`
+
+	c := &RPCCallerBase{}
+
+	assert.PanicsWithError(t,
+		"config processing failed: [mockCaller] invalid LOOKUP config value for key data.item2",
+		func() {
+			wrapDecryptAll(t, doc, nil, c)
+		},
+		"invalid lookup references should fail config processing",
+	)
+}
+
+func TestDecryptAllWithOptionalLookUpErrorAndPattern(t *testing.T) {
+	doc := `
+data:
+  item1: not encrypted
+  item2: "LOOKUP[kvstore,?secret/path]:prefix-%s"
+`
+
+	c := &RPCCallerBase{}
+
+	expect := []MessageReceiver{
+		&NullReceiver{
+			SendMessageFunc: func(msg *Message) {
+				assert.Equalf(t,
+					Message{
+						Channel: "rpc",
+						Subject: "call",
+						IsRaw:   true,
+						Payload: []byte("secret/path"),
+						Labels: map[string]string{
+							"caller":  "-",
+							"feature": "driver:kvstore",
+							"method":  "lookup",
+							"rpcID":   "0",
+						},
+					},
+					*msg,
+					"should make call to lookup for item2",
+				)
+				c.HandleReturn(&Message{
+					Channel: "rpc",
+					Subject: "return",
+					IsRaw:   true,
+					Labels: map[string]string{
+						"caller":  "-",
+						"feature": "driver:kvstore",
+						"method":  "lookup",
+						"rpcID":   "0",
+						"error":   "failed to lookup",
+					},
+				})
+			},
+		},
+	}
+
+	data := wrapDecryptAll(t, doc, expect, c)
+	assert.Equal(t, "prefix-", MustGetMapDataStr(data, "data.item2"), "optional lookup errors should preserve pattern with empty value")
 	assert.Equal(t, "not encrypted", MustGetMapDataStr(data, "data.item1"), "data.item1 should remain unchanged")
 }
 


### PR DESCRIPTION
## Summary

- port #768 to the v4 branch
- fail config processing when ENC/LOOKUP RPC calls return errors instead of replacing values with empty strings
- preserve v4 DecryptString pattern formatting and optional LOOKUP behavior
- include the final #768 hardening for malformed config refs, typed config-processing errors, redacted LOOKUP error logs, and reload recovery from non-error panics

## Why

A transient gcloud-secret lookup failure can otherwise resolve LOOKUP[...] to an empty string and apply broken webhook signing-secret config on one replica. Malformed config values should also fail the reload cleanly so the daemon can roll back instead of crashing.

## Tests

- `GOPROXY=direct GOSUMDB=off GOCACHE=/private/tmp/codex-gocache-honeydipper-v4-direct GOMODCACHE=/private/tmp/codex-gomodcache-honeydipper-v4-direct /private/tmp/go1.25.0-darwin-arm64/go/bin/go test ./pkg/dipper ./internal/service ./internal/config`
