### PR TITLE
fix: checkCancelled should return true for non-active sessions

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -210,9 +210,19 @@ func (s *AgentSession) checkCancelled() bool {
 	}
 	cs := &ConvoState{}
 	cs.load(s.ConvoID, s.store)
+
+	// If this session is not the active session, it's considered cancelled.
+	// This handles the case where a new turn has started and the old session
+	// is no longer active.
+	if cs.ActiveSession == nil || cs.ActiveSession.SessionID != s.ID {
+		return true
+	}
+
+	// Also check if the session is explicitly marked as cancelled
 	if cs.isSessionCancelled(s.ID) {
 		return true
 	}
+	// Check unified convo as well
 	if s.UnifiedConvoID != "" && s.UnifiedConvoID != s.ConvoID {
 		ucs := &ConvoState{}
 		ucs.load(s.UnifiedConvoID, s.store)

--- a/internal/agent/check_cancelled_test.go
+++ b/internal/agent/check_cancelled_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCheckCancelled_ActiveSessionNotCancelled verifies that the active session
+// is not considered cancelled.
+func TestCheckCancelled_ActiveSessionNotCancelled(t *testing.T) {
+	store := newMockStore(nil)
+	cfg := store.GetConfig()
+	cfg.DataSet.Agents["test-agent"] = config.Agent{Name: "test-agent"}
+
+	// Create a ConvoState with session-1 as ActiveSession
+	cs := &ConvoState{
+		ConvoID:       "convo-1",
+		FirstSession:  &ConvoSessionRef{SessionID: "session-1", Status: ConvoSessionStatusActive},
+		LastSession:   &ConvoSessionRef{SessionID: "session-1", Status: ConvoSessionStatusActive},
+		ActiveSession: &ConvoSessionRef{SessionID: "session-1", Status: ConvoSessionStatusActive},
+	}
+	cs.persist(store)
+
+	// Create session matching ActiveSession
+	s := &AgentSession{
+		store:   store,
+		Agent:   &config.Agent{Name: "test-agent"},
+		ID:      "session-1",
+		ConvoID: "convo-1",
+	}
+
+	// Should NOT be cancelled (it's the active session)
+	assert.False(t, s.checkCancelled())
+}
+
+// TestCheckCancelled_NonActiveSessionIsCancelled verifies that a session that
+// is not the active session is considered cancelled.
+func TestCheckCancelled_NonActiveSessionIsCancelled(t *testing.T) {
+	store := newMockStore(nil)
+	cfg := store.GetConfig()
+	cfg.DataSet.Agents["test-agent"] = config.Agent{Name: "test-agent"}
+
+	// Create a ConvoState where session-2 is the active session
+	cs := &ConvoState{
+		ConvoID:       "convo-1",
+		FirstSession:  &ConvoSessionRef{SessionID: "session-1", Status: ConvoSessionStatusComplete},
+		LastSession:   &ConvoSessionRef{SessionID: "session-2", Status: ConvoSessionStatusActive},
+		ActiveSession: &ConvoSessionRef{SessionID: "session-2", Status: ConvoSessionStatusActive},
+	}
+	cs.persist(store)
+
+	// Create session-1 (no longer active)
+	s := &AgentSession{
+		store:   store,
+		Agent:   &config.Agent{Name: "test-agent"},
+		ID:      "session-1",
+		ConvoID: "convo-1",
+	}
+
+	// Should be cancelled (it's not the active session)
+	assert.True(t, s.checkCancelled())
+}
+
+// TestCheckCancelled_ExplicitCancelledSession verifies that an explicitly
+// cancelled session is detected as cancelled.
+func TestCheckCancelled_ExplicitCancelledSession(t *testing.T) {
+	store := newMockStore(nil)
+	cfg := store.GetConfig()
+	cfg.DataSet.Agents["test-agent"] = config.Agent{Name: "test-agent"}
+
+	// Create a ConvoState where session-1 is explicitly cancelled
+	cs := &ConvoState{
+		ConvoID:       "convo-1",
+		FirstSession:  &ConvoSessionRef{SessionID: "session-1", Status: ConvoSessionStatusCancelled},
+		LastSession:   &ConvoSessionRef{SessionID: "session-2", Status: ConvoSessionStatusActive},
+		ActiveSession: &ConvoSessionRef{SessionID: "session-2", Status: ConvoSessionStatusActive},
+	}
+	cs.persist(store)
+
+	// Create session-1 (explicitly cancelled)
+	s := &AgentSession{
+		store:   store,
+		Agent:   &config.Agent{Name: "test-agent"},
+		ID:      "session-1",
+		ConvoID: "convo-1",
+	}
+
+	// Should be cancelled (explicitly marked as cancelled)
+	assert.True(t, s.checkCancelled())
+}


### PR DESCRIPTION
## Summary

This PR fixes a bug where late responses from completed/cancelled sessions were being processed incorrectly.

## The Problem

The previous `checkCancelled()` implementation only checked if a session was **explicitly marked as cancelled** in the ConvoState. This meant:

1. Session A completes normally (status = "complete", not "cancelled")
2. Session B starts (new turn, new session)
3. Late response for Session A arrives
4. `checkCancelled()` checks if Session A is in ConvoState refs
5. Session A is in `FirstSession`, so it checks `isSessionCancelled()`
6. `isSessionCancelled()` returns `false` (Session A is "complete", not "cancelled")
7. **Bug**: Late response is PROCESSED instead of being ignored

## The Fix

Modified `checkCancelled()` to first verify if the session is the **active session** in the ConvoState. If not, return `true` (cancelled).

This is a simple, correct fix because:
- The `ActiveSession` in ConvoState always points to the currently active session
- If a session is not the active session, any response for it should be ignored
- This properly handles the case where a new turn has started

## Changes

1. **`internal/agent/agent_session.go`**: Modified `checkCancelled()` to check if session is active
2. **`internal/agent/check_cancelled_test.go`**: Added 3 test cases to verify the fix

## Testing

- ✅ All existing tests pass
- ✅ New tests pass
- ✅ Linting passes

## Comparison to request_id Approach

This is a much simpler solution than adding `request_id` correlation. The session ID already distinguishes between turns; we just needed to fix the `checkCancelled()` logic.
