### PR TITLE
fix: extend turn lock to cover full turn lifecycle across all entry points

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -63,6 +63,10 @@ type AgentSession struct {
 	ParentSessionID       string
 	ParentTurnID          string
 	ParentToolCallID      string
+	// TurnLockKey is the distributed lock key for this conversation's turn.
+	// It is set when the turn lock is acquired and cleared when released.
+	// The lock prevents concurrent sessions from modifying the same conversation.
+	TurnLockKey string
 
 	store AgentStore
 }
@@ -85,6 +89,21 @@ func (s *AgentSession) unlock() {
 	dipper.Must(s.store.Call("locker", "unlock", map[string]interface{}{
 		"name": AgentKeyPrefix + s.ID,
 	}))
+}
+
+// releaseTurnLock releases the distributed turn lock for this session's conversation.
+// It is idempotent: calling it with an empty TurnLockKey is a no-op.
+func (s *AgentSession) releaseTurnLock() {
+	if s.TurnLockKey == "" {
+		return
+	}
+	if log := s.log(); log != nil {
+		log.Debugf("[agent] session [%s] releasing turn lock %q", s.ID, s.TurnLockKey)
+	}
+	dipper.Must(s.store.Call("locker", "unlock", map[string]interface{}{
+		"name": s.TurnLockKey,
+	}, "timeout", "30s"))
+	s.TurnLockKey = ""
 }
 
 // buildConvoURLs constructs the conversation page URL and focus page URL for the
@@ -123,6 +142,7 @@ func (s *AgentSession) persist(unlocking bool) {
 // syncConvoStateStatus updates the session's status in the shared ConvoState(s) when
 // the session has reached a terminal state (complete or failed).
 // It is called after the session lock has been released to avoid nested locking.
+// When a terminal state is detected, it also releases the distributed turn lock.
 func (s *AgentSession) syncConvoStateStatus() {
 	var status string
 	switch {
@@ -154,6 +174,8 @@ func (s *AgentSession) syncConvoStateStatus() {
 
 		cs.updateSessionStatus(s.ID, status, s.ErrorReason, s.InputTokens, s.OutputTokens, s.TotalTokens)
 	})
+
+	s.releaseTurnLock()
 }
 
 // checkCancelled returns true when this session has been marked as cancelled

--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -117,6 +117,16 @@ func (p *PersistentAgentStore) StartInference(msg *dipper.Message) {
 			"agent_session_id": s.ID,
 		},
 	})
+
+	// Acquire the distributed turn lock after setup so s.ConvoID is populated.
+	// The lock is held for the entire turn lifecycle and released by
+	// syncConvoStateStatus() when the session reaches a terminal state.
+	s.TurnLockKey = ConvoTurnLockPrefix + s.ConvoID
+	dipper.Must(p.Call("locker", "lock", map[string]interface{}{
+		"name":   s.TurnLockKey,
+		"expire": "1h",
+	}, "timeout", "30m"))
+
 	defer s.persist(true)
 	defer dipper.SafeExitOnError("[agent] error in running inference for %s", resumeKey, func(r interface{}) {
 		if s.ErrorReason == "" {
@@ -258,23 +268,6 @@ func (p *PersistentAgentStore) StartNewConvo(agentName, text, user, engine, driv
 // conversation. It must be called from within a goroutine that has already
 // incremented p.wg; it does NOT add/done the WaitGroup itself.
 func (p *PersistentAgentStore) runTurn(agentName, convoID, text, user, engine, driver string) {
-	// Acquire a distributed turn lock so only one turn executes at a time
-	// per conversation. The locker driver already polls every 100ms while
-	// the key is held, so no additional busy-wait is needed here.
-	lockKey := ConvoTurnLockPrefix + convoID
-	dipper.Must(p.Call("locker", "lock", map[string]interface{}{
-		"name":   lockKey,
-		"expire": "1h",
-	}, "timeout", "30m"))
-	// Defer unlock so it runs last (LIFO): after s.persist() and recovery.
-	// The timeout label controls how long the locker driver waits for a
-	// Redis response before giving up.
-	defer func() {
-		dipper.Must(p.Call("locker", "unlock", map[string]interface{}{
-			"name": lockKey,
-		}, "timeout", "30s"))
-	}()
-
 	payload := map[string]interface{}{
 		"text":     text,
 		"user":     user,
@@ -298,6 +291,16 @@ func (p *PersistentAgentStore) runTurn(agentName, convoID, text, user, engine, d
 
 	s := &AgentSession{}
 	s.setup(msg, p, true)
+
+	// Acquire the distributed turn lock after setup so s.ConvoID is populated.
+	// The lock is held for the entire turn lifecycle and released automatically
+	// by syncConvoStateStatus() when the session reaches a terminal state.
+	s.TurnLockKey = ConvoTurnLockPrefix + s.ConvoID
+	dipper.Must(p.Call("locker", "lock", map[string]interface{}{
+		"name":   s.TurnLockKey,
+		"expire": "1h",
+	}, "timeout", "30m"))
+
 	defer s.persist(true)
 	defer dipper.SafeExitOnError("[agent] error running turn for convo "+convoID, func(r interface{}) {
 		if s.ErrorReason == "" {


### PR DESCRIPTION
## Summary

This PR addresses the turn-locking issue where the distributed turn lock (`convo_turn:{convoID}`) was only acquired for UI-initiated paths (`StartTurn`/`StartNewConvo`) and released immediately after the async `sendToDriver()` call, instead of being held across the full multi-round-trip lifecycle of a turn. Workflow-initiated paths (`call_agent` → `StartInference`) bypassed the lock entirely, allowing concurrent sessions on the same conversation to corrupt the history.

## Changes

### `internal/agent/agent_session.go`
1. **Added `TurnLockKey` field** to `AgentSession` struct - stores the distributed lock key for the conversation's turn
2. **Added `releaseTurnLock()` method** - releases the lock via the locker driver. It is idempotent (no-op when `TurnLockKey` is empty) and clears the key after releasing
3. **Modified `syncConvoStateStatus()`** - now calls `s.releaseTurnLock()` after the `lockedConvoStateUpdate()` completes, ensuring the turn lock is released only when the session reaches a terminal state (Complete, Failed, or Cancelled)

### `internal/agent/agent_store.go`
4. **Modified `StartInference()`** - acquires the turn lock (`convo_turn:{convoID}`) after `s.setup()` (which populates `s.ConvoID`) and before `s.run()`. Stores the lock key in `s.TurnLockKey`
5. **Modified `runTurn()`** - moved lock acquisition to after session creation (`s.setup()`), set `s.TurnLockKey`, and removed the immediate `defer unlock` - the lock is now released by `syncConvoStateStatus()` when the session reaches a terminal state

### What's NOT changed
- `ContinueInference()` and `ReceiveInference()` - they restore existing sessions that already hold the turn lock, so no new lock is acquired
- `StartAgentCall()` - sub-agent sessions run under the parent session's lifecycle; no separate turn lock needed
- Error/panic handling - the existing `SafeExitOnError` + `persist(true)` chain flows through `syncConvoStateStatus()` which detects `s.ErrorReason != ""` and releases the lock
- Process crashes - the locker's `expire: "1h"` handles this naturally

## Testing
- `go test ./internal/agent/...` - all tests pass
- `golangci-lint run ./internal/agent/...` - no linting issues