### PR TITLE
feat: add GET /convos/:convoID endpoint to return ConvoState

### DIFF
--- a/internal/api/def.go
+++ b/internal/api/def.go
@@ -52,6 +52,9 @@ func agentDefs() map[string]map[string]Def {
 			http.MethodGet:  {Object: "convo", Name: "convoList", ReqType: TypeFirst, Service: "agent"},
 			http.MethodPost: {Object: "convo", Name: "convoNew", AttachPrincipalUser: true, ReqType: TypeFirst, Service: "agent"},
 		},
+		"convos/:convoID": {
+			http.MethodGet: {Object: "convo", Name: "convoState", ReqType: TypeFirst, Service: "agent"},
+		},
 		"agents": {
 			http.MethodGet: {Object: "agent", Name: "agentList", ReqType: TypeFirst, Service: "agent"},
 		},

--- a/internal/service/agent_apis.go
+++ b/internal/service/agent_apis.go
@@ -8,6 +8,7 @@ package service
 
 import (
 	"encoding/json"
+	"errors"
 	"sort"
 	"strconv"
 	"strings"
@@ -17,8 +18,12 @@ import (
 	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
 )
 
+// errConvoNotFound is returned when a conversation is not found.
+var errConvoNotFound = errors.New("conversation not found")
+
 func setupAgentAPIs() {
 	agentSvc.APIs["convoList"] = handleConvoList
+	agentSvc.APIs["convoState"] = handleConvoState
 	agentSvc.APIs["convoHistory"] = handleConvoHistory
 	agentSvc.APIs["convoCancel"] = handleConvoCancelAPI
 	agentSvc.APIs["convoTurn"] = handleConvoTurnAPI
@@ -84,6 +89,26 @@ func handleConvoHistory(resp *api.Response) {
 // handleConvoCancelAPI marks a conversation as cancelled by convo_id.
 // Expects convoID path param in the payload. Active sessions belonging to the
 // conversation will detect the flag on their next poll cycle and abort.
+// handleConvoState returns the full ConvoState for a single conversation.
+// Expects convoID path param in the payload.
+// If the conversation does not exist, a 404 error is returned.
+func handleConvoState(resp *api.Response) {
+	resp.Request = dipper.DeserializePayload(resp.Request)
+	convoID := dipper.MustGetMapDataStr(resp.Request.Payload, "convoID")
+
+	data := dipper.Must(agentStore.Call("cache", "load", map[string]any{
+		"key": agent.ConvoStateKeyPrefix + convoID,
+	})).([]byte)
+
+	if len(data) == 0 {
+		resp.ReturnError(errConvoNotFound)
+
+		return
+	}
+
+	resp.Return(data)
+}
+
 func handleConvoCancelAPI(resp *api.Response) {
 	resp.Request = dipper.DeserializePayload(resp.Request)
 	convoID := dipper.MustGetMapDataStr(resp.Request.Payload, "convoID")


### PR DESCRIPTION
## Summary

Add a new API endpoint `GET /convos/:convoID` that returns the full ConvoState JSON for a given conversation. This includes the `agent` field with `engine` and `driver` info, which the frontend needs to display in the engine/driver dropdown.

## Changes

### `internal/api/def.go`
- Added `"convos/:convoID"` route with `http.MethodGet` method in `agentDefs()`
- Route definition: `{Object: "convo", Name: "convoState", ReqType: TypeFirst, Service: "agent"}`

### `internal/service/agent_apis.go`
- Added `handleConvoState` handler function that:
  - Extracts `convoID` from the request payload
  - Loads ConvoState from cache using `agentStore.Call("cache", "load", ...)`
  - Returns the ConvoState as JSON
  - Returns error if conversation is not found (`errConvoNotFound`)
- Registered the handler in `setupAgentAPIs()`
- Added `errConvoNotFound` static error variable

## Testing

```bash
go test ./...  # All tests pass
golangci-lint run ./...  # 0 issues
```

## API Usage

**Request:**
```
GET /api/convos/convo-123
```

**Response (200 OK):**
```json
{
  "convo_id": "convo-123",
  "agent": {
    "driver": "openai",
    "engine": "gpt-4o",
    ...
  },
  "first_session": {...},
  "last_session": {...},
  "active_session": null,
  "cancelled": false,
  ...
}
```

**Response (404 Not Found):**
```json
{
  "error": "conversation not found"
}
```