### PR TITLE
feat(agent): add IsChunk field to Message for explicit streaming chunk protocol (Phase 1)

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -167,6 +167,7 @@ func (s *AgentSession) persist(unlocking bool) {
 // When a terminal state is detected, it also releases the distributed turn lock.
 func (s *AgentSession) syncConvoStateStatus() {
 	var status string
+
 	switch {
 	case s.ErrorReason != "":
 		status = ConvoSessionStatusFailed
@@ -692,6 +693,7 @@ func (s *AgentSession) processAgentResponse(msg *dipper.Message) {
 	}
 	m := dipper.MustGetMapData(msg.Payload, "message").(map[string]interface{})
 	var agentMsg AgentMessage
+
 	dipper.Must(mapstructure.Decode(m, &agentMsg))
 	s.coerceToolCallParams(agentMsg.ToolCalls)
 	if log := s.log(); log != nil {
@@ -718,9 +720,8 @@ func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 		s.TotalTokens = s.InputTokens + s.OutputTokens
 	}
 
-	// Streaming chunk: non-complete agent content with no tool calls and not a thinking token.
-	// Accumulate in PendingContent to avoid one Redis rpush per chunk.
-	if agentMsg.Role == RoleAgent && !agentMsg.IsComplete {
+	// Streaming chunk: accumulate in PendingContent to avoid one Redis rpush per chunk.
+	if agentMsg.IsChunk {
 		s.PendingContent += agentMsg.Content
 		s.PendingThoughts += agentMsg.Thoughts
 
@@ -768,6 +769,8 @@ func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 		return
 	}
 
+	// Non-agent message or truncated response (IsChunk=false, IsComplete=false):
+	// persist and re-send to driver to continue.
 	if agentMsg.Role != RoleAgent || !agentMsg.IsComplete {
 		s.persist(false)
 		s.sendToDriver()
@@ -775,6 +778,7 @@ func (s *AgentSession) processAgentMessage(agentMsg *AgentMessage) {
 		return
 	}
 
+	// Agent message with IsComplete=true: notify parent if this is a sub-agent.
 	if s.ParentSessionID != "" {
 		s.notifyParent(*agentMsg)
 	}
@@ -846,6 +850,7 @@ func (s *AgentSession) emitPollResponse(msg *dipper.Message) bool {
 		currentMessage := map[string]string{
 			"content":     am.Content,
 			"is_thinking": strconv.FormatBool(am.IsThinking),
+			"is_chunk":    strconv.FormatBool(am.IsChunk),
 		}
 		if s.Agent.ShouldEmitThoughts && len(am.Thoughts) > 0 {
 			currentMessage["thoughts"] = am.Thoughts
@@ -874,7 +879,8 @@ func (s *AgentSession) emitPollResponse(msg *dipper.Message) bool {
 
 	if live && s.NewPendingContent {
 		liveMessage := map[string]string{
-			"content": s.PendingContent,
+			"content":  s.PendingContent,
+			"is_chunk": "true",
 		}
 		if s.Agent.ShouldEmitThoughts && len(s.PendingThoughts) > 0 {
 			liveMessage["thoughts"] = s.PendingThoughts

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1220,8 +1220,8 @@ func TestProcessAgentMessage_StreamingChunk(t *testing.T) {
 
 	// Non-complete streaming chunks must be accumulated in PendingContent,
 	// not written to convo history, to avoid one Redis rpush per chunk.
-	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: "Hello"})
-	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: ", world"})
+	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: "Hello", IsChunk: true})
+	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: ", world", IsChunk: true})
 
 	assert.Equal(t, "Hello, world", s.PendingContent)
 	assert.Empty(t, s.history, "streaming chunks must not appear in history")
@@ -1233,8 +1233,8 @@ func TestProcessAgentMessage_StreamingComplete(t *testing.T) {
 
 	// Simulate two chunks followed by a final IsComplete=true message that
 	// carries the full content (new protocol: last message is not a delta).
-	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: "Chunk1"})
-	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: "Chunk2"})
+	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: "Chunk1", IsChunk: true})
+	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: "Chunk2", IsChunk: true})
 	s.processAgentMessage(&AgentMessage{Role: RoleAgent, Content: "Chunk1Chunk2", IsComplete: true})
 
 	// PendingContent should be cleared after the complete message.
@@ -1253,6 +1253,7 @@ func TestProcessAgentMessage_Thinking_NotEmittedByDefault(t *testing.T) {
 	agentMsg := &AgentMessage{
 		Role:       RoleAgent,
 		IsThinking: true,
+		IsChunk:    true,
 		Content:    "I am thinking...",
 	}
 
@@ -1269,6 +1270,7 @@ func TestProcessAgentMessage_Thinking_DoesNotRerun(t *testing.T) {
 	agentMsg := &AgentMessage{
 		Role:       RoleAgent,
 		IsThinking: true,
+		IsChunk:    true,
 		Content:    "thinking...",
 	}
 

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -32,6 +32,7 @@ type Message struct {
 	Content      string                   `json:"content" mapstructure:"content"`
 	Thoughts     string                   `json:"thoughts" mapstructure:"thoughts"` // optional field for model reasoning text
 	IsComplete   bool                     `json:"is_complete" mapstructure:"is_complete"`
+	IsChunk      bool                     `json:"is_chunk" mapstructure:"is_chunk"` // true when the message is a streaming chunk
 	InputTokens  int                      `json:"input_tokens" mapstructure:"input_tokens"`
 	OutputTokens int                      `json:"output_tokens" mapstructure:"output_tokens"`
 }


### PR DESCRIPTION
This PR implements **Phase 1** of the clean protocol change to add an explicit `IsChunk` field to the agent `Message` struct. This is a breaking change requiring coordinated deployment of honeydipper/honeydipper (v4 branch), Charles546/hd-driver-openai, and Charles546/hd-driver-claude.

## Changes

### 1. `pkg/agent/types.go`
- Added `IsChunk bool` field to `Message` struct with `json:"is_chunk"` and `mapstructure:"is_chunk"` tags
- This field explicitly distinguishes streaming chunks (`IsChunk=true`) from complete messages (`IsChunk=false`)

### 2. `internal/agent/agent_session.go`
- **`processAgentMessage`**: Replaced the old `if agentMsg.Role == RoleAgent && !agentMsg.IsComplete` logic with clean `if agentMsg.IsChunk` check
  - Streaming chunks (`IsChunk=true`): accumulate in `PendingContent`, return early (no history write)
  - Normal completion (`IsChunk=false, IsComplete=true`): add to history, reset pending, notify parent if sub-agent
  - Truncated responses (`IsChunk=false, IsComplete=false`): persist session and re-send to driver
- **`emitPollResponse`**: Added `"is_chunk"` field to both `full_messages` and `live_message` in poll responses

### 3. `internal/agent/agent_test.go`
- Updated tests to use `IsChunk: true` for streaming chunks and thinking tokens
- Tests now properly reflect the new protocol semantics

## Protocol Semantics (New)

| Message Type | IsChunk | IsComplete | Behavior |
|--------------|---------|------------|----------|
| Streaming chunk | `true` | `false` | Accumulated in memory, not persisted to history |
| Normal completion | `false` | `true` | Added to history, pending cleared, turn may complete |
| Truncated/partial | `false` | `false` | Persisted, driver re-invoked to continue |

## Testing
- All existing tests pass
- `go test ./...` passes
- `golangci-lint run ./...` passes (only pre-existing issues in other files)

## Next Steps (Phase 2 & 3)
- Phase 2: Update Charles546/hd-driver-openai to emit `IsChunk` 
- Phase 3: Update Charles546/hd-driver-claude to emit `IsChunk`