### PR TITLE
feat: Add request_id correlation between daemon and drivers

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -70,6 +70,10 @@ type AgentSession struct {
 	// It is set when the turn lock is acquired and cleared when released.
 	// The lock prevents concurrent sessions from modifying the same conversation.
 	TurnLockKey string
+	// CurrentRequestID is the unique request ID for the current send_to_model call.
+	// It is set when sending a request to the driver and cleared when the turn completes.
+	// The driver should echo this ID back in all agentbus:receive responses.
+	CurrentRequestID string
 
 	store AgentStore
 }
@@ -197,6 +201,8 @@ func (s *AgentSession) syncConvoStateStatus() {
 		cs.updateSessionStatus(s.ID, status, s.ErrorReason, s.InputTokens, s.OutputTokens, s.TotalTokens)
 	})
 
+	// Clear the current request ID when the turn completes.
+	s.CurrentRequestID = ""
 	s.releaseTurnLock()
 }
 
@@ -620,6 +626,11 @@ func (s *AgentSession) sendToDriver() {
 		log.Infof("[agent] session [%s] sending to driver=%s engine=%s history_len=%d tools=%d",
 			s.ID, s.Agent.Driver, s.Agent.Engine, len(history), len(tools))
 	}
+	// Generate a new request ID for this send_to_model call.
+	s.CurrentRequestID = dipper.NewUUID()
+	if log := s.log(); log != nil {
+		log.Debugf("[agent] session [%s] generated request_id=%s", s.ID, s.CurrentRequestID)
+	}
 	s.InputTokens = 0
 	dipper.Must(s.store.CallNoWait("driver:"+s.Agent.Driver, "send_to_model", map[string]interface{}{
 		"engine":         s.Agent.Engine,
@@ -629,6 +640,7 @@ func (s *AgentSession) sendToDriver() {
 		"model_data":     s.Agent.ModelData,
 		"should_stream":  s.Agent.ShouldStream,
 		"agent_settings": s.Agent.AgentSettings,
+		"request_id":     s.CurrentRequestID,
 	}, "agent_session_id", s.ID, "timeout", timeout))
 }
 
@@ -677,6 +689,18 @@ func (s *AgentSession) processAgentResponse(msg *dipper.Message) {
 	if s.checkCancelled() {
 		s.ErrorReason = "conversation cancelled"
 		s.notifyParentFailure(s.ErrorReason)
+
+		return
+	}
+
+	// Validate request_id for correlation (lenient mode: empty request_id = match).
+	// This ensures we ignore responses from cancelled or outdated requests.
+	responseRequestID, _ := dipper.GetMapDataStr(msg.Payload, "request_id")
+	if responseRequestID != "" && responseRequestID != s.CurrentRequestID {
+		if log := s.log(); log != nil {
+			log.Debugf("[agent] session [%s] ignoring response with mismatched request_id: expected=%s got=%s",
+				s.ID, s.CurrentRequestID, responseRequestID)
+		}
 
 		return
 	}

--- a/internal/agent/agent_session_request_id_test.go
+++ b/internal/agent/agent_session_request_id_test.go
@@ -471,3 +471,101 @@ func TestFullFlow_CancelledRequestIgnored(t *testing.T) {
 	require.Len(t, s.history, 1)
 	assert.Equal(t, "new response", s.history[0].Content)
 }
+
+// ---------------------------------------------------------------------------
+// Scenario tests: specific edge cases
+// ---------------------------------------------------------------------------
+
+func TestLateResponseAfterSessionComplete(t *testing.T) {
+	store := newMockStore(nil)
+	agent := newTestAgent()
+	store.cfg.DataSet.Agents["a"] = *agent
+
+	s := &AgentSession{
+		store:            store,
+		Agent:            agent,
+		ID:               "test-session",
+		CurrentRequestID: "old-request-id",
+		ConvoID:          "convo-1",
+		history: []AgentMessage{
+			{Role: RoleAgent, Content: "done", IsComplete: true},
+		},
+	}
+
+	// Step 1: Session completes normally
+	s.syncConvoStateStatus()
+	
+	// Verify CurrentRequestID is cleared
+	assert.Empty(t, s.CurrentRequestID)
+	
+	// Step 2: Late response arrives with old request_id
+	lateMsg := &dipper.Message{
+		Labels: map[string]string{"status": "success"},
+		Payload: map[string]interface{}{
+			"request_id": "old-request-id",
+			"message": map[string]interface{}{
+				"Role":        RoleAgent,
+				"Content":     "late response",
+				"is_complete": true,
+			},
+		},
+	}
+	s.processAgentResponse(lateMsg)
+	
+	// Late response should be IGNORED because CurrentRequestID is now empty
+	// and the response has a non-empty request_id that doesn't match
+	// The history should NOT have the late response
+	for _, h := range s.history {
+		assert.NotEqual(t, "late response", h.Content)
+	}
+}
+
+func TestLateResponseAfterNewTurnStarted(t *testing.T) {
+	store := newMockStore(nil)
+	agent := newTestAgent()
+	store.cfg.DataSet.Agents["a"] = *agent
+
+	s := &AgentSession{
+		store: store,
+		Agent: agent,
+		ID:    "test-session",
+		CurrentMsg: &dipper.Message{
+			Labels:  map[string]string{},
+			Payload: map[string]interface{}{"text": "test"},
+		},
+	}
+
+	// Step 1: First turn sends to driver
+	s.sendToDriver()
+	oldRequestID := s.CurrentRequestID
+	
+	// Step 2: First turn completes (CurrentRequestID cleared)
+	s.history = append(s.history, AgentMessage{Role: RoleAgent, Content: "done", IsComplete: true})
+	s.syncConvoStateStatus()
+	
+	// Verify CurrentRequestID is cleared
+	assert.Empty(t, s.CurrentRequestID)
+	
+	// Step 3: New turn starts (new request_id generated)
+	s.sendToDriver()
+	newRequestID := s.CurrentRequestID
+	assert.NotEqual(t, oldRequestID, newRequestID)
+	
+	// Step 4: Late response from old turn arrives
+	lateMsg := &dipper.Message{
+		Labels: map[string]string{"status": "success"},
+		Payload: map[string]interface{}{
+			"request_id": oldRequestID,
+			"message": map[string]interface{}{
+				"Role":        RoleAgent,
+				"Content":     "late response from old turn",
+				"is_complete": true,
+			},
+		},
+	}
+	s.processAgentResponse(lateMsg)
+	
+	// Late response should be IGNORED
+	assert.Len(t, s.history, 1) // Only the "done" message, not the late response
+	assert.Equal(t, "done", s.history[0].Content)
+}

--- a/internal/agent/agent_session_request_id_test.go
+++ b/internal/agent/agent_session_request_id_test.go
@@ -1,0 +1,473 @@
+// Copyright 2026 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers for request_id correlation
+// ---------------------------------------------------------------------------
+
+func newTestAgent() *config.Agent {
+	return &config.Agent{
+		Name:   "a",
+		Driver: "openai",
+		Engine: "gpt-4",
+	}
+}
+
+func newSessionWithRequestID(t *testing.T, store *mockStore, requestID string) *AgentSession {
+	t.Helper()
+	agent := newTestAgent()
+	store.cfg.DataSet.Agents["a"] = *agent
+
+	return &AgentSession{
+		store:            store,
+		Agent:            agent,
+		ID:               "test-session",
+		CurrentRequestID: requestID,
+		CurrentMsg: &dipper.Message{
+			Labels:  map[string]string{},
+			Payload: map[string]interface{}{"text": "test"},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AgentSession.sendToDriver() request_id tests
+// ---------------------------------------------------------------------------
+
+func TestSendToDriver_GeneratesRequestID(t *testing.T) {
+	store := newMockStore(nil)
+	agent := newTestAgent()
+	store.cfg.DataSet.Agents["a"] = *agent
+
+	s := &AgentSession{
+		store: store,
+		Agent: agent,
+		ID:    "test-session",
+		CurrentMsg: &dipper.Message{
+			Labels:  map[string]string{},
+			Payload: map[string]interface{}{"text": "test"},
+		},
+	}
+
+	// Initially CurrentRequestID should be empty
+	assert.Empty(t, s.CurrentRequestID)
+
+	// Call sendToDriver
+	s.sendToDriver()
+
+	// CurrentRequestID should now be set
+	assert.NotEmpty(t, s.CurrentRequestID)
+
+	// Verify the request_id was passed to the driver
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	assert.Equal(t, s.CurrentRequestID, params["request_id"])
+}
+
+func TestSendToDriver_NewRequestIDEachCall(t *testing.T) {
+	store := newMockStore(nil)
+	agent := newTestAgent()
+	store.cfg.DataSet.Agents["a"] = *agent
+
+	s := &AgentSession{
+		store: store,
+		Agent: agent,
+		ID:    "test-session",
+		CurrentMsg: &dipper.Message{
+			Labels:  map[string]string{},
+			Payload: map[string]interface{}{"text": "test"},
+		},
+	}
+
+	// First call
+	s.sendToDriver()
+	firstRequestID := s.CurrentRequestID
+	assert.NotEmpty(t, firstRequestID)
+
+	// Second call
+	s.sendToDriver()
+	secondRequestID := s.CurrentRequestID
+	assert.NotEmpty(t, secondRequestID)
+
+	// Each call should generate a new request ID
+	assert.NotEqual(t, firstRequestID, secondRequestID)
+}
+
+func TestSendToDriver_RequestIDInPayload(t *testing.T) {
+	store := newMockStore(nil)
+	agent := newTestAgent()
+	store.cfg.DataSet.Agents["a"] = *agent
+
+	s := &AgentSession{
+		store: store,
+		Agent: agent,
+		ID:    "test-session",
+		CurrentMsg: &dipper.Message{
+			Labels:  map[string]string{},
+			Payload: map[string]interface{}{"text": "test"},
+		},
+	}
+
+	s.sendToDriver()
+
+	// Verify request_id is in the payload
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	assert.Contains(t, params, "request_id")
+	assert.NotEmpty(t, params["request_id"])
+}
+
+// ---------------------------------------------------------------------------
+// AgentSession.processAgentResponse() request_id validation tests
+// ---------------------------------------------------------------------------
+
+func TestProcessAgentResponse_AcceptsMatchingRequestID(t *testing.T) {
+	store := newMockStore(nil)
+	s := newSessionWithRequestID(t, store, "test-uuid-123")
+
+	// Create a response with matching request_id
+	msg := &dipper.Message{
+		Labels: map[string]string{"status": "success"},
+		Payload: map[string]interface{}{
+			"request_id": "test-uuid-123",
+			"message": map[string]interface{}{
+				"Role":        RoleAgent,
+				"Content":     "response",
+				"is_complete": true,
+			},
+		},
+	}
+
+	s.processAgentResponse(msg)
+
+	// Should process the response (no error)
+	assert.Empty(t, s.ErrorReason)
+	// History should contain the response
+	require.Len(t, s.history, 1)
+	assert.Equal(t, "response", s.history[0].Content)
+}
+
+func TestProcessAgentResponse_IgnoresMismatchedRequestID(t *testing.T) {
+	store := newMockStore(nil)
+	s := newSessionWithRequestID(t, store, "test-uuid-123")
+
+	// Create a response with different request_id
+	msg := &dipper.Message{
+		Labels: map[string]string{"status": "success"},
+		Payload: map[string]interface{}{
+			"request_id": "different-uuid-456",
+			"message": map[string]interface{}{
+				"Role":        RoleAgent,
+				"Content":     "response",
+				"is_complete": true,
+			},
+		},
+	}
+
+	s.processAgentResponse(msg)
+
+	// Should ignore the response (not process it)
+	assert.Empty(t, s.history) // History should be empty
+}
+
+func TestProcessAgentResponse_AcceptsEmptyRequestID_LenientMode(t *testing.T) {
+	store := newMockStore(nil)
+	s := newSessionWithRequestID(t, store, "test-uuid-123")
+
+	// Create a response with no request_id (lenient mode for backward compatibility)
+	msg := &dipper.Message{
+		Labels: map[string]string{"status": "success"},
+		Payload: map[string]interface{}{
+			"message": map[string]interface{}{
+				"Role":        RoleAgent,
+				"Content":     "response",
+				"is_complete": true,
+			},
+		},
+	}
+
+	s.processAgentResponse(msg)
+
+	// Should process the response (lenient mode)
+	assert.Empty(t, s.ErrorReason)
+	require.Len(t, s.history, 1)
+	assert.Equal(t, "response", s.history[0].Content)
+}
+
+func TestProcessAgentResponse_IgnoresResponseWhenCurrentRequestIDEmpty(t *testing.T) {
+	store := newMockStore(nil)
+	// Session with empty CurrentRequestID (no active request)
+	s := newSessionWithRequestID(t, store, "")
+
+	// Create a response with a request_id
+	msg := &dipper.Message{
+		Labels: map[string]string{"status": "success"},
+		Payload: map[string]interface{}{
+			"request_id": "some-uuid",
+			"message": map[string]interface{}{
+				"Role":        RoleAgent,
+				"Content":     "response",
+				"is_complete": true,
+			},
+		},
+	}
+
+	s.processAgentResponse(msg)
+
+	// Should ignore the response because CurrentRequestID is empty
+	// (no active request to match against)
+	assert.Empty(t, s.history)
+}
+
+func TestProcessAgentResponse_ValidatesRequestIDBeforeProcessing(t *testing.T) {
+	store := newMockStore(nil)
+	s := newSessionWithRequestID(t, store, "valid-uuid")
+
+	// Create a response with mismatched request_id
+	msg := &dipper.Message{
+		Labels: map[string]string{"status": "success"},
+		Payload: map[string]interface{}{
+			"request_id": "invalid-uuid",
+			"message": map[string]interface{}{
+				"Role": RoleAgent,
+				"ToolCalls": []interface{}{
+					map[string]interface{}{
+						"FuncName": "sys_test__func",
+						"Params":   map[string]interface{}{},
+					},
+				},
+				"is_complete": true,
+			},
+		},
+	}
+
+	s.processAgentResponse(msg)
+
+	// Should not process the tool calls because request_id doesn't match
+	assert.Empty(t, s.ToolCalls)
+	assert.Empty(t, store.getEmitted())
+}
+
+// ---------------------------------------------------------------------------
+// AgentSession.syncConvoStateStatus() request_id clearing tests
+// ---------------------------------------------------------------------------
+
+func TestSyncConvoStateStatus_ClearsRequestIDOnCompletion(t *testing.T) {
+	store := newMockStore(nil)
+	agent := newTestAgent()
+	store.cfg.DataSet.Agents["a"] = *agent
+
+	s := &AgentSession{
+		store:            store,
+		Agent:            agent,
+		ID:               "test-session",
+		CurrentRequestID: "test-uuid-123",
+		ConvoID:          "convo-1",
+		history: []AgentMessage{
+			{Role: RoleAgent, Content: "done", IsComplete: true},
+		},
+	}
+
+	// Verify CurrentRequestID is set
+	assert.Equal(t, "test-uuid-123", s.CurrentRequestID)
+
+	// Call syncConvoStateStatus (which should clear CurrentRequestID)
+	s.syncConvoStateStatus()
+
+	// CurrentRequestID should be cleared
+	assert.Empty(t, s.CurrentRequestID)
+}
+
+func TestSyncConvoStateStatus_ClearsRequestIDOnError(t *testing.T) {
+	store := newMockStore(nil)
+	agent := newTestAgent()
+	store.cfg.DataSet.Agents["a"] = *agent
+
+	s := &AgentSession{
+		store:            store,
+		Agent:            agent,
+		ID:               "test-session",
+		CurrentRequestID: "test-uuid-123",
+		ConvoID:          "convo-1",
+		ErrorReason:      "some error",
+	}
+
+	// Verify CurrentRequestID is set
+	assert.Equal(t, "test-uuid-123", s.CurrentRequestID)
+
+	// Call syncConvoStateStatus (which should clear CurrentRequestID)
+	s.syncConvoStateStatus()
+
+	// CurrentRequestID should be cleared
+	assert.Empty(t, s.CurrentRequestID)
+}
+
+func TestSyncConvoStateStatus_DoesNotClearRequestIDBeforeCompletion(t *testing.T) {
+	store := newMockStore(nil)
+	agent := newTestAgent()
+	store.cfg.DataSet.Agents["a"] = *agent
+
+	s := &AgentSession{
+		store:            store,
+		Agent:            agent,
+		ID:               "test-session",
+		CurrentRequestID: "test-uuid-123",
+		ConvoID:          "convo-1",
+		history: []AgentMessage{
+			{Role: RoleAgent, Content: "in progress"}, // Not complete
+		},
+	}
+
+	// Verify CurrentRequestID is set
+	assert.Equal(t, "test-uuid-123", s.CurrentRequestID)
+
+	// Call syncConvoStateStatus (should return early, not clear CurrentRequestID)
+	s.syncConvoStateStatus()
+
+	// CurrentRequestID should NOT be cleared because turn is not complete
+	assert.Equal(t, "test-uuid-123", s.CurrentRequestID)
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests: full flow with request_id
+// ---------------------------------------------------------------------------
+
+func TestFullFlow_RequestIDCorrelation(t *testing.T) {
+	store := newMockStore(nil)
+	agent := newTestAgent()
+	store.cfg.DataSet.Agents["a"] = *agent
+
+	s := &AgentSession{
+		store: store,
+		Agent: agent,
+		ID:    "test-session",
+		CurrentMsg: &dipper.Message{
+			Labels:  map[string]string{},
+			Payload: map[string]interface{}{"text": "test"},
+		},
+	}
+
+	// Step 1: Send to driver (generates request_id)
+	s.sendToDriver()
+	originalRequestID := s.CurrentRequestID
+	assert.NotEmpty(t, originalRequestID)
+
+	// Step 2: Simulate a response with matching request_id
+	msg := &dipper.Message{
+		Labels: map[string]string{"status": "success"},
+		Payload: map[string]interface{}{
+			"request_id": originalRequestID,
+			"message": map[string]interface{}{
+				"Role":        RoleAgent,
+				"Content":     "response",
+				"is_complete": true,
+			},
+		},
+	}
+	s.processAgentResponse(msg)
+
+	// Should process the response
+	assert.Empty(t, s.ErrorReason)
+	require.Len(t, s.history, 1)
+
+	// Step 3: Simulate a new send_to_model (new request_id generated)
+	s.sendToDriver()
+	newRequestID := s.CurrentRequestID
+	assert.NotEmpty(t, newRequestID)
+	assert.NotEqual(t, originalRequestID, newRequestID)
+
+	// Step 4: Old response should be ignored now
+	oldMsg := &dipper.Message{
+		Labels: map[string]string{"status": "success"},
+		Payload: map[string]interface{}{
+			"request_id": originalRequestID,
+			"message": map[string]interface{}{
+				"Role":        RoleAgent,
+				"Content":     "old response",
+				"is_complete": true,
+			},
+		},
+	}
+	s.processAgentResponse(oldMsg)
+
+	// History should still have only 1 message (old response ignored)
+	assert.Len(t, s.history, 1)
+	assert.Equal(t, "response", s.history[0].Content)
+}
+
+func TestFullFlow_CancelledRequestIgnored(t *testing.T) {
+	store := newMockStore(nil)
+	agent := newTestAgent()
+	store.cfg.DataSet.Agents["a"] = *agent
+
+	s := &AgentSession{
+		store: store,
+		Agent: agent,
+		ID:    "test-session",
+		CurrentMsg: &dipper.Message{
+			Labels:  map[string]string{},
+			Payload: map[string]interface{}{"text": "test"},
+		},
+		ConvoID: "convo-1",
+	}
+
+	// Step 1: Send to driver (generates request_id)
+	s.sendToDriver()
+	requestID := s.CurrentRequestID
+
+	// Step 2: Simulate cancellation (new request started, old one cancelled)
+	// This happens when a new turn starts before the old one completes
+	s.CurrentRequestID = "new-request-id"
+
+	// Step 3: Old response arrives
+	oldMsg := &dipper.Message{
+		Labels: map[string]string{"status": "success"},
+		Payload: map[string]interface{}{
+			"request_id": requestID,
+			"message": map[string]interface{}{
+				"Role":        RoleAgent,
+				"Content":     "old response",
+				"is_complete": true,
+			},
+		},
+	}
+	s.processAgentResponse(oldMsg)
+
+	// Old response should be ignored
+	assert.Empty(t, s.history)
+
+	// Step 4: New response with correct request_id should be accepted
+	newMsg := &dipper.Message{
+		Labels: map[string]string{"status": "success"},
+		Payload: map[string]interface{}{
+			"request_id": "new-request-id",
+			"message": map[string]interface{}{
+				"Role":        RoleAgent,
+				"Content":     "new response",
+				"is_complete": true,
+			},
+		},
+	}
+	s.processAgentResponse(newMsg)
+
+	// New response should be processed
+	require.Len(t, s.history, 1)
+	assert.Equal(t, "new response", s.history[0].Content)
+}


### PR DESCRIPTION
## Summary

This PR implements Phase 1 of the request-response correlation feature between the Honeydipper daemon and drivers (like `hd-driver-openai`, `hd-driver-claude`). 

The solution uses a unique `request_id` (UUID) generated for each `send_to_model` call that the driver echoes back in all `agentbus:receive` responses, allowing the daemon to properly ignore return messages if a turn is cancelled.

## Changes

### Modified Files

**`internal/agent/agent_session.go`**:
1. Added `CurrentRequestID` field to `AgentSession` struct to track the current request ID
2. Modified `sendToDriver()` to:
   - Generate a UUID via `dipper.NewUUID()` for each call
   - Store it in `CurrentRequestID`
   - Pass it as `request_id` in the RPC payload to the driver
3. Modified `processAgentResponse()` to:
   - Validate the `request_id` in incoming responses
   - Silently ignore responses with mismatched `request_id`
   - Allow empty `request_id` in responses (lenient mode for backward compatibility)
4. Modified `syncConvoStateStatus()` to clear `CurrentRequestID` when the turn completes

### New Files

**`internal/agent/agent_session_request_id_test.go`**:
- Comprehensive unit tests for all request_id correlation scenarios
- Tests for `sendToDriver()` generating and passing `request_id`
- Tests for `processAgentResponse()` validation (matching, mismatching, lenient mode)
- Tests for `syncConvoStateStatus()` clearing `CurrentRequestID`
- Integration tests for full flow with request_id correlation

## Design Decisions

1. **Lenient mode**: Empty `request_id` in response = match (backward compatible with unupdated drivers)
2. **Scope**: Only `send_to_model` RPC and `agentbus:receive` responses
3. **UUID for request_id**: Globally unique, no coordination needed
4. **Validation in `processAgentResponse`**: Covers all response types (streaming chunks, tool calls, final, errors)
5. **New `sendToDriver` call = new request_id**: Naturally invalidates old in-flight responses

## Testing

- ✅ All existing tests pass
- ✅ New tests pass (13 test cases)
- ✅ Race detector clean
- ✅ Linting passes

## Related Issues

This is Phase 1 - daemon changes only. Driver changes will be implemented in subsequent phases.

## Checklist

- [x] Code compiles without errors
- [x] All tests pass
- [x] Race detector clean
- [x] Linting passes
- [x] Documentation updated (code comments)
- [x] New test file added with comprehensive tests
