### PR TITLE
fix: only use TokenCounter when set to 'simple' and write token counts back to messages [SUPERSEDED]

### DIFF
--- a/internal/agent/agent_compaction.go
+++ b/internal/agent/agent_compaction.go
@@ -127,7 +127,13 @@ func (s *AgentSession) handleCompactionResult(c AgentToolCall, toolResults []map
 
 	// Update in-memory history
 	s.history = newHistory
-	s.PrevContextSize = 0 // reset previous context size since we're starting fresh with the summary as context
+	s.PrevContextSize = 0  // reset previous context size since we're starting fresh with the summary as context
+	s.lastCountedIndex = 0 // reset token counting index for incremental counting
+
+	// Reset ContextTokens in ConvoState since history changed
+	lockedConvoStateUpdate(s.ConvoID, s.store, func(cs *ConvoState) {
+		cs.ContextTokens = 0
+	})
 	s.CurrentCall = 0
 	s.ToolResults = nil
 

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -228,7 +228,7 @@ func (s *AgentSession) setup(msg *dipper.Message, store AgentStore, locking bool
 		}
 
 		// Initialize custom token counter if configured
-		if s.Agent != nil && s.Agent.TokenCounter != "" && s.Agent.TokenCounter != "default" {
+		if s.Agent != nil && s.Agent.TokenCounter == "simple" {
 			s.TokenCounter = &SimpleTokenCounter{}
 		}
 	}
@@ -316,6 +316,10 @@ func (s *AgentSession) initNewSession(id string, msg *dipper.Message, store Agen
 			cs.Agent = interpolateAgentConfig(s.store, msg.Labels["agent_name"], msg.Payload)
 		}
 		s.Agent = cs.Agent
+		// Initialize custom token counter if configured
+		if s.Agent != nil && s.Agent.TokenCounter == "simple" {
+			s.TokenCounter = &SimpleTokenCounter{}
+		}
 		cs.registerSession(s.ID, agentName, s.Type, true)
 	})
 	// Also register in the unified convo state when it spans multiple convo IDs
@@ -529,13 +533,19 @@ func (s *AgentSession) sendToDriver() {
 		if s.lastCountedIndex == 0 {
 			// First send: count system prompt + all history messages
 			cs.ContextTokens = s.countSystemPromptTokens()
-			for _, msg := range s.history {
-				cs.ContextTokens += s.countMessageTokens(msg)
+			for i, msg := range s.history {
+				msgTokens := s.countMessageTokens(msg)
+				cs.ContextTokens += msgTokens
+				// Write token counts back to the message for UI display
+				s.history[i].InputTokens = msgTokens
 			}
 		} else {
 			// Subsequent sends: only count new messages since last counted index
 			for i := s.lastCountedIndex; i < len(s.history); i++ {
-				cs.ContextTokens += s.countMessageTokens(s.history[i])
+				msgTokens := s.countMessageTokens(s.history[i])
+				cs.ContextTokens += msgTokens
+				// Write token counts back to the message for UI display
+				s.history[i].InputTokens = msgTokens
 			}
 		}
 		// Update lastCountedIndex to current history length
@@ -643,6 +653,8 @@ func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 	s.TotalTokens = s.InputTokens + s.OutputTokens
 
 	// Count output tokens (including tool call arguments) and add to context
+
+	// Count output tokens (including tool call arguments) and add to context
 	// for next round trip. This ensures tool calls and their arguments are
 	// included in the context token count.
 	outputTokens := s.countMessageTokens(*agentMsg)
@@ -650,8 +662,10 @@ func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 		cs.ContextTokens += outputTokens
 	})
 
-	// Streaming chunk: non-complete agent content with no tool calls and not a thinking token.
-	// Accumulate in PendingContent to avoid one Redis rpush per chunk.
+	// Write output tokens back to the message for UI display in convo history
+	if s.TokenCounter != nil {
+		agentMsg.OutputTokens = outputTokens
+	}
 	if agentMsg.Role == RoleAgent && !agentMsg.IsComplete {
 		s.PendingContent += agentMsg.Content
 		s.PendingThoughts += agentMsg.Thoughts

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -59,6 +59,7 @@ type AgentSession struct {
 	TotalTokens           int
 	InputTokens           int
 	OutputTokens          int
+	TokenCounter          agentpkg.TokenCounter
 	ParentSessionID       string
 	ParentTurnID          string
 	ParentToolCallID      string
@@ -220,6 +221,11 @@ func (s *AgentSession) setup(msg *dipper.Message, store AgentStore, locking bool
 		s.Agent = cs.Agent
 		if s.Agent == nil {
 			panic(fmt.Sprintf("agent config not found for session %s: ConvoState.Agent=nil", s.ID))
+		}
+
+		// Initialize custom token counter if configured
+		if s.Agent != nil && s.Agent.TokenCounter != "" && s.Agent.TokenCounter != "default" {
+			s.TokenCounter = &SimpleTokenCounter{}
 		}
 	}
 
@@ -461,7 +467,13 @@ func (s *AgentSession) sendToDriver() {
 		log.Infof("[agent] session [%s] sending to driver=%s engine=%s history_len=%d tools=%d",
 			s.ID, s.Agent.Driver, s.Agent.Engine, len(history), len(tools))
 	}
-	s.InputTokens = 0
+	// Count input tokens using custom counter if configured
+	if s.TokenCounter != nil {
+		for _, msg := range history {
+			s.InputTokens += s.TokenCounter.CountTokens(msg.Content)
+		}
+	}
+
 	s.OutputTokens = 0
 	dipper.Must(s.store.CallNoWait("driver:"+s.Agent.Driver, "send_to_model", map[string]interface{}{
 		"engine":         s.Agent.Engine,
@@ -545,9 +557,18 @@ func (s *AgentSession) processAgentResponse(msg *dipper.Message) {
 func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 	// Streaming chunk: non-complete agent content with no tool calls and not a thinking token.
 	// Accumulate in PendingContent to avoid one Redis rpush per chunk.
-	s.InputTokens += agentMsg.InputTokens
-	s.OutputTokens += agentMsg.OutputTokens
-	s.TotalTokens += agentMsg.InputTokens + agentMsg.OutputTokens
+	// Use custom token counter if configured, otherwise use driver-reported values
+	if s.TokenCounter != nil {
+		if agentMsg.Role == RoleAgent {
+			s.OutputTokens += s.TokenCounter.CountTokens(agentMsg.Content)
+		}
+		// Input tokens are counted in sendToDriver(), don't add driver-reported values
+		// to avoid double counting
+	} else {
+		s.InputTokens += agentMsg.InputTokens
+		s.OutputTokens += agentMsg.OutputTokens
+	}
+	s.TotalTokens = s.InputTokens + s.OutputTokens
 
 	// Streaming chunk: non-complete agent content with no tool calls and not a thinking token.
 	// Accumulate in PendingContent to avoid one Redis rpush per chunk.

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -63,6 +63,7 @@ type AgentSession struct {
 	ParentSessionID       string
 	ParentTurnID          string
 	ParentToolCallID      string
+	lastCountedIndex      int // index of last message counted in ConvoState.ContextTokens
 
 	store AgentStore
 }
@@ -210,6 +211,9 @@ func (s *AgentSession) setup(msg *dipper.Message, store AgentStore, locking bool
 		s.load(id, store)
 		s.store = store
 		s.loadConvoHistory()
+		// Set lastCountedIndex after loading history so incremental counting
+		// starts from the correct position.
+		s.lastCountedIndex = len(s.history)
 	} else {
 		s.initNewSession(id, msg, store)
 	}
@@ -242,6 +246,7 @@ func (s *AgentSession) initNewSession(id string, msg *dipper.Message, store Agen
 	s.Type, _ = dipper.GetMapDataStr(msg.Payload, "type")
 	if s.Type == "" {
 		s.Type = agentpkg.SessionTypeChatTurn
+		s.lastCountedIndex = 0 // initialize token counting index for new session
 	}
 
 	s.TTL = AgentSessionDefaultTTL
@@ -252,6 +257,9 @@ func (s *AgentSession) initNewSession(id string, msg *dipper.Message, store Agen
 	if convoID, ok := dipper.GetMapDataStr(msg.Payload, "convo_id"); ok && convoID != "" {
 		s.ConvoID = convoID
 		s.loadConvoHistory()
+		// Set lastCountedIndex after loading history so incremental counting
+		// starts from the correct position.
+		s.lastCountedIndex = len(s.history)
 	} else {
 		s.ConvoID = dipper.NewUUID()
 	}
@@ -431,6 +439,58 @@ func (s *AgentSession) recover() {
 	s.sendToDriver()
 }
 
+// countMessageTokens counts all tokens in a message including content, tool calls, and tool results.
+// It uses the SimpleTokenCounter as the default implementation.
+func (s *AgentSession) countMessageTokens(msg AgentMessage) int {
+	counter := &SimpleTokenCounter{}
+
+	total := 0
+
+	// Count content tokens
+	total += counter.CountTokens(msg.Content)
+
+	// Count thoughts tokens
+	total += counter.CountTokens(msg.Thoughts)
+
+	// Count tool call tokens (function names and parameters)
+	for _, tc := range msg.ToolCalls {
+		total += counter.CountTokens(tc.FuncName)
+		// Convert params to string for counting
+		if tc.Params != nil {
+			paramsStr := fmt.Sprintf("%v", tc.Params)
+			total += counter.CountTokens(paramsStr)
+		}
+	}
+
+	// Count tool result tokens
+	for _, tr := range msg.ToolResult {
+		resultStr := fmt.Sprintf("%v", tr)
+		total += counter.CountTokens(resultStr)
+	}
+
+	return total
+}
+
+// countSystemPromptTokens counts tokens in the system prompt.
+func (s *AgentSession) countSystemPromptTokens() int {
+	counter := &SimpleTokenCounter{}
+
+	systemPrompt := s.Agent.SystemPrompt
+	if s.Type == AgentSessionTypeInference && len(s.Agent.InferencePrompt) > 0 {
+		systemPrompt = s.Agent.InferencePrompt
+	}
+
+	return counter.CountTokens(systemPrompt)
+}
+
+// getConvoContextTokens safely retrieves the current context tokens from ConvoState.
+func (s *AgentSession) getConvoContextTokens() int {
+	cs := &ConvoState{}
+	cs.load(s.ConvoID, s.store)
+
+	return cs.ContextTokens
+}
+
 func (s *AgentSession) sendToDriver() {
 	tools := s.BuildTools()
 	timeout := s.CurrentMsg.Labels["timeout"]
@@ -463,18 +523,30 @@ func (s *AgentSession) sendToDriver() {
 	history = append(history, AgentMessage{Role: RoleSystem, Content: systemPrompt})
 	history = append(history, s.history...)
 
-	if log := s.log(); log != nil {
-		log.Infof("[agent] session [%s] sending to driver=%s engine=%s history_len=%d tools=%d",
-			s.ID, s.Agent.Driver, s.Agent.Engine, len(history), len(tools))
-	}
-	// Count input tokens using custom counter if configured
-	if s.TokenCounter != nil {
-		for _, msg := range history {
-			s.InputTokens += s.TokenCounter.CountTokens(msg.Content)
+	// Incremental token counting: count system prompt on first send, then only
+	// count new messages since last counted index.
+	lockedConvoStateUpdate(s.ConvoID, s.store, func(cs *ConvoState) {
+		if s.lastCountedIndex == 0 {
+			// First send: count system prompt + all history messages
+			cs.ContextTokens = s.countSystemPromptTokens()
+			for _, msg := range s.history {
+				cs.ContextTokens += s.countMessageTokens(msg)
+			}
+		} else {
+			// Subsequent sends: only count new messages since last counted index
+			for i := s.lastCountedIndex; i < len(s.history); i++ {
+				cs.ContextTokens += s.countMessageTokens(s.history[i])
+			}
 		}
-	}
+		// Update lastCountedIndex to current history length
+		s.lastCountedIndex = len(s.history)
+	})
 
-	s.OutputTokens = 0
+	if log := s.log(); log != nil {
+		log.Infof("[agent] session [%s] sending to driver=%s engine=%s history_len=%d tools=%d context_tokens=%d",
+			s.ID, s.Agent.Driver, s.Agent.Engine, len(history), len(tools), s.getConvoContextTokens())
+	}
+	s.InputTokens = 0
 	dipper.Must(s.store.CallNoWait("driver:"+s.Agent.Driver, "send_to_model", map[string]interface{}{
 		"engine":         s.Agent.Engine,
 		"history":        history,
@@ -569,6 +641,14 @@ func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 		s.OutputTokens += agentMsg.OutputTokens
 	}
 	s.TotalTokens = s.InputTokens + s.OutputTokens
+
+	// Count output tokens (including tool call arguments) and add to context
+	// for next round trip. This ensures tool calls and their arguments are
+	// included in the context token count.
+	outputTokens := s.countMessageTokens(*agentMsg)
+	lockedConvoStateUpdate(s.ConvoID, s.store, func(cs *ConvoState) {
+		cs.ContextTokens += outputTokens
+	})
 
 	// Streaming chunk: non-complete agent content with no tool calls and not a thinking token.
 	// Accumulate in PendingContent to avoid one Redis rpush per chunk.

--- a/internal/agent/convo_state.go
+++ b/internal/agent/convo_state.go
@@ -28,16 +28,19 @@ const (
 
 // ConvoSessionRef is a compact record of an agent session that belongs to a conversation.
 type ConvoSessionRef struct {
-	SessionID    string    `json:"session_id"`
-	AgentName    string    `json:"agent_name"`
-	Type         string    `json:"type"`
-	Status       string    `json:"status"`
-	ErrorReason  string    `json:"error_reason,omitempty"`
-	InputTokens  int       `json:"input_tokens,omitempty"`
-	OutputTokens int       `json:"output_tokens,omitempty"`
-	TotalTokens  int       `json:"total_tokens,omitempty"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	SessionID    string `json:"session_id"`
+	AgentName    string `json:"agent_name"`
+	Type         string `json:"type"`
+	Status       string `json:"status"`
+	ErrorReason  string `json:"error_reason,omitempty"`
+	InputTokens  int    `json:"input_tokens,omitempty"`
+	OutputTokens int    `json:"output_tokens,omitempty"`
+	TotalTokens  int    `json:"total_tokens,omitempty"`
+	// ContextTokens tracks the token count of the current history including
+	// system message, persisted for incremental counting across round trips.
+	ContextTokens int       `json:"context_tokens,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
 }
 
 // ConvoState is the persisted, queryable view of a conversation.
@@ -55,7 +58,10 @@ type ConvoState struct {
 	Cancelled      bool             `json:"cancelled"`
 	// TotalTokens accumulates the sum of input+output tokens for
 	// completed/failed sessions that belonged to this conversation.
-	TotalTokens    int      `json:"total_tokens,omitempty"`
+	TotalTokens int `json:"total_tokens,omitempty"`
+	// ContextTokens tracks the token count of the current history including
+	// system message, persisted for incremental counting across round trips.
+	ContextTokens  int      `json:"context_tokens,omitempty"`
 	Generation     int      `json:"generation"`
 	ArchivedConvos []string `json:"archived_convos,omitempty"`
 	TTL            string   `json:"ttl"`

--- a/internal/agent/token_counter_integration_test.go
+++ b/internal/agent/token_counter_integration_test.go
@@ -1,0 +1,82 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	agentpkg "github.com/honeydipper/honeydipper/v4/pkg/agent"
+)
+
+func TestAgentSession_CustomTokenCounter_FieldPresent(t *testing.T) {
+	// Verify AgentSession has TokenCounter field
+	session := &AgentSession{}
+
+	// Test that we can set it
+	session.TokenCounter = &SimpleTokenCounter{}
+
+	if session.TokenCounter == nil {
+		t.Error("Failed to set TokenCounter field")
+	}
+}
+
+func TestAgentSession_CustomTokenCounter_CountTokens(t *testing.T) {
+	counter := &SimpleTokenCounter{}
+
+	tests := []struct {
+		name     string
+		text     string
+		expected int
+	}{
+		{"empty", "", 0},
+		{"short", "hello", 1},
+		{"typical", "The quick brown fox jumps", 6},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := counter.CountTokens(tc.text)
+			if result != tc.expected {
+				t.Errorf("CountTokens(%q) = %d, want %d", tc.text, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestAgentSession_TokenCounterConfigIntegration(t *testing.T) {
+	// Test that Agent config TokenCounter field can be read
+	agent := &config.Agent{
+		Name:         "test-agent",
+		TokenCounter: "custom",
+	}
+
+	if agent.TokenCounter != "custom" {
+		t.Errorf("Expected TokenCounter to be 'custom', got %q", agent.TokenCounter)
+	}
+}
+
+func TestAgentSession_TokenCounter_NilBehavior(t *testing.T) {
+	// When TokenCounter is nil, session should work without custom counting
+	session := &AgentSession{
+		TokenCounter: nil,
+		InputTokens:  10,
+		OutputTokens: 20,
+	}
+
+	// Verify default behavior works
+	session.TotalTokens = session.InputTokens + session.OutputTokens
+
+	if session.TotalTokens != 30 {
+		t.Errorf("Expected TotalTokens = 30, got %d", session.TotalTokens)
+	}
+}
+
+func TestAgentSession_TokenCounter_InterfaceCompliance(t *testing.T) {
+	// Verify SimpleTokenCounter implements agentpkg.TokenCounter interface
+	var _ agentpkg.TokenCounter = (*SimpleTokenCounter)(nil)
+
+	counter := &SimpleTokenCounter{}
+	result := counter.CountTokens("test text")
+	if result < 1 {
+		t.Error("CountTokens should return at least 1 for non-empty text")
+	}
+}

--- a/internal/agent/token_counting_test.go
+++ b/internal/agent/token_counting_test.go
@@ -1,0 +1,276 @@
+// Copyright 2024 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeTestAgent() config.Agent {
+	return config.Agent{
+		Name:         "testagent",
+		Driver:       "openai",
+		Engine:       "gpt-4",
+		SystemPrompt: "You are a helpful assistant.",
+	}
+}
+
+func TestCountMessageTokens_EmptyMessage(t *testing.T) {
+	store := newMockStore(nil)
+	agent := makeTestAgent()
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	s := &AgentSession{
+		ID:    "test-session",
+		Agent: &agent,
+		store: store,
+	}
+
+	msg := AgentMessage{}
+	tokens := s.countMessageTokens(msg)
+	assert.Equal(t, 0, tokens, "Empty message should have 0 tokens")
+}
+
+func TestCountMessageTokens_ContentOnly(t *testing.T) {
+	store := newMockStore(nil)
+	agent := makeTestAgent()
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	s := &AgentSession{
+		ID:    "test-session",
+		Agent: &agent,
+		store: store,
+	}
+
+	msg := AgentMessage{
+		Content: "Hello, world!",
+	}
+	tokens := s.countMessageTokens(msg)
+	// "Hello, world!" has 13 chars, 13/4 = 3 tokens
+	assert.Equal(t, 3, tokens)
+}
+
+func TestCountMessageTokens_WithToolCalls(t *testing.T) {
+	store := newMockStore(nil)
+	agent := makeTestAgent()
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	s := &AgentSession{
+		ID:    "test-session",
+		Agent: &agent,
+		store: store,
+	}
+
+	msg := AgentMessage{
+		Content: "Calling a tool",
+		ToolCalls: []AgentToolCall{
+			{
+				FuncName: "sys_test__action",
+				Params: map[string]interface{}{
+					"param1": "value1",
+				},
+			},
+		},
+	}
+	tokens := s.countMessageTokens(msg)
+	assert.True(t, tokens > 10, "Message with tool calls should have more than 10 tokens, got %d", tokens)
+}
+
+func TestCountMessageTokens_WithToolResults(t *testing.T) {
+	store := newMockStore(nil)
+	agent := makeTestAgent()
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	s := &AgentSession{
+		ID:    "test-session",
+		Agent: &agent,
+		store: store,
+	}
+
+	msg := AgentMessage{
+		Role: RoleToolResult,
+		ToolResult: []map[string]interface{}{
+			{
+				"status": "success",
+				"data":   "result data",
+			},
+		},
+	}
+	tokens := s.countMessageTokens(msg)
+	assert.True(t, tokens > 0, "Tool result message should have tokens, got %d", tokens)
+}
+
+func TestCountMessageTokens_WithThoughts(t *testing.T) {
+	store := newMockStore(nil)
+	agent := makeTestAgent()
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	s := &AgentSession{
+		ID:    "test-session",
+		Agent: &agent,
+		store: store,
+	}
+
+	msg := AgentMessage{
+		Content:  "Hello",
+		Thoughts: "I should respond politely",
+	}
+	tokens := s.countMessageTokens(msg)
+	assert.Equal(t, 7, tokens)
+}
+
+func TestCountSystemPromptTokens_Default(t *testing.T) {
+	store := newMockStore(nil)
+	agent := makeTestAgent()
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	s := &AgentSession{
+		ID:    "test-session",
+		Type:  AgentSessionTypeChatTurn,
+		Agent: &agent,
+		store: store,
+	}
+
+	tokens := s.countSystemPromptTokens()
+	assert.Equal(t, 7, tokens)
+}
+
+func TestCountSystemPromptTokens_InferencePrompt(t *testing.T) {
+	store := newMockStore(nil)
+	agent := config.Agent{
+		Name:            "testagent",
+		Driver:          "openai",
+		Engine:          "gpt-4",
+		SystemPrompt:    "You are a helpful assistant.",
+		InferencePrompt: "Answer the question.",
+	}
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	s := &AgentSession{
+		ID:    "test-session",
+		Type:  AgentSessionTypeInference,
+		Agent: &agent,
+		store: store,
+	}
+
+	tokens := s.countSystemPromptTokens()
+	assert.Equal(t, 5, tokens)
+}
+
+func TestConvoStateContextTokens_Persistence(t *testing.T) {
+	store := newMockStore(nil)
+	agent := makeTestAgent()
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	cs := &ConvoState{
+		ConvoID:       "test-convo",
+		ContextTokens: 100,
+		TTL:           "72h",
+	}
+	cs.persist(store)
+
+	cs2 := &ConvoState{}
+	cs2.load("test-convo", store)
+	assert.Equal(t, 100, cs2.ContextTokens, "ContextTokens should be persisted and loaded")
+}
+
+func TestLastCountedIndex_InitNewSession(t *testing.T) {
+	store := newMockStore(nil)
+	agent := makeTestAgent()
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_name": "testagent",
+		},
+		Payload: map[string]interface{}{
+			"type": AgentSessionTypeChatTurn,
+			"text": "hello",
+		},
+	}
+
+	s := &AgentSession{}
+	s.initNewSession("test-id", msg, store)
+
+	assert.Equal(t, 0, s.lastCountedIndex, "New session should have lastCountedIndex = 0")
+}
+
+func TestLastCountedIndex_LoadSession(t *testing.T) {
+	store := newMockStore(nil)
+	agent := makeTestAgent()
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	s := &AgentSession{
+		ID:      "test-session",
+		ConvoID: "test-convo",
+		Agent:   &agent,
+		history: []AgentMessage{
+			{Role: RoleUser, Content: "Hello"},
+			{Role: RoleAgent, Content: "Hi there!"},
+		},
+		store: store,
+	}
+	s.persist(false)
+
+	msg := &dipper.Message{
+		Labels: map[string]string{
+			"agent_session_id": "test-session",
+			"agent_name":       "testagent",
+		},
+		Payload: map[string]interface{}{
+			"type":     AgentSessionTypeChatTurn,
+			"convo_id": "test-convo",
+		},
+	}
+
+	s2 := &AgentSession{}
+	s2.setup(msg, store, false)
+	s2.history = []AgentMessage{
+		{Role: RoleUser, Content: "Hello"},
+		{Role: RoleAgent, Content: "Hi there!"},
+	}
+	s2.lastCountedIndex = len(s2.history)
+	assert.Equal(t, 2, s2.lastCountedIndex, "Loaded session should have lastCountedIndex = len(history)")
+}
+
+func TestCompactionResetsContextTokens(t *testing.T) {
+	store := newMockStore(nil)
+	agent := makeTestAgent()
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	cs := &ConvoState{
+		ConvoID:       "test-convo",
+		ContextTokens: 500,
+		TTL:           "72h",
+	}
+	cs.persist(store)
+
+	s := &AgentSession{
+		ID:               "test-session",
+		ConvoID:          "test-convo",
+		Agent:            &agent,
+		lastCountedIndex: 10,
+		store:            store,
+	}
+
+	s.lastCountedIndex = 0
+	lockedConvoStateUpdate(s.ConvoID, s.store, func(cs *ConvoState) {
+		cs.ContextTokens = 0
+	})
+
+	cs2 := &ConvoState{}
+	cs2.load("test-convo", store)
+	assert.Equal(t, 0, cs2.ContextTokens, "ContextTokens should be reset after compaction")
+	assert.Equal(t, 0, s.lastCountedIndex, "lastCountedIndex should be reset after compaction")
+}

--- a/internal/agent/token_counting_test.go
+++ b/internal/agent/token_counting_test.go
@@ -274,3 +274,214 @@ func TestCompactionResetsContextTokens(t *testing.T) {
 	assert.Equal(t, 0, cs2.ContextTokens, "ContextTokens should be reset after compaction")
 	assert.Equal(t, 0, s.lastCountedIndex, "lastCountedIndex should be reset after compaction")
 }
+
+func TestTokenCountsWrittenBackToMessages(t *testing.T) {
+	store := newMockStore(nil)
+	agent := makeTestAgent()
+	agent.TokenCounter = "simple"
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	s := &AgentSession{
+		ID:               "test-session",
+		ConvoID:          "test-convo",
+		Agent:            &agent,
+		TokenCounter:     &SimpleTokenCounter{},
+		store:            store,
+		lastCountedIndex: 0,
+	}
+
+	// Add some history messages
+	s.history = []AgentMessage{
+		{Role: RoleUser, Content: "Hello"},
+		{Role: RoleAgent, Content: "Hi there!"},
+	}
+
+	// Create a mock ConvoState
+	cs := &ConvoState{
+		ConvoID: "test-convo",
+		TTL:     "72h",
+	}
+	cs.persist(store)
+
+	// Count tokens and write back to messages
+	for i, msg := range s.history {
+		msgTokens := s.countMessageTokens(msg)
+		s.history[i].InputTokens = msgTokens
+	}
+
+	// Verify token counts were written back
+	if s.history[0].InputTokens == 0 {
+		t.Errorf("Expected InputTokens > 0 for first message, got %d", s.history[0].InputTokens)
+	}
+	if s.history[1].InputTokens == 0 {
+		t.Errorf("Expected InputTokens > 0 for second message, got %d", s.history[1].InputTokens)
+	}
+
+	// Verify the tokens are reasonable (1 token ≈ 4 chars)
+	// "Hello" = 5 chars = 1 token
+	if s.history[0].InputTokens != 1 {
+		t.Errorf("Expected InputTokens = 1 for 'Hello', got %d", s.history[0].InputTokens)
+	}
+}
+
+func TestOutputTokensWrittenBackToAgentMessage(t *testing.T) {
+	store := newMockStore(nil)
+	agent := makeTestAgent()
+	agent.TokenCounter = "simple"
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	s := &AgentSession{
+		ID:           "test-session",
+		ConvoID:      "test-convo",
+		Agent:        &agent,
+		TokenCounter: &SimpleTokenCounter{},
+		store:        store,
+	}
+
+	// Create a mock ConvoState
+	cs := &ConvoState{
+		ConvoID: "test-convo",
+		TTL:     "72h",
+	}
+	cs.persist(store)
+
+	// Create an agent message
+	agentMsg := &AgentMessage{
+		Role:    RoleAgent,
+		Content: "This is a test response",
+	}
+
+	// Count output tokens
+	outputTokens := s.countMessageTokens(*agentMsg)
+
+	// Simulate writing back to message (as done in processAgentMessage)
+	agentMsg.OutputTokens = outputTokens
+
+	// Verify output tokens were written back
+	if agentMsg.OutputTokens == 0 {
+		t.Errorf("Expected OutputTokens > 0, got %d", agentMsg.OutputTokens)
+	}
+
+	// "This is a test response" = 24 chars = 6 tokens
+	if agentMsg.OutputTokens < 5 || agentMsg.OutputTokens > 7 {
+		t.Errorf("Expected OutputTokens between 5-7 for test message, got %d", agentMsg.OutputTokens)
+	}
+}
+
+func TestTokenCountsNotWrittenBackWhenTokenCounterNil(t *testing.T) {
+	store := newMockStore(nil)
+	agent := makeTestAgent()
+	agent.TokenCounter = "" // Not set to "simple"
+	store.cfg.DataSet.Agents["testagent"] = agent
+
+	s := &AgentSession{
+		ID:           "test-session",
+		Agent:        &agent,
+		TokenCounter: nil, // No custom counter
+		store:        store,
+	}
+
+	// Create an agent message
+	agentMsg := &AgentMessage{
+		Role:    RoleAgent,
+		Content: "Test message",
+	}
+
+	// Simulate what happens in processAgentMessage when TokenCounter is nil
+	// Should use driver-reported values instead of custom counting
+	if s.TokenCounter == nil {
+		agentMsg.InputTokens = 10  // Simulated driver-reported value
+		agentMsg.OutputTokens = 20 // Simulated driver-reported value
+	}
+
+	// Verify driver-reported values are used
+	if agentMsg.InputTokens != 10 {
+		t.Errorf("Expected InputTokens = 10 (driver-reported), got %d", agentMsg.InputTokens)
+	}
+	if agentMsg.OutputTokens != 20 {
+		t.Errorf("Expected OutputTokens = 20 (driver-reported), got %d", agentMsg.OutputTokens)
+	}
+}
+
+func TestTokenCounterOnlyUsedWhenSetToSimple(t *testing.T) {
+	store := newMockStore(nil)
+
+	// Test with TokenCounter set to "simple" - should use custom counter
+	agentSimple := config.Agent{
+		Name:         "testagent-simple",
+		Driver:       "openai",
+		Engine:       "gpt-4",
+		SystemPrompt: "You are a helpful assistant.",
+		TokenCounter: "simple",
+	}
+	store.cfg.DataSet.Agents["testagent-simple"] = agentSimple
+
+	sSimple := &AgentSession{}
+
+	// TokenCounter should be initialized when set to "simple"
+	sSimple.setup(&dipper.Message{
+		Labels: map[string]string{
+			"agent_name": "testagent-simple",
+		},
+		Payload: map[string]interface{}{
+			"type": AgentSessionTypeChatTurn,
+			"text": "hello",
+		},
+	}, store, false)
+
+	if sSimple.TokenCounter == nil {
+		t.Error("TokenCounter should be initialized when agent.TokenCounter is set to 'simple'")
+	}
+
+	// Test with TokenCounter set to other values - should NOT use custom counter
+	agentOther := config.Agent{
+		Name:         "testagent-other",
+		Driver:       "openai",
+		Engine:       "gpt-4",
+		SystemPrompt: "You are a helpful assistant.",
+		TokenCounter: "other",
+	}
+	store.cfg.DataSet.Agents["testagent-other"] = agentOther
+
+	sOther := &AgentSession{}
+
+	sOther.setup(&dipper.Message{
+		Labels: map[string]string{
+			"agent_name": "testagent-other",
+		},
+		Payload: map[string]interface{}{
+			"type": AgentSessionTypeChatTurn,
+			"text": "hello",
+		},
+	}, store, false)
+
+	if sOther.TokenCounter != nil {
+		t.Error("TokenCounter should NOT be initialized when agent.TokenCounter is set to 'other'")
+	}
+
+	// Test with TokenCounter empty - should NOT use custom counter
+	agentEmpty := config.Agent{
+		Name:         "testagent-empty",
+		Driver:       "openai",
+		Engine:       "gpt-4",
+		SystemPrompt: "You are a helpful assistant.",
+		TokenCounter: "",
+	}
+	store.cfg.DataSet.Agents["testagent-empty"] = agentEmpty
+
+	sEmpty := &AgentSession{}
+
+	sEmpty.setup(&dipper.Message{
+		Labels: map[string]string{
+			"agent_name": "testagent-empty",
+		},
+		Payload: map[string]interface{}{
+			"type": AgentSessionTypeChatTurn,
+			"text": "hello",
+		},
+	}, store, false)
+
+	if sEmpty.TokenCounter != nil {
+		t.Error("TokenCounter should NOT be initialized when agent.TokenCounter is empty")
+	}
+}


### PR DESCRIPTION
Superseded by changes pushed directly to PR #773.