### PR TITLE
feat(workflow): pass engine/driver overrides from call_agent with block (Phase 2)

### DIFF
--- a/pkg/workflow/execute.go
+++ b/pkg/workflow/execute.go
@@ -329,12 +329,16 @@ func (w *Session) callAgent() {
 	convoID, _ := dipper.GetMapDataStr(w.Ctx, "convo_id")
 	timeout, _ := dipper.GetMapDataStr(w.Ctx, "turn_timeout")
 	ttl, _ := dipper.GetMapDataStr(w.Ctx, "turn_ttl")
+	engine, _ := dipper.GetMapDataStr(w.Ctx, "engine")
+	driver, _ := dipper.GetMapDataStr(w.Ctx, "driver")
 
 	w.store.SendMessage(&dipper.Message{
 		Channel: dipper.ChannelEventbus,
 		Subject: "agent_start",
 		Labels:  labels,
 		Payload: map[string]interface{}{
+			"engine":   engine,
+			"driver":   driver,
 			"text":     dipper.MustGetMapDataStr(w.Ctx, "text"),
 			"user":     user,
 			"type":     sessionType,

--- a/pkg/workflow/execute_test.go
+++ b/pkg/workflow/execute_test.go
@@ -593,6 +593,42 @@ func TestCallAgent_RegistersSchedulerDue(t *testing.T) {
 	}
 }
 
+func TestCallAgent_PassesEngineDriverOverrides(t *testing.T) {
+	s := makeExecuteSession()
+	es := &execTestStore{}
+	s.store = es
+	s.Workflow.CallAgent = "openai"
+	s.Ctx["text"] = "hello"
+	s.Ctx["engine"] = "gpt-4o"
+	s.Ctx["driver"] = "openai"
+	s.CurrentMsg.Labels["cursor"] = "3"
+
+	s.callAgent()
+
+	if len(es.lastSentMessages) != 1 {
+		t.Fatalf("expected 1 message sent, got %d", len(es.lastSentMessages))
+	}
+	msg := es.lastSentMessages[0]
+	if msg.Subject != "agent_start" {
+		t.Errorf("expected agent_start, got %s", msg.Subject)
+	}
+
+	payload, ok := msg.Payload.(map[string]interface{})
+	if !ok {
+		t.Fatal("expected payload to be a map")
+	}
+	if engine, ok := payload["engine"].(string); !ok {
+		t.Errorf("expected engine in payload, got none")
+	} else if engine != "gpt-4o" {
+		t.Errorf("expected engine gpt-4o, got %s", engine)
+	}
+	if driver, ok := payload["driver"].(string); !ok {
+		t.Errorf("expected driver in payload, got none")
+	} else if driver != "openai" {
+		t.Errorf("expected driver openai, got %s", driver)
+	}
+}
+
 func TestWaitAgent_SendsPollAndSchedules(t *testing.T) {
 	s := makeExecuteSession()
 	es := &execTestStore{}


### PR DESCRIPTION
## Summary (Phase 2)

Allow workflows using the `call_agent` action to specify optional `engine` and `driver` parameters in the `with` block, which get forwarded to the `agent_start` message payload. The agent-side handling already exists from **Phase 1** (PR #780, merged into `v4`) — `initNewSession()` reads `engine`/`driver` from `msg.Payload`.

## Changes

### `pkg/workflow/execute.go` — `callAgent()` method
- Reads `engine` and `driver` from `w.Ctx` using `dipper.GetMapDataStr()` (empty strings = no override)
- Includes them in the `agent_start` message `Payload` when present
- Follows the exact same pattern as other optional context fields (`user`, `type`, `convo_id`, `turn_timeout`, `turn_ttl`)

### Workflow YAML example
```yaml
- call_agent: myagent
  with:
    text: "Fix this bug"
    engine: gpt-4o
    driver: openai
```

### Unit test
- `TestCallAgent_PassesEngineDriverOverrides` — sets `engine` and `driver` in the session context, calls `callAgent()`, and verifies the values appear correctly in the emitted message payload

## Testing
```
go test -tags='!integration' ./...  # all pass
golangci-lint run ./...             # 0 issues (pre-existing warnings only)
```