### PR TITLE
feat(redis-cache): add per-field expiration toggle + hget/hgetall handlers (Phase 1)

### DIFF
--- a/drivers/cmd/redis-cache/hget_test.go
+++ b/drivers/cmd/redis-cache/hget_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package main
+
+import (
+	"testing"
+
+	"github.com/go-redis/redismock/v8"
+	"github.com/honeydipper/honeydipper/v4/drivers/pkg/redisclient"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHget(t *testing.T) {
+	if driver == nil {
+		TestLoadOptions(t)
+	}
+
+	db, mock := redismock.NewClientMock()
+	redisOptions = &redisclient.Options{Client: db}
+
+	assert.Panics(t, func() { hget(&dipper.Message{}) }, "hget should panic with empty request")
+
+	msg := &dipper.Message{
+		Payload: map[string]interface{}{
+			"key":   "hfoo",
+			"field": "field1",
+		},
+		Reply: make(chan dipper.Message, 1),
+	}
+
+	mock.ExpectHGet("hfoo", "field1").SetVal("value1")
+	assert.NotPanics(t, func() { hget(msg) }, "hget should not panic with good data")
+	select {
+	case reply := <-msg.Reply:
+		assert.Equal(t, "value1", string(reply.Payload.([]byte)), "hget should return the field value")
+		assert.True(t, reply.IsRaw, "hget should return raw payload")
+	default:
+		assert.Fail(t, "hget should reply a dipper message")
+	}
+
+	mock.ClearExpect()
+
+	msg2 := &dipper.Message{
+		Payload: map[string]interface{}{
+			"key":   "hfoo2",
+			"field": "missing",
+		},
+		Reply: make(chan dipper.Message, 1),
+	}
+	mock.ExpectHGet("hfoo2", "missing").RedisNil()
+	assert.NotPanics(t, func() { hget(msg2) }, "hget should not panic on cache miss")
+	select {
+	case reply := <-msg2.Reply:
+		assert.Nil(t, reply.Payload, "hget with cache miss should return a nil Payload")
+	default:
+		assert.Fail(t, "hget with cache miss should reply a dipper message")
+	}
+}

--- a/drivers/cmd/redis-cache/hgetall_test.go
+++ b/drivers/cmd/redis-cache/hgetall_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package main
+
+import (
+	"testing"
+
+	"github.com/go-redis/redismock/v8"
+	"github.com/honeydipper/honeydipper/v4/drivers/pkg/redisclient"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHgetall(t *testing.T) {
+	if driver == nil {
+		TestLoadOptions(t)
+	}
+
+	db, mock := redismock.NewClientMock()
+	redisOptions = &redisclient.Options{Client: db}
+
+	assert.Panics(t, func() { hgetall(&dipper.Message{}) }, "hgetall should panic with empty request")
+
+	msg := &dipper.Message{
+		Payload: map[string]interface{}{
+			"key": "hfoo",
+		},
+		Reply: make(chan dipper.Message, 1),
+	}
+
+	mock.ExpectHGetAll("hfoo").SetVal(map[string]string{"field1": "value1", "field2": "value2"})
+	assert.NotPanics(t, func() { hgetall(msg) }, "hgetall should not panic with good data")
+	select {
+	case reply := <-msg.Reply:
+		result, ok := reply.Payload.(map[string]any)
+		assert.True(t, ok, "hgetall should return a map[string]any")
+		assert.Equal(t, "value1", result["field1"], "hgetall should return field1 value")
+		assert.Equal(t, "value2", result["field2"], "hgetall should return field2 value")
+	default:
+		assert.Fail(t, "hgetall should reply a dipper message")
+	}
+
+	mock.ClearExpect()
+
+	msg2 := &dipper.Message{
+		Payload: map[string]interface{}{
+			"key": "hfoo2",
+		},
+		Reply: make(chan dipper.Message, 1),
+	}
+	// A non-existent key returns an empty map and nil error from go-redis.
+	mock.ExpectHGetAll("hfoo2").SetVal(map[string]string{})
+	assert.NotPanics(t, func() { hgetall(msg2) }, "hgetall should not panic on empty hash")
+	select {
+	case reply := <-msg2.Reply:
+		result, ok := reply.Payload.(map[string]any)
+		assert.True(t, ok, "hgetall should return a map[string]any")
+		assert.Empty(t, result, "hgetall with empty hash should return an empty map")
+	default:
+		assert.Fail(t, "hgetall with empty hash should reply a dipper message")
+	}
+}

--- a/drivers/cmd/redis-cache/hset.go
+++ b/drivers/cmd/redis-cache/hset.go
@@ -9,6 +9,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -28,6 +29,15 @@ var streamHsetIntervalHours = 2
 // Controls how far back conversation history can be retrieved.
 // Default: 336 hours (2 weeks). Configurable via driver option "data.stream_ttl_hours".
 var streamHsetTTLHours = 336
+
+// perFieldExpiration controls how TTL is applied to hash fields saved via the
+// hset handler. When true, each field gets its own expiration through per-field
+// HEXPIRE (requires Redis >= 7.4). When false (the default), the whole hash key
+// is given a single shared TTL via EXPIRE, which is compatible with older Redis
+// versions.
+//
+// Configurable via driver option "data.per_field_expiration" (boolean).
+var perFieldExpiration = false
 
 const (
 	streamHvalsScript = `
@@ -87,6 +97,24 @@ func loadStreamConfig() {
 
 	log.Infof("[%s] stream_hset: interval=%dh, ttl=%dh (default: 336h=2w)",
 		driver.Service, streamHsetIntervalHours, streamHsetTTLHours)
+}
+
+// loadHashConfig loads hash-related configuration from driver options.
+func loadHashConfig() {
+	if driver.Options == nil {
+		return
+	}
+
+	if v, ok := dipper.GetMapData(driver.Options, "data.per_field_expiration"); ok {
+		switch t := v.(type) {
+		case bool:
+			perFieldExpiration = t
+		default:
+			log.Warningf("[%s] redis cache invalid per_field_expiration type %T, using default", driver.Service, t)
+		}
+	}
+
+	log.Infof("[%s] hash per_field_expiration: %v", driver.Service, perFieldExpiration)
 }
 
 func streamHset(msg *dipper.Message) {
@@ -273,6 +301,19 @@ func hset(msg *dipper.Message) {
 		log.Panicf("[%s] redis error: %v", driver.Service, err)
 	}
 	if len(fields) > 0 {
+		applyHashExpiration(ctx, client, key, exp, fields)
+	}
+
+	msg.Reply <- dipper.Message{}
+}
+
+// applyHashExpiration sets the TTL for a hash key written by hset. When
+// perFieldExpiration is enabled (Redis >= 7.4), each field receives its own
+// expiration via per-field HEXPIRE (executed through a Lua script so expired
+// fields are auto-removed by Redis). Otherwise the whole hash key is given a
+// single shared TTL via EXPIRE, which works on Redis versions older than 7.4.
+func applyHashExpiration(ctx context.Context, client redisclient.Options, key string, exp time.Duration, fields []string) {
+	if perFieldExpiration {
 		ttlSeconds := int64(exp / time.Second)
 		args := make([]interface{}, 2+len(fields))
 		args[0] = ttlSeconds
@@ -283,9 +324,70 @@ func hset(msg *dipper.Message) {
 		if _, err := client.Eval(ctx, hexpireScript, []string{key}, args...).Result(); err != nil && !errors.Is(err, redis.Nil) {
 			log.Panicf("[%s] redis error: %v", driver.Service, err)
 		}
+
+		return
 	}
 
-	msg.Reply <- dipper.Message{}
+	if err := client.Expire(ctx, key, exp).Err(); err != nil && !errors.Is(err, redis.Nil) {
+		log.Panicf("[%s] redis error: %v", driver.Service, err)
+	}
+}
+
+// hget performs HGET key field and returns the raw field value. It returns an
+// empty (nil) payload on a cache miss (redis.Nil) and panics on real errors,
+// mirroring the behavior of the load handler.
+func hget(msg *dipper.Message) {
+	dipper.DeserializePayload(msg)
+	key := dipper.MustGetMapDataStr(msg.Payload, "key")
+	field := dipper.MustGetMapDataStr(msg.Payload, "field")
+
+	client := redisclient.NewClient(redisOptions)
+	defer client.Close()
+	ctx, cancel := driver.GetContext(msg)
+	defer cancel()
+
+	val, err := client.HGet(ctx, key, field).Result()
+	switch {
+	case errors.Is(err, redis.Nil):
+		msg.Reply <- dipper.Message{}
+	case err != nil:
+		log.Panicf("[%s] redis error: %v", driver.Service, err)
+	default:
+		msg.Reply <- dipper.Message{
+			Payload: []byte(val),
+			IsRaw:   true,
+		}
+	}
+}
+
+// hgetall performs HGETALL key and returns a map[string]any of field -> value
+// (string). When per-field expiration is enabled, expired hash fields are
+// auto-removed by Redis so they are naturally excluded from the result. It
+// returns an empty (no error) payload on a cache miss.
+func hgetall(msg *dipper.Message) {
+	dipper.DeserializePayload(msg)
+	key := dipper.MustGetMapDataStr(msg.Payload, "key")
+
+	client := redisclient.NewClient(redisOptions)
+	defer client.Close()
+	ctx, cancel := driver.GetContext(msg)
+	defer cancel()
+
+	val, err := client.HGetAll(ctx, key).Result()
+	switch {
+	case errors.Is(err, redis.Nil):
+		msg.Reply <- dipper.Message{}
+	case err != nil:
+		log.Panicf("[%s] redis error: %v", driver.Service, err)
+	default:
+		result := map[string]any{}
+		for k, v := range val {
+			result[k] = v
+		}
+		msg.Reply <- dipper.Message{
+			Payload: result,
+		}
+	}
 }
 
 func hvals(msg *dipper.Message) {

--- a/drivers/cmd/redis-cache/hset_test.go
+++ b/drivers/cmd/redis-cache/hset_test.go
@@ -25,6 +25,11 @@ func TestHset(t *testing.T) {
 		TestLoadOptions(t)
 	}
 
+	// Explicitly enable per-field expiration to preserve the existing per-field
+	// HEXPIRE (Redis >= 7.4) code path coverage.
+	perFieldExpiration = true
+	defer func() { perFieldExpiration = false }()
+
 	db, mock := redismock.NewClientMock()
 	redisOptions = &redisclient.Options{Client: db}
 
@@ -71,6 +76,63 @@ func TestHset(t *testing.T) {
 	}
 }
 
+// TestHsetWholeHashExpire verifies the fallback path used when per-field
+// expiration is disabled (perFieldExpiration = false): the whole hash key is
+// given a single shared TTL via EXPIRE instead of per-field HEXPIRE. This keeps
+// the feature compatible with Redis versions older than 7.4.
+func TestHsetWholeHashExpire(t *testing.T) {
+	if driver == nil {
+		TestLoadOptions(t)
+	}
+
+	perFieldExpiration = false
+
+	db, mock := redismock.NewClientMock()
+	redisOptions = &redisclient.Options{Client: db}
+
+	assert.Panics(t, func() { hset(&dipper.Message{}) }, "hset should panic with empty request")
+
+	msg := &dipper.Message{
+		Payload: map[string]interface{}{
+			"key": "hfoo",
+			"value": map[string]interface{}{
+				"field": "value",
+			},
+		},
+		Reply: make(chan dipper.Message, 1),
+	}
+
+	mock.ExpectHSet("hfoo", map[string]interface{}{"field": "value"}).SetVal(1)
+	mock.ExpectExpire("hfoo", 24*time.Hour).SetVal(true)
+	assert.NotPanics(t, func() { hset(msg) }, "hset should not panic with whole-hash expire (default ttl)")
+	select {
+	case <-msg.Reply:
+	default:
+		assert.Fail(t, "hset should reply a dipper message")
+	}
+
+	mock.ClearExpect()
+
+	msg2 := &dipper.Message{
+		Payload: map[string]interface{}{
+			"key": "hfoo2",
+			"value": map[string]interface{}{
+				"field": "value2",
+			},
+			"ttl": "1h",
+		},
+		Reply: make(chan dipper.Message, 1),
+	}
+	mock.ExpectHSet("hfoo2", map[string]interface{}{"field": "value2"}).SetVal(1)
+	mock.ExpectExpire("hfoo2", time.Hour).SetVal(true)
+	assert.NotPanics(t, func() { hset(msg2) }, "hset should not panic with whole-hash expire (custom ttl)")
+	select {
+	case <-msg2.Reply:
+	default:
+		assert.Fail(t, "hset should reply a dipper message")
+	}
+}
+
 func TestHvals(t *testing.T) {
 	if driver == nil {
 		TestLoadOptions(t)
@@ -88,11 +150,11 @@ func TestHvals(t *testing.T) {
 		Reply: make(chan dipper.Message, 1),
 	}
 
-	mock.ExpectHVals("hfoo").SetVal([]string{"\"value\""})
+	mock.ExpectHVals("hfoo").SetVal([]string{`"value"`})
 	assert.NotPanics(t, func() { hvals(msg) }, "hvals should not panic with good data")
 	select {
 	case reply := <-msg.Reply:
-		assert.Equal(t, "[\"value\"]", string(reply.Payload.([]byte)), "hvals should return hash field value")
+		assert.Equal(t, `["value"]`, string(reply.Payload.([]byte)), "hvals should return hash field value")
 	default:
 		assert.Fail(t, "hvals should reply a dipper message")
 	}

--- a/drivers/cmd/redis-cache/main.go
+++ b/drivers/cmd/redis-cache/main.go
@@ -82,6 +82,8 @@ func main() {
 	driver.RPCHandlers["hset"] = hset
 	driver.RPCHandlers["hvals"] = hvals
 	driver.RPCHandlers["hmget"] = hmget
+	driver.RPCHandlers["hget"] = hget
+	driver.RPCHandlers["hgetall"] = hgetall
 	driver.RPCHandlers["stream_hset"] = streamHset
 	driver.RPCHandlers["stream_hvals"] = streamHvals
 	driver.Run()
@@ -94,6 +96,7 @@ func loadOptions() {
 
 	// Load stream_hset configuration from driver options
 	loadStreamConfig()
+	loadHashConfig()
 }
 
 func start(msg *dipper.Message) {


### PR DESCRIPTION
## Summary

This is **Phase 1** of the redis hashes workflow caching feature. It adds a config-controlled expiration toggle plus two new read handlers to the built-in `redis-cache` driver (mapped to the `cache` feature), without touching `pkg/workflow/cache.go` (Phases 2/3).

### Changes (`drivers/cmd/redis-cache/`)

1. **New config option `data.per_field_expiration` (boolean, default `false`)**
   - Package var `perFieldExpiration = false`.
   - Read during option loading in the new `loadHashConfig()` (mirrors how `stream_*` options are loaded in `loadStreamConfig`), called from `loadOptions`.
   - When `true` → keep existing per-field `HEXPIRE` behavior (requires Redis >= 7.4).
   - When `false` (default) → do **not** call `HEXPIRE`; instead set `EXPIRE` on the whole hash key, providing compatibility with lower Redis versions.

2. **New `hget` RPC handler** — `HGET key field` → raw bytes (`IsRaw`). Returns an empty (nil) payload on `redis.Nil` (cache miss) and panics on real errors, same style as the existing `load` handler.

3. **New `hgetall` RPC handler** — `HGETALL key` → `map[string]any` of field → value(string). Returns an empty (no-error) payload on `redis.Nil`. When per-field expiry is enabled, expired hash fields are auto-removed by Redis, so `hgetall` naturally excludes them.

4. **Modified `hset`** — keeps the existing `HSET` + (when `per_field_expiration` is `true`) per-field `hexpireScript` path; when `false`, replaces the `HEXPIRE` step with `client.Expire(ctx, key, exp)` on the whole hash key (reusing the already-computed `exp`/`ttl`). The expiration logic is extracted into `applyHashExpiration` to keep the `hset` function lint-clean (nestif/nlreturn).

### Tests
- Added `hget_test.go` and `hgetall_test.go` (redismock, `//go:build !integration`).
- Extended `hset_test.go` to cover **both** toggle states: per-field `HEXPIRE` script path (`TestHset`, sets `perFieldExpiration = true`) and the whole-hash `EXPIRE` fallback (`TestHsetWholeHashExpire`).

### Verification
- `go test ./...` passes from repo root.
- `golangci-lint run ./drivers/cmd/redis-cache/...` → **0 issues**.
- The 12 lint issues reported by the repo-wide `golangci-lint run ./...` are pre-existing on the pristine `v4` baseline (in `drivers/cmd/web`, `pkg/dipper`, `pkg/workflow`) and are unrelated to this change.

### Notes
- Per the user's change to the plan, the default for `data.per_field_expiration` is **`false`** (the architect's finalized plan had default `true`).
- Phase 2/3 (hash-field load/save and whole-hash read-only in `pkg/workflow/cache.go`) are intentionally out of scope for this PR.
- Documentation (Phase 4) is out of scope for Phase 1.