### PR TITLE
feat: add configurable timeout fields for agent sessions (Phase 1)

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -17,16 +17,18 @@ import (
 
 // Session type constants, cache key prefixes, default TTL, and role labels.
 const (
-	AgentSessionTypeInference      = agentpkg.SessionTypeInference
-	AgentSessionTypeChatTurn       = agentpkg.SessionTypeChatTurn
-	AgentKeyPrefix                 = "agent_session:"
-	ConvoHistoryKeyPrefix          = "convo_history:"
-	MCPToolsCachePrefix            = "mcp_tools:"
-	AgentSessionDefaultTTL         = "336h"
-	AgentSessionDefaultTimeout     = "1h"
-	MCPToolsCacheDefaultTTL        = "6h"
-	AgentSessionDefaultPollTimeout = time.Second * 9
-	MinPollInterval                = time.Second * 2
+	AgentSessionTypeInference            = agentpkg.SessionTypeInference
+	AgentSessionTypeChatTurn             = agentpkg.SessionTypeChatTurn
+	AgentKeyPrefix                       = "agent_session:"
+	ConvoHistoryKeyPrefix                = "convo_history:"
+	MCPToolsCachePrefix                  = "mcp_tools:"
+	AgentSessionDefaultTTL               = "336h"
+	AgentSessionDefaultTimeout           = "1h"
+	MCPToolsCacheDefaultTTL              = "6h"
+	AgentSessionDefaultTurnLockExpire    = "1h"
+	AgentSessionDefaultDriverCallTimeout = "300s"
+	AgentSessionDefaultPollTimeout       = time.Second * 9
+	MinPollInterval                      = time.Second * 2
 
 	RoleSystem     = agentpkg.RoleSystem
 	RoleUser       = agentpkg.RoleUser
@@ -101,9 +103,13 @@ func (s *AgentSession) unlock() {
 // store is passed explicitly because this may run before setup() sets s.store.
 func (s *AgentSession) lockTurn(store AgentStore, convoID string) {
 	s.TurnLockKey = ConvoTurnLockPrefix + convoID
+	expire := AgentSessionDefaultTurnLockExpire
+	if s.Agent != nil && s.Agent.TurnLockTimeout != "" {
+		expire = s.Agent.TurnLockTimeout
+	}
 	dipper.Must(store.Call("locker", "lock", map[string]interface{}{
 		"name":   s.TurnLockKey,
-		"expire": "1h",
+		"expire": expire,
 	}, "timeout", "30m"))
 }
 
@@ -405,6 +411,31 @@ func interpolateAgentConfig(store AgentStore, agentName string, payload any) *co
 	agent.Engine = dipper.InterpolateStr("agent_engine", agent.Engine, envData)
 	agent.PreContext = dipper.Interpolate("agent_pre_context", agent.PreContext, envData).([]string)
 	agent.FileTool = dipper.InterpolateStr("agent_file_tool", agent.FileTool, envData)
+	agent.TurnLockTimeout = dipper.InterpolateStr("agent_turn_lock_timeout", agent.TurnLockTimeout, envData)
+	agent.DriverCallTimeout = dipper.InterpolateStr("agent_driver_call_timeout", agent.DriverCallTimeout, envData)
+	// Validate duration format for timeout fields, fall back to defaults if invalid
+	if agent.TurnLockTimeout != "" {
+		if _, err := time.ParseDuration(agent.TurnLockTimeout); err != nil {
+			if log := store.GetLogger(); log != nil {
+				log.Warningf(
+					"[agent] invalid turn_lock_timeout duration %q, using default %s",
+					agent.TurnLockTimeout, AgentSessionDefaultTurnLockExpire,
+				)
+			}
+			agent.TurnLockTimeout = ""
+		}
+	}
+	if agent.DriverCallTimeout != "" {
+		if _, err := time.ParseDuration(agent.DriverCallTimeout); err != nil {
+			if log := store.GetLogger(); log != nil {
+				log.Warningf(
+					"[agent] invalid driver_call_timeout duration %q, using default %s",
+					agent.DriverCallTimeout, AgentSessionDefaultDriverCallTimeout,
+				)
+			}
+			agent.DriverCallTimeout = ""
+		}
+	}
 	agent.AgentSettings = dipper.Interpolate("agent_", agent.AgentSettings, envData)
 	tools := make([]config.AgentToolDef, len(agent.Tools))
 	for i, tool := range agent.Tools {
@@ -554,7 +585,10 @@ func (s *AgentSession) sendToDriver() {
 	tools := s.BuildTools()
 	timeout := s.CurrentMsg.Labels["timeout"]
 	if timeout == "" {
-		timeout = AgentSessionDefaultTimeout
+		timeout = AgentSessionDefaultDriverCallTimeout
+		if s.Agent != nil && s.Agent.DriverCallTimeout != "" {
+			timeout = s.Agent.DriverCallTimeout
+		}
 	}
 
 	// Build the system prompt from the current agent config (inference vs chat).

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -186,6 +186,8 @@ type Agent struct {
 	FileTool           string                 `json:"file_tool" mapstructure:"file_tool"`
 	Description        string
 	TokenCounter       string `json:"token_counter" mapstructure:"token_counter"`
+	TurnLockTimeout    string `json:"turn_lock_timeout" mapstructure:"turn_lock_timeout"`
+	DriverCallTimeout  string `json:"driver_call_timeout" mapstructure:"driver_call_timeout"`
 	Meta               interface{}
 }
 


### PR DESCRIPTION
## Summary
This PR implements Phase 1 of the timeout control improvement for Honeydipper agents. It adds two new configurable timeout fields to the Agent schema and corresponding default constants.

## Changes

### 1. New Constants in `internal/agent/agent_session.go`
- `AgentSessionDefaultTurnLockExpire = "1h"` - Default expiration for turn lock
- `AgentSessionDefaultDriverCallTimeout = "300s"` - Default timeout for driver RPC calls (5 minutes, reduced from 1h)

### 2. New Agent Schema Fields in `internal/config/schema.go`
- `TurnLockTimeout string` - Controls turn lock expiration, JSON tag: `turn_lock_timeout`
- `DriverCallTimeout string` - Controls driver call timeout, JSON tag: `driver_call_timeout`

### 3. Interpolation and Validation
- Updated `interpolateAgentConfig` to interpolate the new timeout fields using `dipper.InterpolateStr`
- Added validation for duration format with warnings and fallback to defaults if invalid

### 4. Runtime Usage
- Updated `lockTurn` to use the configurable `TurnLockTimeout` from agent config (falls back to `AgentSessionDefaultTurnLockExpire`)
- Updated `sendToDriver` to use the configurable `DriverCallTimeout` from agent config with new 300s default (was 1h)

## Usage Example
```yaml
agents:
  my-agent:
    driver: openai
    engine: gpt-4
    turn_lock_timeout: "30m"    # Optional: turn lock expires after 30 minutes
    driver_call_timeout: "120s" # Optional: driver calls timeout after 2 minutes
```

## Testing
- All existing tests pass
- Code builds successfully
- Linting passes