### PR TITLE
feat: add distributed per-conversation turn-locking to agent store

### DIFF
--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -254,6 +254,23 @@ func (p *PersistentAgentStore) StartNewConvo(agentName, text, user string) strin
 // conversation. It must be called from within a goroutine that has already
 // incremented p.wg; it does NOT add/done the WaitGroup itself.
 func (p *PersistentAgentStore) runTurn(agentName, convoID, text, user string) {
+	// Acquire a distributed turn lock so only one turn executes at a time
+	// per conversation. The locker driver already polls every 100ms while
+	// the key is held, so no additional busy-wait is needed here.
+	lockKey := ConvoTurnLockPrefix + convoID
+	dipper.Must(p.Call("locker", "lock", map[string]interface{}{
+		"name":   lockKey,
+		"expire": "1h",
+	}, "timeout", "30m"))
+	// Defer unlock so it runs last (LIFO): after s.persist() and recovery.
+	// The timeout label controls how long the locker driver waits for a
+	// Redis response before giving up.
+	defer func() {
+		dipper.Must(p.Call("locker", "unlock", map[string]interface{}{
+			"name": lockKey,
+		}, "timeout", "30s"))
+	}()
+
 	msg := &dipper.Message{
 		Labels: map[string]string{
 			"agent_name": agentName,

--- a/internal/agent/convo_state.go
+++ b/internal/agent/convo_state.go
@@ -13,6 +13,12 @@ import (
 // ConvoState cache-key prefix, stream prefix, and session-status values.
 const (
 	ConvoStateKeyPrefix = "convo_state:"
+	// ConvoTurnLockPrefix is the distributed-lock key prefix used to serialise
+	// chat turns on the same conversation. Only one turn may execute at a time
+	// per conversation; subsequent turns block until the current one finishes.
+	// The locker driver polls every 100ms while the key is held, so no
+	// additional busy-wait is needed.
+	ConvoTurnLockPrefix = "convo_turn:"
 	// ConvoStream is the stream_hset prefix used to track convo-state changes.
 	ConvoStream = "convo_stream_"
 	// ConvoStreamTTL is how long each 2-hour stream block is kept in Redis.


### PR DESCRIPTION
## Summary

Implements distributed per-conversation turn-locking so that only one chat turn may execute at a time per conversation. Subsequent turns on the same conversation block (via the locker driver's built-in 100ms polling) until the current turn finishes.

## Changes

### `internal/agent/convo_state.go`
- Added `ConvoTurnLockPrefix = "convo_turn:"` constant — the distributed-lock key prefix used to serialise chat turns on the same conversation.

### `internal/agent/agent_store.go`
- In `runTurn`: acquires a distributed lock via the locker driver at the start of the function and defers its release.
  - Lock key: `convo_turn:<convoID>`
  - Lock parameters: `expire: "1h"`, label `timeout: "30m"`
  - Unlock parameters: label `timeout: "30s"`
- Uses `dipper.Must` for both lock/unlock calls (panic/recover error handling).
- Defer for unlock is registered **before** `s.setup()` so it runs last in LIFO order — after `s.persist()` and recovery.

## Design Notes
- The locker driver already polls every 100ms while a key is held, so no additional busy-wait is needed.
- The 1h expire TTL provides crash recovery: if the process crashes mid-turn, the lock auto-releases after 1h.
- The 30m timeout on the lock call gives the RPC layer ample time to reach Redis before giving up.
- The 30s timeout on the unlock call ensures the unlock RPC has enough time to complete.

## Testing
- `go test ./internal/agent/...` — all tests pass ✅
- `golangci-lint run ./internal/agent/...` — zero lint issues ✅