### PR TITLE
Make stream_hset TTL configurable with default 2 weeks

### DIFF
--- a/drivers/cmd/redis-cache/hset.go
+++ b/drivers/cmd/redis-cache/hset.go
@@ -20,10 +20,16 @@ import (
 	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
 )
 
-const (
-	StreamHsetIntervalHours = 2
-	StreamHsetTTLHours      = 48
+// streamHsetIntervalHours is the time interval in hours for stream_hset blocks.
+// Configurable via driver option "data.stream_interval_hours".
+var streamHsetIntervalHours = 2
 
+// streamHsetTTLHours is the TTL in hours for stream_hset data.
+// Controls how far back conversation history can be retrieved.
+// Default: 336 hours (2 weeks). Configurable via driver option "data.stream_ttl_hours".
+var streamHsetTTLHours = 336
+
+const (
 	streamHvalsScript = `
 	    local sessions = {'"'..KEYS[1]..'"', '"'..KEYS[#KEYS]..'"'}
 
@@ -47,6 +53,42 @@ const (
 	`
 )
 
+// loadStreamConfig loads stream_hset configuration from driver options.
+func loadStreamConfig() {
+	if driver.Options == nil {
+		return
+	}
+
+	if v, ok := dipper.GetMapData(driver.Options, "data.stream_ttl_hours"); ok {
+		switch t := v.(type) {
+		case int64:
+			streamHsetTTLHours = int(t)
+		case int:
+			streamHsetTTLHours = t
+		case float64:
+			streamHsetTTLHours = int(t)
+		default:
+			log.Warningf("[%s] redis cache invalid stream_ttl_hours type %T, using default", driver.Service, t)
+		}
+	}
+
+	if v, ok := dipper.GetMapData(driver.Options, "data.stream_interval_hours"); ok {
+		switch t := v.(type) {
+		case int64:
+			streamHsetIntervalHours = int(t)
+		case int:
+			streamHsetIntervalHours = t
+		case float64:
+			streamHsetIntervalHours = int(t)
+		default:
+			log.Warningf("[%s] redis cache invalid stream_interval_hours type %T, using default", driver.Service, t)
+		}
+	}
+
+	log.Infof("[%s] stream_hset: interval=%dh, ttl=%dh (default: 336h=2w)",
+		driver.Service, streamHsetIntervalHours, streamHsetTTLHours)
+}
+
 func streamHset(msg *dipper.Message) {
 	dipper.DeserializePayload(msg)
 	prefix := dipper.MustGetMapDataStr(msg.Payload, "prefix")
@@ -54,7 +96,7 @@ func streamHset(msg *dipper.Message) {
 	val := dipper.MustGetMapDataStr(msg.Payload, "value")
 	ttl, _ := dipper.GetMapData(msg.Payload, "ttl")
 
-	exp := StreamHsetTTLHours * time.Hour
+	exp := time.Duration(streamHsetTTLHours) * time.Hour
 	if ttl != nil {
 		switch t := ttl.(type) {
 		case int64:
@@ -71,7 +113,7 @@ func streamHset(msg *dipper.Message) {
 	}
 
 	curr := time.Now().Truncate(time.Hour)
-	if df := curr.Hour() % StreamHsetIntervalHours; df != 0 {
+	if df := curr.Hour() % streamHsetIntervalHours; df != 0 {
 		curr = curr.Add(time.Duration(-df) * time.Hour)
 	}
 
@@ -99,15 +141,15 @@ func streamHvals(msg *dipper.Message) {
 	raw, _ := dipper.GetMapDataBool(msg.Payload, "raw")
 
 	end := time.Now().Truncate(time.Hour)
-	oldest := end.Add(-StreamHsetTTLHours * time.Hour)
-	if df := oldest.Hour() % StreamHsetIntervalHours; df != 0 {
+	oldest := end.Add(-time.Duration(streamHsetTTLHours) * time.Hour)
+	if df := oldest.Hour() % streamHsetIntervalHours; df != 0 {
 		oldest = oldest.Add(time.Duration(-df) * time.Hour)
 	}
 
 	if asOf != "" {
 		end = dipper.Must(time.ParseInLocation("2006010215", asOf, oldest.Location())).(time.Time)
 	}
-	if df := end.Hour() % StreamHsetIntervalHours; df != 0 {
+	if df := end.Hour() % streamHsetIntervalHours; df != 0 {
 		end = end.Add(time.Duration(-df) * time.Hour)
 	}
 
@@ -134,16 +176,16 @@ func streamHvals(msg *dipper.Message) {
 		if blocks < 0 {
 			blocks = 0
 		}
-		earliest = end.Add(time.Duration(-blocks*StreamHsetIntervalHours) * time.Hour)
+		earliest = end.Add(-time.Duration(blocks*streamHsetIntervalHours) * time.Hour)
 		if earliest.Before(oldest) {
 			earliest = oldest
 		}
 	}
 
-	size := int(end.Sub(earliest).Hours()/StreamHsetIntervalHours) + 1
+	size := int(end.Sub(earliest).Hours()/float64(streamHsetIntervalHours)) + 1
 	keys := make([]string, size)
 	for i := 0; i < size; i++ {
-		t := earliest.Add(time.Duration(i*StreamHsetIntervalHours) * time.Hour)
+		t := earliest.Add(time.Duration(i*streamHsetIntervalHours) * time.Hour)
 		keys[i] = prefix + t.Format("2006010215")
 	}
 

--- a/drivers/cmd/redis-cache/hset_test.go
+++ b/drivers/cmd/redis-cache/hset_test.go
@@ -155,7 +155,7 @@ func TestStreamHset(t *testing.T) {
 	assert.Panics(t, func() { streamHset(&dipper.Message{}) }, "streamHset should panic with empty request")
 
 	now := time.Now().Truncate(time.Hour)
-	if df := now.Hour() % StreamHsetIntervalHours; df != 0 {
+	if df := now.Hour() % streamHsetIntervalHours; df != 0 {
 		now = now.Add(time.Duration(-df) * time.Hour)
 	}
 	setName := "session_stream_" + now.Format("2006010215")
@@ -170,7 +170,7 @@ func TestStreamHset(t *testing.T) {
 	}
 
 	mock.ExpectHSet(setName, []string{"sid-1", `{"id":"sid-1"}`}).SetVal(1)
-	mock.ExpectExpire(setName, StreamHsetTTLHours*time.Hour).SetVal(true)
+	mock.ExpectExpire(setName, time.Duration(streamHsetTTLHours)*time.Hour).SetVal(true)
 	assert.NotPanics(t, func() { streamHset(msg) }, "streamHset should not panic with valid input")
 	select {
 	case <-msg.Reply:
@@ -199,10 +199,10 @@ func TestStreamHvals(t *testing.T) {
 	}
 
 	end := time.Now().Truncate(time.Hour)
-	if df := end.Hour() % StreamHsetIntervalHours; df != 0 {
+	if df := end.Hour() % streamHsetIntervalHours; df != 0 {
 		end = end.Add(time.Duration(-df) * time.Hour)
 	}
-	earliest := end.Add(-2 * StreamHsetIntervalHours * time.Hour)
+	earliest := end.Add(-time.Duration(2*streamHsetIntervalHours) * time.Hour)
 
 	keys := []string{
 		"session_stream_" + earliest.Format("2006010215"),

--- a/drivers/cmd/redis-cache/main.go
+++ b/drivers/cmd/redis-cache/main.go
@@ -91,6 +91,9 @@ func loadOptions() {
 	log = driver.GetLogger()
 	redisOptions = redisclient.GetRedisOpts(driver)
 	log.Infof("[%s] receiving driver data %+v", driver.Service, driver.Options)
+
+	// Load stream_hset configuration from driver options
+	loadStreamConfig()
 }
 
 func start(msg *dipper.Message) {


### PR DESCRIPTION
## Summary

This PR makes the `stream_hset` TTL (Time To Live) configurable instead of being hardcoded as a constant. This allows users to control how far back conversation history can be retrieved.

## Changes

### Before
- `StreamHsetTTLHours` was a constant set to 48 hours (2 days)
- `StreamHsetIntervalHours` was a constant set to 2 hours
- No way to configure these values

### After
- `streamHsetTTLHours` is now a configurable variable with default **336 hours (2 weeks)**
- `streamHsetIntervalHours` is now a configurable variable with default 2 hours
- Configuration is done via driver options in the YAML config

## Configuration

Users can now configure the TTL and interval in their Honeydipper config:

```yaml
drivers:
  redis-cache:
    data:
      # Stream TTL (conversation history retention)
      # Default: 336 hours (2 weeks)
      stream_ttl_hours: 336
      
      # Stream block interval
      # Default: 2 hours
      stream_interval_hours: 2
```

## Technical Details

1. **hset.go**: 
   - Changed constants to package-level variables
   - Added `loadStreamConfig()` function to load configuration from `driver.Options`
   - Updated all references from `StreamHsetTTLHours` to `streamHsetTTLHours` (and same for Interval)

2. **main.go**:
   - Added call to `loadStreamConfig()` in `loadOptions()` function

3. **hset_test.go**:
   - Updated to use new variable names
   - Fixed type conversion issues

## Testing

- All existing tests pass
- Linting passes (golangci-lint)
- Build succeeds

## Breaking Changes

None. The default behavior changes from 48 hours to 336 hours (2 weeks), which is an increase in retention time. This is likely desired behavior for users who want longer conversation history.

## Related Issues

This change addresses the need to configure conversation history retention time, which was previously limited to 48 hours.