### PR TITLE
feat: cache built tools in ConvoState to avoid rebuilding on every call

### DIFF
--- a/internal/agent/convo_state.go
+++ b/internal/agent/convo_state.go
@@ -72,8 +72,9 @@ type ConvoState struct {
 	ArchivedConvos []string `json:"archived_convos,omitempty"`
 	TTL            string   `json:"ttl"`
 
-	Agent  *config.Agent     `json:"agent,omitempty"`
-	Skills map[string]string `json:"skills,omitempty"`
+	Agent  *config.Agent        `json:"agent,omitempty"`
+	Skills map[string]string    `json:"skills,omitempty"`
+	Tools  map[string]AgentTool `json:"tools,omitempty"`
 }
 
 // load reads and deserialises the ConvoState for convoID from the cache.

--- a/internal/agent/pre_context.go
+++ b/internal/agent/pre_context.go
@@ -174,6 +174,7 @@ func (s *AgentSession) resumeWithSkills(skillMap map[string]string) {
 	s.persist(false)
 	lockedConvoStateUpdate(s.ConvoID, s.store, func(cs *ConvoState) {
 		cs.Agent = s.Agent
+		cs.Tools = nil // invalidate tool cache because hd_load_skill may now be needed
 		if len(skillMap) > 0 {
 			cs.Skills = skillMap
 		}

--- a/internal/agent/tool_call.go
+++ b/internal/agent/tool_call.go
@@ -15,7 +15,19 @@ import (
 var ErrToolCall = errors.New("tool call error")
 
 // BuildTools assembles the tool map from the agent's configured system and workflow tools.
+// Results are cached in ConvoState.Tools so repeated calls avoid rebuilding
+// from scratch. The cache is invalidated in resumeWithSkills() when skills
+// are loaded, which may enable the hd_load_skill tool.
 func (s *AgentSession) BuildTools() map[string]AgentTool {
+	// Try cached tools from ConvoState
+	if s.ConvoID != "" {
+		cs := &ConvoState{}
+		cs.load(s.ConvoID, s.store)
+		if cs.Tools != nil {
+			return cs.Tools
+		}
+	}
+
 	tools := map[string]AgentTool{}
 
 	for _, toolDef := range s.Agent.Tools {
@@ -55,6 +67,13 @@ func (s *AgentSession) BuildTools() map[string]AgentTool {
 		Description: "Get the conversation page URL and focus page URL for the current conversation. " +
 			"Use this to obtain URLs that can be sent to external systems like PagerDuty, Slack, etc.",
 		Params: map[string]interface{}{},
+	}
+
+	// Cache tools in ConvoState for future calls
+	if s.ConvoID != "" {
+		lockedConvoStateUpdate(s.ConvoID, s.store, func(cs *ConvoState) {
+			cs.Tools = tools
+		})
 	}
 
 	return tools


### PR DESCRIPTION
## Summary

Cache the assembled tool map in `ConvoState.Tools` so that `BuildTools()` does not need to rebuild from scratch on every call. This avoids redundant Redis calls when `sendToDriver()` and `coerceToolCallParams()` invoke `BuildTools()` multiple times per session.

## Changes

- **convo_state.go**: Added `Tools map[string]AgentTool` field to `ConvoState`
- **tool_call.go**: 
  - At the start of `BuildTools()`, check for cached tools in `ConvoState` (non-locked read)
  - After building, save tools to `ConvoState` via `lockedConvoStateUpdate()`
- **pre_context.go**: Invalidate cached tools in `resumeWithSkills()` by setting `cs.Tools = nil`, forcing a rebuild when `hd_load_skill` may become needed

## Design Decisions

- When `ConvoID` is empty (testing/edge cases), `BuildTools()` falls through to building from scratch without caching
- `cs.load()` in the read path uses a non-locked Redis read (atomic and safe)
- Write path uses `lockedConvoStateUpdate()` for serialized access
- If two goroutines race on the initial build, both build and the second write wins — the result is identical since building is deterministic from the same config
- Existing tests create sessions without `ConvoID`, so they continue to build from scratch — no test changes needed

## Testing

- All existing tests pass
- Linting passes with 0 issues