### PR TITLE
fix(agent): reload convo history under turn lock to avoid stale tool_use

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -91,6 +91,21 @@ func (s *AgentSession) unlock() {
 	}))
 }
 
+// lockTurn acquires the per-conversation turn lock for convoID and records the
+// key on the session so syncConvoStateStatus/releaseTurnLock can release it when
+// the turn reaches a terminal state. The lock serialises turns within a
+// conversation and is held for the whole turn lifecycle. Take it before reading
+// the conversation history so a turn that waits for an in-flight prior turn
+// resumes from that prior turn's completed history rather than a stale snapshot.
+// store is passed explicitly because this may run before setup() sets s.store.
+func (s *AgentSession) lockTurn(store AgentStore, convoID string) {
+	s.TurnLockKey = ConvoTurnLockPrefix + convoID
+	dipper.Must(store.Call("locker", "lock", map[string]interface{}{
+		"name":   s.TurnLockKey,
+		"expire": "1h",
+	}, "timeout", "30m"))
+}
+
 // releaseTurnLock releases the distributed turn lock for this session's conversation.
 // It is idempotent: calling it with an empty TurnLockKey is a no-op.
 func (s *AgentSession) releaseTurnLock() {
@@ -216,8 +231,16 @@ func (s *AgentSession) load(id string, store AgentStore) {
 // setup initialises a new session or restores an existing one from cache.
 // Returns the conversation ID.
 func (s *AgentSession) setup(msg *dipper.Message, store AgentStore, locking bool) {
-	id, ok := msg.Labels["agent_session_id"]
-	if !ok || id == "" {
+	// A non-empty agent_session_id label means "restore this session". Otherwise
+	// adopt a session id the caller minted before setup (StartInference does this
+	// so it can ack the id and take the turn lock before reading history), and
+	// fall back to generating one.
+	labelID := msg.Labels["agent_session_id"]
+	id := labelID
+	if id == "" {
+		id = s.ID
+	}
+	if id == "" {
 		id = dipper.NewUUID()
 	}
 
@@ -228,7 +251,7 @@ func (s *AgentSession) setup(msg *dipper.Message, store AgentStore, locking bool
 		}))
 	}
 
-	if ok && id != "" {
+	if labelID != "" {
 		s.load(id, store)
 		s.store = store
 		s.loadConvoHistory()

--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -108,7 +108,20 @@ func (p *PersistentAgentStore) StartInference(msg *dipper.Message) {
 	})
 	p.Infof("[agent] StartInference agent=%s", msg.Labels["agent_name"])
 	s := &AgentSession{}
-	s.setup(msg, p, true)
+	defer s.persist(true)
+	defer dipper.SafeExitOnError("[agent] error in running inference for %s", resumeKey, func(r interface{}) {
+		if s.ErrorReason == "" {
+			s.ErrorReason = fmt.Sprintf("%v", r)
+		}
+		s.notifyParentFailure(s.ErrorReason)
+	})
+
+	// StartInference always begins a new turn; tool-call results and other
+	// continuations re-enter via ContinueInference, not here. Mint the session id
+	// up front so we can ack it to the caller — which polls on it — before taking
+	// the turn lock, which can block up to 30m waiting on a prior turn. setup()
+	// adopts this pre-set s.ID.
+	s.ID = dipper.NewUUID()
 	p.EmitMessage(dipper.Message{
 		Channel: dipper.ChannelEventbus,
 		Subject: "agent_response",
@@ -118,22 +131,19 @@ func (p *PersistentAgentStore) StartInference(msg *dipper.Message) {
 		},
 	})
 
-	// Acquire the distributed turn lock after setup so s.ConvoID is populated.
-	// The lock is held for the entire turn lifecycle and released by
-	// syncConvoStateStatus() when the session reaches a terminal state.
-	s.TurnLockKey = ConvoTurnLockPrefix + s.ConvoID
-	dipper.Must(p.Call("locker", "lock", map[string]interface{}{
-		"name":   s.TurnLockKey,
-		"expire": "1h",
-	}, "timeout", "30m"))
+	if convoID, _ := dipper.GetMapDataStr(msg.Payload, "convo_id"); convoID != "" {
+		// Existing conversation: lock before setup so setup's history read happens
+		// under the turn lock and can't pick up a stale snapshot from an in-flight
+		// prior turn.
+		s.lockTurn(p, convoID)
+		s.setup(msg, p, true)
+	} else {
+		// Brand-new conversation: no prior turn exists to race with. Let setup
+		// mint the convo id, then lock it.
+		s.setup(msg, p, true)
+		s.lockTurn(p, s.ConvoID)
+	}
 
-	defer s.persist(true)
-	defer dipper.SafeExitOnError("[agent] error in running inference for %s", resumeKey, func(r interface{}) {
-		if s.ErrorReason == "" {
-			s.ErrorReason = fmt.Sprintf("%v", r)
-		}
-		s.notifyParentFailure(s.ErrorReason)
-	})
 	s.run()
 }
 
@@ -290,16 +300,14 @@ func (p *PersistentAgentStore) runTurn(agentName, convoID, text, user, engine, d
 	}
 
 	s := &AgentSession{}
-	s.setup(msg, p, true)
 
-	// Acquire the distributed turn lock after setup so s.ConvoID is populated.
-	// The lock is held for the entire turn lifecycle and released automatically
-	// by syncConvoStateStatus() when the session reaches a terminal state.
-	s.TurnLockKey = ConvoTurnLockPrefix + s.ConvoID
-	dipper.Must(p.Call("locker", "lock", map[string]interface{}{
-		"name":   s.TurnLockKey,
-		"expire": "1h",
-	}, "timeout", "30m"))
+	// Take the turn lock before setup so the history is read under the lock. The
+	// convo id is known here (it is a parameter), so unlike StartInference we do
+	// not need to run setup first to discover it. This avoids starting the turn
+	// from a stale snapshot when a previous turn for the same conversation is
+	// still in flight (its final tool_result not yet persisted).
+	s.lockTurn(p, convoID)
+	s.setup(msg, p, true)
 
 	defer s.persist(true)
 	defer dipper.SafeExitOnError("[agent] error running turn for convo "+convoID, func(r interface{}) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -47,6 +47,7 @@ type mockStore struct {
 	mu           sync.Mutex
 	calls        []string
 	resp         map[string][]byte
+	lockTriggers map[string]func() // fired when a locker:lock with the keyed name is acquired
 	emitted      []*dipper.Message
 	cfg          *config.Config
 	logger       *logging.Logger
@@ -103,6 +104,20 @@ func (m *mockStore) getEmitted() []*dipper.Message {
 func (m *mockStore) Call(feature, method string, params interface{}, labelsKV ...string) ([]byte, error) {
 	base := feature + ":" + method
 	if p, ok := params.(map[string]interface{}); ok {
+		// Fire any lock trigger registered for this lock name (locks are keyed by
+		// "name"). Tests use this to mutate cache state at the moment a lock is
+		// acquired (e.g. a prior turn completing and persisting its history the
+		// instant the turn lock is granted).
+		if base == "locker:lock" {
+			if name, okn := p["name"].(string); okn {
+				m.mu.Lock()
+				trigger := m.lockTriggers[name]
+				m.mu.Unlock()
+				if trigger != nil {
+					trigger()
+				}
+			}
+		}
 		if k, ok2 := p["key"].(string); ok2 {
 			full := base + ":" + k
 			// If this is a cache save, record the saved value so subsequent
@@ -1678,6 +1693,126 @@ func TestPersistentAgentStore_StartInference(t *testing.T) {
 	assert.True(t, helper.hasCall("driver:openai:send_to_model"))
 	// session should have been persisted.
 	assert.True(t, helper.hasCall("cache:save"))
+}
+
+// assertNoDanglingToolUse fails if any agent tool_use in history is not
+// immediately followed by a tool_result — the malformed shape that triggers the
+// upstream "tool_use without tool_result" 400.
+func assertNoDanglingToolUse(t *testing.T, history []AgentMessage) {
+	t.Helper()
+	for i, m := range history {
+		if m.Role == RoleAgent && len(m.ToolCalls) > 0 {
+			require.Less(t, i+1, len(history),
+				"trailing tool_use with no following message (stale history was sent)")
+			require.Equal(t, RoleToolResult, history[i+1].Role,
+				"tool_use at %d must be followed by a tool_result, got %q", i, history[i+1].Role)
+		}
+	}
+}
+
+// raceHistories returns the stale snapshot a new turn would read while a prior
+// turn is still in flight (ending in an unanswered tool_use) and the completed
+// history that becomes visible once the prior turn finishes.
+func raceHistories() (stale, complete []AgentMessage) {
+	stale = []AgentMessage{
+		{Role: RoleUser, Content: "prior turn"},
+		{Role: RoleAgent, ToolCalls: []AgentToolCall{{FuncName: "ag__sre_github_agent"}}},
+	}
+	complete = []AgentMessage{
+		{Role: RoleUser, Content: "prior turn"},
+		{Role: RoleAgent, ToolCalls: []AgentToolCall{{FuncName: "ag__sre_github_agent"}}},
+		{Role: RoleToolResult, ToolResult: []map[string]interface{}{{"status": "success"}}},
+		{Role: RoleAgent, Content: "done", IsComplete: true},
+	}
+
+	return stale, complete
+}
+
+// TestPersistentAgentStore_StartInference_NewTurnLocksBeforeReadingHistory
+// covers the common new-turn path: StartInference mints the session id up front
+// (so it can ack before the turn lock) and, because the convo id is in the
+// message, takes the turn lock before setup so history is read once, under the
+// lock. The lock trigger simulates the prior turn completing (and persisting its
+// history) the instant the turn lock is granted; without locking first, the
+// request would carry the dangling tool_use.
+func TestPersistentAgentStore_StartInference_NewTurnLocksBeforeReadingHistory(t *testing.T) {
+	cfg := &config.Config{DataSet: &config.DataSet{
+		Agents: map[string]config.Agent{
+			"bot": {Name: "bot", Driver: "openai", Engine: "gpt-4"},
+		},
+		Systems:   map[string]config.System{},
+		Workflows: map[string]config.Workflow{},
+	}}
+	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
+
+	stale, complete := raceHistories()
+	histKey := "cache:lrange:" + ConvoHistoryKeyPrefix + "convo-race"
+	helper.resp[histKey] = mustMarshalJSON(stale)
+	helper.lockTriggers = map[string]func(){
+		ConvoTurnLockPrefix + "convo-race": func() {
+			helper.mu.Lock()
+			helper.resp[histKey] = mustMarshalJSON(complete)
+			helper.mu.Unlock()
+		},
+	}
+
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
+
+	msg := &dipper.Message{
+		Labels: map[string]string{"agent_name": "bot"},
+		Payload: map[string]interface{}{
+			"convo_id": "convo-race",
+			"text":     "new turn triggered by the posted comment",
+		},
+	}
+
+	store.StartInference(msg)
+
+	require.True(t, helper.hasCall("driver:openai:send_to_model"))
+	params := helper.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	history, ok := params["history"].([]AgentMessage)
+	require.True(t, ok, "history should be []AgentMessage")
+	assertNoDanglingToolUse(t, history)
+}
+
+// TestPersistentAgentStore_RunTurn_LocksBeforeReadingHistory verifies runTurn
+// takes the turn lock before reading history (it can, because the convo id is a
+// parameter). The lock trigger swaps the stale snapshot for the completed one
+// the moment the turn lock is granted; if the read happened before the lock the
+// request would carry the dangling tool_use.
+func TestPersistentAgentStore_RunTurn_LocksBeforeReadingHistory(t *testing.T) {
+	cfg := &config.Config{DataSet: &config.DataSet{
+		Agents: map[string]config.Agent{
+			"bot": {Name: "bot", Driver: "openai", Engine: "gpt-4"},
+		},
+		Systems:   map[string]config.System{},
+		Workflows: map[string]config.Workflow{},
+	}}
+	helper := &mockStoreHelper{mockStore: *newMockStore(cfg)}
+
+	stale, complete := raceHistories()
+	histKey := "cache:lrange:" + ConvoHistoryKeyPrefix + "convo-run"
+	helper.resp[histKey] = mustMarshalJSON(stale)
+	helper.lockTriggers = map[string]func(){
+		ConvoTurnLockPrefix + "convo-run": func() {
+			helper.mu.Lock()
+			helper.resp[histKey] = mustMarshalJSON(complete)
+			helper.mu.Unlock()
+		},
+	}
+
+	store := NewAgentStore(helper, "").(*PersistentAgentStore)
+
+	// runTurn does not manage the WaitGroup itself; call it directly.
+	store.runTurn("bot", "convo-run", "new turn", "user", "", "")
+
+	require.True(t, helper.hasCall("driver:openai:send_to_model"))
+	params := helper.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	history, ok := params["history"].([]AgentMessage)
+	require.True(t, ok, "history should be []AgentMessage")
+	assertNoDanglingToolUse(t, history)
 }
 
 func TestPersistentAgentStore_ReceiveInference(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for contributing!

See https://github.com/honeydipper/honeydipper/blob/master/CODE_OF_CONDUCT.md for information on our contributor code of conduct, and https://github.com/honeydipper/honeydipper/tree/master/docs for more information on developing on Honeydipper.

If possible, please follow these guidelines for commit messages:
https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

-->
#### Description
<!--
Add a description of your pull request.
-->
A new turn's setup() loads the conversation history before acquiring the per-conversation turn lock. When a previous turn is still in flight (its final tool_result not yet persisted), that snapshot is stale and can end in an unanswered tool_use. The turn lock serialises turns but does not protect the pre-lock read, so once the lock is finally acquired the turn proceeds from the stale history, appends the new user message after the dangling tool_use, and sends it to the model.

This surfaces as an upstream 400: "tool_use ids were found without tool_result blocks immediately after: call_<N>_0". It is easily triggered when the last tool call posts a PR comment, whose webhook starts a new turn for the same conversation before the current turn finishes.

Reload the history after taking the turn lock in both turn-entry paths (StartInference and runTurn) so each turn starts from the completed prior turn. Adds a regression test that simulates the history changing between the two reads.


#### This PR fixes the following issues
<!--
Replace this comment with fixed issues in the following format:
Fixes #123
Fixes #124
-->
