### PR TITLE
feat: add resolveUnresolvedToolCalls safeguard to handle cancelled conversations

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -903,3 +903,54 @@ func (s *AgentSession) emitPollResponse(msg *dipper.Message) bool {
 
 	return true
 }
+
+// resolveUnresolvedToolCalls checks the conversation history for unresolved tool calls
+// (tool calls without corresponding results) and creates synthetic tool result
+// messages with failure status. This handles the case where a conversation was
+// cancelled before tool calls could complete.
+// The method is idempotent: safe to call multiple times without creating duplicates.
+func (s *AgentSession) resolveUnresolvedToolCalls() {
+	if len(s.history) == 0 {
+		return
+	}
+
+	// Check if the last message has unresolved tool calls
+	// Unresolved tool calls means: the last message has ToolCalls populated,
+	// but there is no subsequent RoleToolResult message with the results.
+	lastMsg := s.history[len(s.history)-1]
+
+	// If the last message doesn't have tool calls, nothing to resolve
+	if len(lastMsg.ToolCalls) == 0 {
+		return
+	}
+
+	// If the last message is itself a tool result, the tool calls have been resolved
+	if lastMsg.Role == RoleToolResult {
+		return
+	}
+
+	// At this point, we have unresolved tool calls in the last message
+	// Create synthetic tool results with failure status
+	toolResults := make([]map[string]interface{}, len(lastMsg.ToolCalls))
+
+	for i, tc := range lastMsg.ToolCalls {
+		toolResults[i] = map[string]interface{}{
+			"status":    "failure",
+			"reason":    "conversation cancelled before tool call could complete",
+			"data":      nil,
+			"func_name": tc.FuncName,
+		}
+	}
+
+	toolResultMsg := AgentMessage{
+		Role:       RoleToolResult,
+		ToolResult: toolResults,
+	}
+
+	s.appendConvoHistory(&toolResultMsg)
+
+	if log := s.log(); log != nil {
+		log.Infof("[agent] session [%s] resolved %d unresolved tool calls from previous cancelled conversation",
+			s.ID, len(lastMsg.ToolCalls))
+	}
+}

--- a/internal/agent/agent_store.go
+++ b/internal/agent/agent_store.go
@@ -147,6 +147,9 @@ func (p *PersistentAgentStore) StartInference(msg *dipper.Message) {
 	// in-flight prior turns.
 	s.loadConvoHistory()
 
+	// Resolve any unresolved tool calls from a previous cancelled conversation
+	s.resolveUnresolvedToolCalls()
+
 	s.run()
 }
 
@@ -319,6 +322,9 @@ func (p *PersistentAgentStore) runTurn(agentName, convoID, text, user, engine, d
 	// stale snapshot when a previous turn for the same conversation is still
 	// in flight (its final tool_result not yet persisted).
 	s.loadConvoHistory()
+
+	// Resolve any unresolved tool calls from a previous cancelled conversation
+	s.resolveUnresolvedToolCalls()
 
 	defer s.persist(true)
 	defer dipper.SafeExitOnError("[agent] error running turn for convo "+convoID, func(r interface{}) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -2698,3 +2698,165 @@ func TestAgentOverrideEngineAndDriver_NoOverride(t *testing.T) {
 	require.True(t, ok, "engine must be a string")
 	assert.Equal(t, "default_engine", engine, "engine should be from agent config")
 }
+
+// TestResolveUnresolvedToolCalls_NoHistory tests that the method does nothing when history is empty.
+func TestResolveUnresolvedToolCalls_NoHistory(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{Name: "a"}
+
+	s := &AgentSession{
+		store:   store,
+		history: []AgentMessage{},
+	}
+
+	s.resolveUnresolvedToolCalls()
+
+	assert.Empty(t, s.history)
+}
+
+// TestResolveUnresolvedToolCalls_NoToolCalls tests that the method does nothing when the last message has no tool calls.
+func TestResolveUnresolvedToolCalls_NoToolCalls(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{Name: "a"}
+
+	s := &AgentSession{
+		store: store,
+		history: []AgentMessage{
+			{Role: RoleUser, Content: "hello"},
+			{Role: RoleAgent, Content: "Hi there!"},
+		},
+	}
+
+	s.resolveUnresolvedToolCalls()
+
+	assert.Len(t, s.history, 2)
+}
+
+// TestResolveUnresolvedToolCalls_LastMessageIsToolResult tests that the method does nothing when the last message is a tool result.
+func TestResolveUnresolvedToolCalls_LastMessageIsToolResult(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{Name: "a"}
+
+	s := &AgentSession{
+		store: store,
+		history: []AgentMessage{
+			{Role: RoleUser, Content: "hello"},
+			{
+				Role: RoleAgent,
+				ToolCalls: []AgentToolCall{
+					{FuncName: "test_tool", Params: map[string]interface{}{"arg": "val"}},
+				},
+			},
+			{
+				Role: RoleToolResult,
+				ToolResult: []map[string]interface{}{
+					{"status": "success", "data": "result"},
+				},
+			},
+		},
+	}
+
+	s.resolveUnresolvedToolCalls()
+
+	assert.Len(t, s.history, 3)
+}
+
+// TestResolveUnresolvedToolCalls_ResolvesUnresolvedToolCalls tests that the method adds synthetic tool results for unresolved tool calls.
+func TestResolveUnresolvedToolCalls_ResolvesUnresolvedToolCalls(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{Name: "a"}
+
+	s := &AgentSession{
+		ID:    "test-session",
+		store: store,
+		history: []AgentMessage{
+			{Role: RoleUser, Content: "hello"},
+			{
+				Role: RoleAgent,
+				ToolCalls: []AgentToolCall{
+					{FuncName: "test_tool1", Params: map[string]interface{}{"arg": "val1"}},
+					{FuncName: "test_tool2", Params: map[string]interface{}{"arg": "val2"}},
+				},
+			},
+		},
+	}
+
+	s.resolveUnresolvedToolCalls()
+
+	assert.Len(t, s.history, 3)
+	assert.Equal(t, RoleToolResult, s.history[2].Role)
+	assert.Len(t, s.history[2].ToolResult, 2)
+	assert.Equal(t, "failure", s.history[2].ToolResult[0]["status"])
+	assert.Equal(t, "conversation cancelled before tool call could complete", s.history[2].ToolResult[0]["reason"])
+	assert.Equal(t, "test_tool1", s.history[2].ToolResult[0]["func_name"])
+	assert.Equal(t, "test_tool2", s.history[2].ToolResult[1]["func_name"])
+}
+
+// TestResolveUnresolvedToolCalls_Idempotent tests that calling the method multiple times doesn't create duplicates.
+func TestResolveUnresolvedToolCalls_Idempotent(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{Name: "a"}
+
+	s := &AgentSession{
+		ID:    "test-session",
+		store: store,
+		history: []AgentMessage{
+			{Role: RoleUser, Content: "hello"},
+			{
+				Role: RoleAgent,
+				ToolCalls: []AgentToolCall{
+					{FuncName: "test_tool", Params: map[string]interface{}{"arg": "val"}},
+				},
+			},
+		},
+	}
+
+	// Call twice
+	s.resolveUnresolvedToolCalls()
+	s.resolveUnresolvedToolCalls()
+
+	// Should only have added one tool result message
+	assert.Len(t, s.history, 3)
+	assert.Equal(t, RoleToolResult, s.history[2].Role)
+}
+
+// TestResolveUnresolvedToolCalls_WithExistingToolResultInHistory tests that the method works correctly when there's already a tool result in history.
+func TestResolveUnresolvedToolCalls_WithExistingToolResultInHistory(t *testing.T) {
+	store := newMockStore(nil)
+	store.cfg.DataSet.Agents["a"] = config.Agent{Name: "a"}
+
+	s := &AgentSession{
+		ID:    "test-session",
+		store: store,
+		history: []AgentMessage{
+			{Role: RoleUser, Content: "hello"},
+			{
+				Role: RoleAgent,
+				ToolCalls: []AgentToolCall{
+					{FuncName: "tool1", Params: map[string]interface{}{}},
+				},
+			},
+			{
+				Role: RoleToolResult,
+				ToolResult: []map[string]interface{}{
+					{"status": "success", "data": "result1"},
+				},
+			},
+			{Role: RoleUser, Content: "follow up"},
+			{
+				Role: RoleAgent,
+				ToolCalls: []AgentToolCall{
+					{FuncName: "tool2", Params: map[string]interface{}{}},
+				},
+			},
+		},
+	}
+
+	s.resolveUnresolvedToolCalls()
+
+	// Should add a tool result for tool2
+	assert.Len(t, s.history, 6)
+	assert.Equal(t, RoleToolResult, s.history[5].Role)
+	assert.Len(t, s.history[5].ToolResult, 1)
+	assert.Equal(t, "tool2", s.history[5].ToolResult[0]["func_name"])
+}


### PR DESCRIPTION
## Summary

This PR implements a safeguard to handle unresolved tool calls when starting new conversations or turns after a cancellation. 

## Changes Made

### 1. New Method: `resolveUnresolvedToolCalls()` (agent_session.go)
- Added to `AgentSession` struct
- Detects unresolved tool calls by checking if the last message in `s.history` has `ToolCalls` populated but no corresponding `ToolResult`
- Creates synthetic tool result messages with failure status and reason "conversation cancelled before tool call could complete"
- Uses `s.appendConvoHistory()` to append the synthetic tool result message for persistence
- Includes appropriate logging when unresolved tool calls are resolved
- **Idempotent**: Safe to call multiple times without creating duplicates

### 2. Integration Points (agent_store.go)
- Called `resolveUnresolvedToolCalls()` in `StartInference()` after `s.loadConvoHistory()` and before `s.run()`
- Called `resolveUnresolvedToolCalls()` in `runTurn()` after `s.loadConvoHistory()` and before `s.run()`

### 3. Unit Tests (agent_test.go)
Added comprehensive tests covering:
- Empty history (no-op)
- Last message has no tool calls (no-op)
- Last message is a tool result (no-op)
- Resolves unresolved tool calls correctly
- Idempotency (calling twice doesn't create duplicates)
- Works correctly with existing tool results in history

## Problem Solved

When a conversation is cancelled while tool calls are still unresolved (tool calls without corresponding results), and a new turn starts, models that require tool call/result matching throw errors. This fix detects and resolves unresolved tool calls at the entry points before any new messages are added to the history.

## Testing

- All existing tests pass
- New unit tests cover all scenarios
- Linting passes (golangci-lint)

## Notes

- The safeguard is applied after loading conversation history but before appending new user messages
- The fix ensures future conversations work correctly by persisting the synthetic tool results
- Branch name has a minor typo ("tool-calls" vs "tool-calls") - functionality is unaffected