### PR TITLE
feat(workflow): support redis hash field caching with # key syntax (Phase 2)

### DIFF
--- a/pkg/workflow/cache.go
+++ b/pkg/workflow/cache.go
@@ -9,12 +9,46 @@ package workflow
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
 )
 
 const LabelFromCache = "from_cache"
+
+// cacheKeyMode enumerates how a CacheKey should be interpreted when loading or
+// saving workflow cache data.
+type cacheKeyMode int
+
+const (
+	// cacheKeyModeNormal targets a plain key with no '#' (the legacy behavior).
+	cacheKeyModeNormal cacheKeyMode = iota
+	// cacheKeyModeHashField targets a single field of a Redis hash, written as
+	// "name#field". Each field is stored and TTL'd as an independent entry.
+	cacheKeyModeHashField
+	// cacheKeyModeWholeHash targets an entire Redis hash, written as "name#".
+	// Whole-hash read-only is implemented in a later phase; for now it falls
+	// through to the legacy load/save behavior like a normal key.
+	cacheKeyModeWholeHash
+)
+
+// parseCacheKey splits a CacheKey on the first '#' into the hash name and field
+// components and reports which caching mode applies. When no '#' is present the
+// key is treated as a normal (legacy) key.
+func parseCacheKey(key string) (hashName, field string, mode cacheKeyMode) {
+	parts := strings.SplitN(key, "#", 2)
+	if len(parts) == 1 {
+		return "", "", cacheKeyModeNormal
+	}
+
+	hashName, field = parts[0], parts[1]
+	if field == "" {
+		return hashName, "", cacheKeyModeWholeHash
+	}
+
+	return hashName, field, cacheKeyModeHashField
+}
 
 func (w *Session) processCheckCacheState() {
 	delete(w.Ctx, "cache-data")
@@ -36,15 +70,32 @@ func (w *Session) processCheckCacheState() {
 	}
 
 	if data == nil {
-		buf, _ := w.store.Call("cache", "load", map[string]any{
-			"key": "workflow-cache/" + w.Workflow.CacheKey,
-		})
-		if len(buf) == 0 {
-			w.store.GetLogger().Warningf("[%s.%s] cache missing for %s", w.ID, w.CurrentMsg.Labels["cursor"], w.Workflow.CacheKey)
+		hashName, field, mode := parseCacheKey(w.Workflow.CacheKey)
+		switch mode {
+		case cacheKeyModeHashField:
+			buf, _ := w.store.Call("cache", "hget", map[string]any{
+				"key":   "workflow-cache/" + hashName,
+				"field": field,
+			})
+			if len(buf) == 0 {
+				w.store.GetLogger().Warningf("[%s.%s] cache missing for %s", w.ID, w.CurrentMsg.Labels["cursor"], w.Workflow.CacheKey)
 
-			return
+				return
+			}
+			dipper.Must(json.Unmarshal(buf, &data))
+		default:
+			// Normal keys and whole-hash ("name#") keys use the existing load
+			// behavior. Whole-hash read-only is implemented in a later phase.
+			buf, _ := w.store.Call("cache", "load", map[string]any{
+				"key": "workflow-cache/" + w.Workflow.CacheKey,
+			})
+			if len(buf) == 0 {
+				w.store.GetLogger().Warningf("[%s.%s] cache missing for %s", w.ID, w.CurrentMsg.Labels["cursor"], w.Workflow.CacheKey)
+
+				return
+			}
+			dipper.Must(json.Unmarshal(buf, &data))
 		}
-		dipper.Must(json.Unmarshal(buf, &data))
 	}
 
 	w.Ctx["cache-data"] = data
@@ -70,12 +121,28 @@ func (w *Session) processSaveCacheState() {
 			memcache.Set(w.Workflow.CacheKey, data.(map[string]any), t)
 		}
 
-		buf := dipper.Must(json.Marshal(data)).([]byte)
-		dipper.Must(w.store.Call("cache", "save", map[string]any{
-			"key":   "workflow-cache/" + w.Workflow.CacheKey,
-			"value": string(buf),
-			"ttl":   ttl,
-		}))
+		hashName, field, mode := parseCacheKey(w.Workflow.CacheKey)
+		switch mode {
+		case cacheKeyModeHashField:
+			// Store a single hash field as an independent, TTL'd entry. The
+			// redis-cache driver applies per-field HEXPIRE (when enabled) or
+			// whole-hash EXPIRE to the underlying hash key.
+			buf := dipper.Must(json.Marshal(data)).([]byte)
+			dipper.Must(w.store.Call("cache", "hset", map[string]any{
+				"key":   "workflow-cache/" + hashName,
+				"value": map[string]any{field: string(buf)},
+				"ttl":   ttl,
+			}))
+		default:
+			// Normal keys and whole-hash ("name#") keys use the existing save
+			// behavior. Whole-hash read-only is implemented in a later phase.
+			buf := dipper.Must(json.Marshal(data)).([]byte)
+			dipper.Must(w.store.Call("cache", "save", map[string]any{
+				"key":   "workflow-cache/" + w.Workflow.CacheKey,
+				"value": string(buf),
+				"ttl":   ttl,
+			}))
+		}
 
 		w.store.GetLogger().Infof("[%s.%s] cache saved for %s", w.ID, w.CurrentMsg.Labels["cursor"], w.Workflow.CacheKey)
 	}

--- a/pkg/workflow/cache_test.go
+++ b/pkg/workflow/cache_test.go
@@ -10,6 +10,8 @@
 package workflow
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -319,5 +321,183 @@ func TestProcessSaveCacheState_MemcacheEnabled_TTLCapped(t *testing.T) {
 	item := es.GetCache().Get("test-key")
 	if item == nil {
 		t.Fatal("expected data in memcache")
+	}
+}
+
+func TestProcessCheckCacheState_HashField_MemcacheHit(t *testing.T) {
+	s := makeExecuteSession()
+	es := &cacheTestStore{memcacheEnabled: true}
+	s.store = es
+	s.Workflow.CacheKey = "myhash#myfield"
+	s.CurrentMsg = &dipper.Message{Labels: map[string]string{}}
+	es.GetCache().Set("myhash#myfield", map[string]any{"data": "memcached-result"}, time.Hour)
+
+	s.processCheckCacheState()
+
+	if s.CurrentMsg.Labels[LabelFromCache] != "true" {
+		t.Error("expected from_cache label to be set")
+	}
+	data := s.Ctx["cache-data"].(map[string]any)
+	if data["data"] != "memcached-result" {
+		t.Errorf("expected memcached data, got %v", data)
+	}
+	if es.lastCallFeature == "cache" {
+		t.Error("should not call external cache when memcache hit")
+	}
+}
+
+func TestProcessCheckCacheState_HashField_MissHget(t *testing.T) {
+	s := makeExecuteSession()
+	es := &cacheTestStore{memcacheEnabled: false}
+	es.callReturn = func(feature, method string) ([]byte, error) {
+		if feature == "cache" && method == "hget" {
+			return []byte(`{"data": "hash-field-result"}`), nil
+		}
+
+		return nil, nil
+	}
+	s.store = es
+	s.Workflow.CacheKey = "myhash#myfield"
+	s.CurrentMsg = &dipper.Message{Labels: map[string]string{}}
+
+	s.processCheckCacheState()
+
+	if s.CurrentMsg.Labels[LabelFromCache] != "true" {
+		t.Error("expected from_cache label to be set")
+	}
+	if es.lastCallFeature != "cache" || es.lastCallMethod != "hget" {
+		t.Errorf("expected cache hget call, got %s.%s", es.lastCallFeature, es.lastCallMethod)
+	}
+	params, ok := es.lastCallParams.(map[string]any)
+	if !ok {
+		t.Fatalf("params should be map")
+	}
+	if params["key"] != "workflow-cache/myhash" {
+		t.Errorf("unexpected hget key: %v", params["key"])
+	}
+	if params["field"] != "myfield" {
+		t.Errorf("unexpected hget field: %v", params["field"])
+	}
+	data := s.Ctx["cache-data"].(map[string]any)
+	if data["data"] != "hash-field-result" {
+		t.Errorf("expected hash field data, got %v", data)
+	}
+}
+
+func TestProcessSaveCacheState_HashField(t *testing.T) {
+	s := makeExecuteSession()
+	es := &cacheTestStore{memcacheEnabled: true}
+	s.store = es
+	s.Workflow.CacheKey = "myhash#myfield"
+	s.Workflow.CacheTTL = "30m"
+	s.Ctx["cache-data"] = map[string]any{"result": "data"}
+
+	s.processSaveCacheState()
+
+	item := es.GetCache().Get("myhash#myfield")
+	if item == nil {
+		t.Fatal("expected data in memcache for hash field key")
+	}
+	if es.lastCallFeature != "cache" || es.lastCallMethod != "hset" {
+		t.Errorf("expected cache hset call, got %s.%s", es.lastCallFeature, es.lastCallMethod)
+	}
+	params, ok := es.lastCallParams.(map[string]any)
+	if !ok {
+		t.Fatalf("params should be map")
+	}
+	if params["key"] != "workflow-cache/myhash" {
+		t.Errorf("unexpected hset key: %v", params["key"])
+	}
+	if params["ttl"] != "30m" {
+		t.Errorf("unexpected hset ttl: %v", params["ttl"])
+	}
+	expected, _ := json.Marshal(map[string]any{"result": "data"})
+	if !reflect.DeepEqual(params["value"], map[string]any{"myfield": string(expected)}) {
+		t.Errorf("unexpected hset value: %v", params["value"])
+	}
+}
+
+func TestProcessCheckCacheState_NormalKeyUsesLoad(t *testing.T) {
+	s := makeExecuteSession()
+	es := &cacheTestStore{memcacheEnabled: false}
+	es.callReturn = func(feature, method string) ([]byte, error) {
+		if feature == "cache" && method == "load" {
+			return []byte(`{"data": "normal-result"}`), nil
+		}
+
+		return nil, nil
+	}
+	s.store = es
+	s.Workflow.CacheKey = "test-key"
+	s.CurrentMsg = &dipper.Message{Labels: map[string]string{}}
+
+	s.processCheckCacheState()
+
+	if es.lastCallFeature != "cache" || es.lastCallMethod != "load" {
+		t.Errorf("expected cache load call for normal key, got %s.%s", es.lastCallFeature, es.lastCallMethod)
+	}
+	if s.CurrentMsg.Labels[LabelFromCache] != "true" {
+		t.Error("expected from_cache label to be set")
+	}
+}
+
+func TestProcessSaveCacheState_NormalKeyUsesSave(t *testing.T) {
+	s := makeExecuteSession()
+	es := &cacheTestStore{memcacheEnabled: true}
+	s.store = es
+	s.Workflow.CacheKey = "test-key"
+	s.Workflow.CacheTTL = "1h"
+	s.Ctx["cache-data"] = map[string]any{"result": "data"}
+
+	s.processSaveCacheState()
+
+	if es.lastCallFeature != "cache" || es.lastCallMethod != "save" {
+		t.Errorf("expected cache save call for normal key, got %s.%s", es.lastCallFeature, es.lastCallMethod)
+	}
+	params, ok := es.lastCallParams.(map[string]any)
+	if !ok {
+		t.Fatalf("params should be map")
+	}
+	if params["key"] != "workflow-cache/test-key" {
+		t.Errorf("unexpected cache key for normal key: %v", params["key"])
+	}
+}
+
+func TestProcessCheckCacheState_WholeHashFallsThrough(t *testing.T) {
+	s := makeExecuteSession()
+	es := &cacheTestStore{memcacheEnabled: false}
+	es.callReturn = func(feature, method string) ([]byte, error) {
+		if feature == "cache" && method == "load" {
+			return []byte(`{"data": "whole-hash-result"}`), nil
+		}
+
+		return nil, nil
+	}
+	s.store = es
+	s.Workflow.CacheKey = "myhash#"
+	s.CurrentMsg = &dipper.Message{Labels: map[string]string{}}
+
+	s.processCheckCacheState()
+
+	if es.lastCallFeature != "cache" || es.lastCallMethod != "load" {
+		t.Errorf("expected cache load call for whole-hash key (phase 3 not implemented), got %s.%s", es.lastCallFeature, es.lastCallMethod)
+	}
+	if s.CurrentMsg.Labels[LabelFromCache] != "true" {
+		t.Error("expected from_cache label to be set")
+	}
+}
+
+func TestProcessSaveCacheState_WholeHashFallsThrough(t *testing.T) {
+	s := makeExecuteSession()
+	es := &cacheTestStore{memcacheEnabled: true}
+	s.store = es
+	s.Workflow.CacheKey = "myhash#"
+	s.Workflow.CacheTTL = "1h"
+	s.Ctx["cache-data"] = map[string]any{"result": "data"}
+
+	s.processSaveCacheState()
+
+	if es.lastCallFeature != "cache" || es.lastCallMethod != "save" {
+		t.Errorf("expected cache save call for whole-hash key (phase 3 not implemented), got %s.%s", es.lastCallFeature, es.lastCallMethod)
 	}
 }


### PR DESCRIPTION
## Summary

**Phase 2** of the redis hashes workflow caching feature (Phase 1 merged via #802). This makes `name#field` cache keys load/save a single hash field as an independent, TTL'd cache entry, while leaving plain (no `#`) keys on the legacy `load`/`save` path unchanged.

### Changes (`pkg/workflow/cache.go`)
- **New `parseCacheKey` helper** — splits a `CacheKey` on the **first** `#` (via `strings.SplitN(key, "#", 2)`) into `(hashName, field, mode)`:
  - `cacheKeyModeHashField` — `name#field`, non-empty field.
  - `cacheKeyModeWholeHash` — `name#`, empty field (detected, but left flowing through to the legacy path; **Phase 3** will implement read-only).
  - `cacheKeyModeNormal` — no `#` (legacy behavior).
- **`processCheckCacheState`** — for a hash-field key: try the in-memory memcache keyed by the full `CacheKey`; on miss call the `cache` feature's `hget` RPC with `key = "workflow-cache/" + hashName` and `field`, `json.Unmarshal` the result into `cache-data`, and on hit set `LabelFromCache`, `status=success`, and export `cache-data*`. Normal keys are unchanged.
- **`processSaveCacheState`** — if `LabelFromCache` is NOT set and the key is a hash-field: set the memcache keyed by the full `CacheKey` (unchanged ttl cap), then call the `cache` `hset` RPC with `key = "workflow-cache/" + hashName`, `value = {field: string(json)}`, and `ttl`. The driver (Phase 1) applies per-field `HEXPIRE` (toggle on) or whole-hash `EXPIRE` (toggle off). Normal keys still use `cache` `save`.

Redis key mapping: `CacheKey = "name#field"` → Redis hash key `"workflow-cache/name"`, hash field `"field"`. Each field's TTL is handled by the driver, so no signature change to the `hset` handler was needed.

### Tests (`pkg/workflow/cache_test.go`)
Added (redismock-free, `//go:build !integration`) covering:
- (a) hash-field load hit from memcache (no external call),
- (b) hash-field load miss → `hget` call with correct `key`/`field` → `cache-data` set,
- (c) hash-field save → memcache set + `hset` call with correct `key`/`value`/`ttl`,
- (d) normal keys still use `save`/`load` (and a whole-hash `name#` key falls through to `load`/`save`, confirming Phase 3 is detected but not implemented here).

### Verification
- `go test ./...` from repo root → **all pass** (exit 0); `pkg/workflow` package passes.
- `golangci-lint run ./pkg/workflow/...` → **no issues** in `cache.go` / `cache_test.go`.
- The 3 `govet` (`slices.Contains` type-inference) issues reported by the repo-wide lint are **pre-existing on `v4`** and unrelated to this change (in `session_init.go` / `session_init_test.go`).

### Scope / commits
- Commit + PR titles use the `workflow` scope, which is in the allowed list in `.github/workflows/check-semantic-commits.yml`.
- Phase 3 (whole-hash read-only for `name#`) and optional Phase 4 docs are intentionally out of scope.