### PR TITLE
feat: add optional engine/driver override parameters to conversation APIs and workflow call_agent

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -309,6 +309,14 @@ func (s *AgentSession) initNewSession(id string, msg *dipper.Message, store Agen
 		if cs.Agent == nil {
 			cs.Agent = interpolateAgentConfig(s.store, msg.Labels["agent_name"], msg.Payload)
 		}
+		// Apply optional engine/driver overrides from the API request payload.
+		// These override the agent config values when non-empty.
+		if engine, ok := dipper.GetMapDataStr(msg.Payload, "engine"); ok && engine != "" {
+			cs.Agent.Engine = engine
+		}
+		if driver, ok := dipper.GetMapDataStr(msg.Payload, "driver"); ok && driver != "" {
+			cs.Agent.Driver = driver
+		}
 		s.Agent = cs.Agent
 		cs.registerSession(s.ID, agentName, s.Type, true)
 	})

--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -24,10 +24,12 @@ type AgentStore interface {
 	CancelConvo(msg *dipper.Message)
 	// StartTurn fires a new chat turn on an existing conversation without a
 	// return path back to a workflow. It is used by the UI-initiated turn API.
-	StartTurn(convoID, text, user string)
+	// engine and driver are optional overrides; empty strings mean "no override".
+	StartTurn(convoID, text, user, engine, driver string)
 	// StartNewConvo starts a brand-new conversation for the named agent and
 	// returns the generated convo_id synchronously. The session runs asynchronously.
-	StartNewConvo(agentName, text, user string) string
+	// engine and driver are optional overrides; empty strings mean "no override".
+	StartNewConvo(agentName, text, user, engine, driver string) string
 
 	GetAgent(name string) *config.Agent
 	GetSystem(name string) *config.System
@@ -202,7 +204,8 @@ func (p *PersistentAgentStore) Stop() {
 // StartTurn starts a new chat turn on an existing conversation without a workflow
 // return path. The agent name is inferred from the most recent session recorded in
 // the ConvoState. The turn runs asynchronously; errors are logged, not propagated.
-func (p *PersistentAgentStore) StartTurn(convoID, text, user string) {
+// engine and driver are optional overrides; empty strings mean "no override".
+func (p *PersistentAgentStore) StartTurn(convoID, text, user, engine, driver string) {
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
@@ -230,13 +233,14 @@ func (p *PersistentAgentStore) StartTurn(convoID, text, user string) {
 		}
 
 		p.Infof("[agent] StartTurn convo=%s agent=%s", convoID, agentName)
-		p.runTurn(agentName, convoID, text, user)
+		p.runTurn(agentName, convoID, text, user, engine, driver)
 	}()
 }
 
 // StartNewConvo starts a brand-new conversation for the named agent and returns
 // the generated convo_id synchronously. The session runs asynchronously.
-func (p *PersistentAgentStore) StartNewConvo(agentName, text, user string) string {
+// engine and driver are optional overrides; empty strings mean "no override".
+func (p *PersistentAgentStore) StartNewConvo(agentName, text, user, engine, driver string) string {
 	convoID := dipper.NewUUID()
 	p.wg.Add(1)
 	go func() {
@@ -244,7 +248,7 @@ func (p *PersistentAgentStore) StartNewConvo(agentName, text, user string) strin
 		defer dipper.SafeExitOnError("[agent] error in StartNewConvo")
 
 		p.Infof("[agent] StartNewConvo convo=%s agent=%s", convoID, agentName)
-		p.runTurn(agentName, convoID, text, user)
+		p.runTurn(agentName, convoID, text, user, engine, driver)
 	}()
 
 	return convoID
@@ -253,7 +257,7 @@ func (p *PersistentAgentStore) StartNewConvo(agentName, text, user string) strin
 // runTurn creates and runs a single chat-turn session for the given agent and
 // conversation. It must be called from within a goroutine that has already
 // incremented p.wg; it does NOT add/done the WaitGroup itself.
-func (p *PersistentAgentStore) runTurn(agentName, convoID, text, user string) {
+func (p *PersistentAgentStore) runTurn(agentName, convoID, text, user, engine, driver string) {
 	// Acquire a distributed turn lock so only one turn executes at a time
 	// per conversation. The locker driver already polls every 100ms while
 	// the key is held, so no additional busy-wait is needed here.
@@ -271,15 +275,25 @@ func (p *PersistentAgentStore) runTurn(agentName, convoID, text, user string) {
 		}, "timeout", "30s"))
 	}()
 
+	payload := map[string]interface{}{
+		"text":     text,
+		"user":     user,
+		"convo_id": convoID,
+	}
+	// Pass optional engine/driver overrides through the message payload
+	// so initNewSession can pick them up.
+	if engine != "" {
+		payload["engine"] = engine
+	}
+	if driver != "" {
+		payload["driver"] = driver
+	}
+
 	msg := &dipper.Message{
 		Labels: map[string]string{
 			"agent_name": agentName,
 		},
-		Payload: map[string]interface{}{
-			"text":     text,
-			"user":     user,
-			"convo_id": convoID,
-		},
+		Payload: payload,
 	}
 
 	s := &AgentSession{}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -144,7 +144,7 @@ func (m *mockStore) CallNoWait(feature, method string, params interface{}, label
 	return nil
 }
 
-func (m *mockStore) getNoWaitParams(key string) map[string]interface{} { //nolint:unparam
+func (m *mockStore) getNoWaitParams(key string) map[string]interface{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.noWaitParams == nil {
@@ -164,15 +164,15 @@ func (m *mockStore) CallRawNoWait(feature, method string, params []byte, rpcID s
 
 func (m *mockStore) GetName() string { return "mock-store" }
 
-func (m *mockStore) StartInference(msg *dipper.Message)                {}
-func (m *mockStore) ContinueInference(msg *dipper.Message)             {}
-func (m *mockStore) ReceiveInference(msg *dipper.Message)              {}
-func (m *mockStore) PollInference(msg *dipper.Message)                 {}
-func (m *mockStore) StartAgentCall(msg *dipper.Message)                {}
-func (m *mockStore) StartMCPCall(msg *dipper.Message)                  {}
-func (m *mockStore) CancelConvo(msg *dipper.Message)                   {}
-func (m *mockStore) StartTurn(convoID, text, user string)              {}
-func (m *mockStore) StartNewConvo(agentName, text, user string) string { return "" }
+func (m *mockStore) StartInference(msg *dipper.Message)                                {}
+func (m *mockStore) ContinueInference(msg *dipper.Message)                             {}
+func (m *mockStore) ReceiveInference(msg *dipper.Message)                              {}
+func (m *mockStore) PollInference(msg *dipper.Message)                                 {}
+func (m *mockStore) StartAgentCall(msg *dipper.Message)                                {}
+func (m *mockStore) StartMCPCall(msg *dipper.Message)                                  {}
+func (m *mockStore) CancelConvo(msg *dipper.Message)                                   {}
+func (m *mockStore) StartTurn(convoID, text, user, engine, driver string)              {}
+func (m *mockStore) StartNewConvo(agentName, text, user, engine, driver string) string { return "" }
 
 func (m *mockStore) GetAgent(name string) *config.Agent {
 	a := m.cfg.DataSet.Agents[name]
@@ -1871,7 +1871,7 @@ func TestStartTurn_UsesParentAgentWhenLastSessionIsSubAgent(t *testing.T) {
 
 	store := NewAgentStore(helper, "").(*PersistentAgentStore)
 
-	store.StartTurn(convoID, "hello again", "user1")
+	store.StartTurn(convoID, "hello again", "user1", "", "")
 	store.Wait()
 
 	// The new session must be dispatched to the parent agent (super_coder), not code_executor.
@@ -2405,4 +2405,118 @@ func TestSetup_NoForgetHistory_NoMarker(t *testing.T) {
 
 	// No cache:del should be called
 	assert.False(t, store.hasCall("cache:del"), "cache:del should NOT be called without forget_history")
+}
+
+// ---------------------------------------------------------------------------
+// Engine / driver override tests
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Engine / driver override tests
+// ---------------------------------------------------------------------------
+
+func TestAgentOverrideEngineAndDriver_NewConvo(t *testing.T) {
+	cfg := &config.Config{
+		DataSet: &config.DataSet{
+			Agents: map[string]config.Agent{
+				"test_agent": {
+					Name:   "test_agent",
+					Driver: "default_driver",
+					Engine: "default_engine",
+				},
+			},
+			Workflows: map[string]config.Workflow{},
+			Systems:   map[string]config.System{},
+		},
+	}
+	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
+
+	store.StartNewConvo("test_agent", "hello", "user1", "gpt-4", "openai-new")
+	store.Wait()
+
+	// The session should have been created with the overridden engine/driver.
+	params := helper.getNoWaitParams("driver:openai-new:send_to_model")
+	require.NotNil(t, params, "expected send_to_model to be called with overridden driver")
+	engine, ok := params["engine"].(string)
+	require.True(t, ok, "engine must be a string")
+	assert.Equal(t, "gpt-4", engine, "engine should be overridden")
+}
+
+func TestAgentOverrideEngineAndDriver_ExistingTurn(t *testing.T) {
+	convoID := dipper.NewUUID()
+	cfg := &config.Config{
+		DataSet: &config.DataSet{
+			Agents: map[string]config.Agent{
+				"test_agent": {
+					Name:   "test_agent",
+					Driver: "default_driver",
+					Engine: "default_engine",
+				},
+			},
+			Workflows: map[string]config.Workflow{},
+			Systems:   map[string]config.System{},
+		},
+	}
+
+	cs := &ConvoState{
+		ConvoID: convoID,
+		TTL:     ConvoStreamTTL,
+		Agent:   &config.Agent{Name: "test_agent", Driver: "default_driver", Engine: "default_engine"},
+		FirstSession: &ConvoSessionRef{
+			SessionID: "session-first",
+			AgentName: "test_agent",
+			Type:      AgentSessionTypeChatTurn,
+			Status:    ConvoSessionStatusComplete,
+		},
+		LastSession: &ConvoSessionRef{
+			SessionID: "session-last",
+			AgentName: "test_agent",
+			Type:      AgentSessionTypeChatTurn,
+			Status:    ConvoSessionStatusComplete,
+		},
+	}
+
+	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
+	helper.resp["cache:load:"+ConvoStateKeyPrefix+convoID] = mustMarshalJSON(cs)
+	helper.resp["cache:lrange:"+ConvoHistoryKeyPrefix+convoID] = mustMarshalJSON([]AgentMessage{})
+
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
+
+	store.StartTurn(convoID, "follow up", "user1", "claude-3", "anthropic")
+	store.Wait()
+
+	params := helper.getNoWaitParams("driver:anthropic:send_to_model")
+	require.NotNil(t, params, "expected send_to_model to be called with overridden driver")
+	engine, ok := params["engine"].(string)
+	require.True(t, ok, "engine must be a string")
+	assert.Equal(t, "claude-3", engine, "engine should be overridden")
+}
+
+func TestAgentOverrideEngineAndDriver_NoOverride(t *testing.T) {
+	cfg := &config.Config{
+		DataSet: &config.DataSet{
+			Agents: map[string]config.Agent{
+				"test_agent": {
+					Name:   "test_agent",
+					Driver: "default_driver",
+					Engine: "default_engine",
+				},
+			},
+			Workflows: map[string]config.Workflow{},
+			Systems:   map[string]config.System{},
+		},
+	}
+	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
+
+	store.StartNewConvo("test_agent", "hello", "user1", "", "")
+	store.Wait()
+
+	// No override — should use default_driver from config.
+	params := helper.getNoWaitParams("driver:default_driver:send_to_model")
+	require.NotNil(t, params, "expected send_to_model to be called with default driver")
+	engine, ok := params["engine"].(string)
+	require.True(t, ok, "engine must be a string")
+	assert.Equal(t, "default_engine", engine, "engine should be from agent config")
 }

--- a/internal/agent/pre_context_test.go
+++ b/internal/agent/pre_context_test.go
@@ -81,15 +81,15 @@ func (f *FakeStore) CallWithMessageNoWait(msg *dipper.Message) error     { retur
 func (f *FakeStore) GetName() string                                     { return "fake" }
 
 // AgentStore minimal methods.
-func (f *FakeStore) StartInference(msg *dipper.Message)    {}
-func (f *FakeStore) PollInference(msg *dipper.Message)     {}
-func (f *FakeStore) ContinueInference(msg *dipper.Message) {}
-func (f *FakeStore) ReceiveInference(msg *dipper.Message)  {}
-func (f *FakeStore) StartAgentCall(msg *dipper.Message)    {}
-func (f *FakeStore) StartMCPCall(msg *dipper.Message)      {}
-func (f *FakeStore) CancelConvo(msg *dipper.Message)       {}
-func (f *FakeStore) StartTurn(convoID, text, user string)  {}
-func (f *FakeStore) StartNewConvo(agentName, text, user string) string {
+func (f *FakeStore) StartInference(msg *dipper.Message)                   {}
+func (f *FakeStore) PollInference(msg *dipper.Message)                    {}
+func (f *FakeStore) ContinueInference(msg *dipper.Message)                {}
+func (f *FakeStore) ReceiveInference(msg *dipper.Message)                 {}
+func (f *FakeStore) StartAgentCall(msg *dipper.Message)                   {}
+func (f *FakeStore) StartMCPCall(msg *dipper.Message)                     {}
+func (f *FakeStore) CancelConvo(msg *dipper.Message)                      {}
+func (f *FakeStore) StartTurn(convoID, text, user, engine, driver string) {}
+func (f *FakeStore) StartNewConvo(agentName, text, user, engine, driver string) string {
 	return ""
 }
 func (f *FakeStore) GetAgent(name string) *config.Agent       { return &config.Agent{} }

--- a/internal/api/def.go
+++ b/internal/api/def.go
@@ -55,6 +55,9 @@ func agentDefs() map[string]map[string]Def {
 		"agents": {
 			http.MethodGet: {Object: "agent", Name: "agentList", ReqType: TypeFirst, Service: "agent"},
 		},
+		"engines": {
+			http.MethodGet: {Object: "engine", Name: "agentEngines", ReqType: TypeFirst, Service: "agent"},
+		},
 		"convos/:convoID/history": {
 			http.MethodGet: {Object: "convo", Name: "convoHistory", ReqType: TypeFirst, Service: "agent"},
 		},

--- a/internal/service/agent_apis.go
+++ b/internal/service/agent_apis.go
@@ -24,6 +24,7 @@ func setupAgentAPIs() {
 	agentSvc.APIs["convoTurn"] = handleConvoTurnAPI
 	agentSvc.APIs["convoNew"] = handleConvoNewAPI
 	agentSvc.APIs["agentList"] = handleAgentListAPI
+	agentSvc.APIs["agentEngines"] = handleAgentListEnginesAPI
 }
 
 // buildUserTag combines the authenticated user name and provider into a tag like "user@provider".
@@ -95,22 +96,24 @@ func handleConvoCancelAPI(resp *api.Response) {
 }
 
 // handleConvoTurnAPI starts a new chat turn on an existing conversation from the UI.
-// Expects convoID path param plus text (and optional user) in the request body.
-// The turn runs asynchronously; the API returns immediately with {"ok":true}.
+// Expects convoID path param plus text (and optional user, engine, driver) in the
+// request body. The turn runs asynchronously; the API returns immediately with {"ok":true}.
 func handleConvoTurnAPI(resp *api.Response) {
 	resp.Request = dipper.DeserializePayload(resp.Request)
 	convoID := dipper.MustGetMapDataStr(resp.Request.Payload, "convoID")
 
 	// POST body arrives as a JSON string under payload["body"].
 	var body struct {
-		Text string `json:"text"`
+		Text   string `json:"text"`
+		Engine string `json:"engine"`
+		Driver string `json:"driver"`
 	}
 	if bodyStr, ok := dipper.GetMapDataStr(resp.Request.Payload, "body"); ok && bodyStr != "" {
 		_ = json.Unmarshal([]byte(bodyStr), &body)
 	}
 
 	user := buildUserTag(resp.Request.Labels["user"], resp.Request.Labels["user_provider"])
-	agentStore.StartTurn(convoID, body.Text, user)
+	agentStore.StartTurn(convoID, body.Text, user, body.Engine, body.Driver)
 
 	resp.Return([]byte(`{"ok":true}`))
 }
@@ -123,15 +126,17 @@ func handleConvoNewAPI(resp *api.Response) {
 	resp.Request = dipper.DeserializePayload(resp.Request)
 
 	var body struct {
-		Agent string `json:"agent"`
-		Text  string `json:"text"`
+		Agent  string `json:"agent"`
+		Text   string `json:"text"`
+		Engine string `json:"engine"`
+		Driver string `json:"driver"`
 	}
 	if bodyStr, ok := dipper.GetMapDataStr(resp.Request.Payload, "body"); ok && bodyStr != "" {
 		_ = json.Unmarshal([]byte(bodyStr), &body)
 	}
 
 	user := buildUserTag(resp.Request.Labels["user"], resp.Request.Labels["user_provider"])
-	convoID := agentStore.StartNewConvo(body.Agent, body.Text, user)
+	convoID := agentStore.StartNewConvo(body.Agent, body.Text, user, body.Engine, body.Driver)
 
 	data := dipper.Must(json.Marshal(map[string]string{"convo_id": convoID})).([]byte)
 	resp.Return(data)
@@ -148,5 +153,32 @@ func handleAgentListAPI(resp *api.Response) {
 	sort.Strings(names)
 
 	data := dipper.Must(json.Marshal(names)).([]byte)
+	resp.Return(data)
+}
+
+// handleAgentListEnginesAPI returns a sorted JSON array of unique {driver, engine}
+// pairs from all configured agents. The UI uses this to populate the engine/driver
+// override dropdown. Pairs are deduplicated by "driver:engine" key.
+func handleAgentListEnginesAPI(resp *api.Response) {
+	agents := agentStore.GetConfig().DataSet.Agents
+	type engineEntry struct {
+		Driver string `json:"driver"`
+		Engine string `json:"engine"`
+	}
+	seen := map[string]bool{}
+	entries := []engineEntry{}
+	for _, agent := range agents {
+		key := agent.Driver + ":" + agent.Engine
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		entries = append(entries, engineEntry{Driver: agent.Driver, Engine: agent.Engine})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Driver+":"+entries[i].Engine < entries[j].Driver+":"+entries[j].Engine
+	})
+
+	data := dipper.Must(json.Marshal(entries)).([]byte)
 	resp.Return(data)
 }

--- a/internal/service/agent_svc_test.go
+++ b/internal/service/agent_svc_test.go
@@ -55,10 +55,14 @@ func (m *mockAgentStore) PollInference(_ *dipper.Message)     { m.record("poll")
 func (m *mockAgentStore) StartAgentCall(_ *dipper.Message)    { m.record("agent_call") }
 func (m *mockAgentStore) StartMCPCall(_ *dipper.Message)      { m.record("mcp_call") }
 func (m *mockAgentStore) CancelConvo(_ *dipper.Message)       { m.record("cancel_convo") }
-func (m *mockAgentStore) StartTurn(_, _, _ string)            { m.record("start_turn") }
-func (m *mockAgentStore) StartNewConvo(_, _, _ string) string { m.record("start_new_convo"); return "" } //nolint:nlreturn
-func (m *mockAgentStore) Stop()                               {}
-func (m *mockAgentStore) Wait()                               {}
+func (m *mockAgentStore) StartTurn(_, _, _, _, _ string)      { m.record("start_turn") }
+func (m *mockAgentStore) StartNewConvo(_, _, _, _, _ string) string {
+	m.record("start_new_convo")
+
+	return ""
+}
+func (m *mockAgentStore) Stop() {}
+func (m *mockAgentStore) Wait() {}
 
 func (m *mockAgentStore) GetAgent(_ string) *config.Agent       { return &config.Agent{} }
 func (m *mockAgentStore) GetSystem(_ string) *config.System     { return &config.System{} }


### PR DESCRIPTION
## Summary

Adds optional `engine` and `driver` parameters to the existing start-conversation (`POST /convos`) and start-turn (`POST /convos/:convoID/turn`) APIs — and, via workflow `call_agent` with-block — to allow switching AI engine/driver mid-conversation.

### Phase 1 (API Layer)

- **`internal/agent/agent_store.go`**: Updated `AgentStore` interface — `StartTurn()` and `StartNewConvo()` now accept optional `engine`/`driver` overrides (empty strings = no override). Updated `PersistentAgentStore` methods and `runTurn()` to pass overrides through the message payload.
- **`internal/agent/agent_session.go`**: In `initNewSession()`, inside the `lockedConvoStateUpdate` callback, checks for `engine` and `driver` in `msg.Payload` and overrides the corresponding fields. Gets atomically persisted.
- **`internal/service/agent_apis.go`**: Updated `handleConvoTurnAPI` and `handleConvoNewAPI` to parse optional `engine`/`driver` from request body JSON. Added `handleAgentListEnginesAPI` — scans configured agents, deduplicates unique `{driver, engine}` pairs, returns sorted JSON array.
- **`internal/api/def.go`**: Added `"engines"` route with `GET` method registered in `agentDefs()`.
- **Tests**: Added `TestAgentOverrideEngineAndDriver_NewConvo`, `TestAgentOverrideEngineAndDriver_ExistingTurn`, and `TestAgentOverrideEngineAndDriver_NoOverride`. All pass.

### Phase 2 (Workflow Layer)

- **`pkg/workflow/execute.go`**: In `callAgent()`, reads `engine` and `driver` from `w.Ctx` using `dipper.GetMapDataStr()` and includes them in the `agent_start` message payload when non-empty — following the same pattern as other optional context fields (`user`, `type`, `convo_id`, `turn_timeout`, `turn_ttl`).

  Workflow YAML example:
  ```yaml
  - call_agent: myagent
    with:
      text: "Fix this bug"
      engine: gpt-4o
      driver: openai
  ```

- **Tests**: Added `TestCallAgent_PassesEngineDriverOverrides` — verifies engine/driver appear in the emitted message payload with correct values.

## Testing
```
go test -tags='!integration' ./...  # all pass
golangci-lint run ./...             # 0 issues
```