### PR TITLE
feat(workflow): support whole-hash read-only cache with trailing # key

### DIFF
--- a/pkg/workflow/cache.go
+++ b/pkg/workflow/cache.go
@@ -28,8 +28,8 @@ const (
 	// "name#field". Each field is stored and TTL'd as an independent entry.
 	cacheKeyModeHashField
 	// cacheKeyModeWholeHash targets an entire Redis hash, written as "name#".
-	// Whole-hash read-only is implemented in a later phase; for now it falls
-	// through to the legacy load/save behavior like a normal key.
+	// The whole hash is read directly from Redis (hgetall) as a read-only
+	// aggregate view; it is never written back.
 	cacheKeyModeWholeHash
 )
 
@@ -50,6 +50,56 @@ func parseCacheKey(key string) (hashName, field string, mode cacheKeyMode) {
 	return hashName, field, cacheKeyModeHashField
 }
 
+// decodeCacheField returns the decoded value for a single Redis hash field. Hash
+// fields store JSON-encoded values, so a string field is unmarshaled; any other
+// type is returned as-is.
+func decodeCacheField(value any) any {
+	if s, ok := value.(string); ok {
+		var decoded any
+		dipper.Must(json.Unmarshal([]byte(s), &decoded))
+
+		return decoded
+	}
+
+	return value
+}
+
+// loadWholeHashCache reads the entire Redis hash for hashName via the cache
+// feature's hgetall RPC and aggregates it into a cache-data map keyed by field.
+// It is a read-only operation: the caller must never write the result back. The
+// second return value reports whether usable data was found.
+func (w *Session) loadWholeHashCache(hashName string) (map[string]any, bool) {
+	if hashName == "" {
+		w.store.GetLogger().Warningf("[%s.%s] cache missing for %s", w.ID, w.CurrentMsg.Labels["cursor"], w.Workflow.CacheKey)
+
+		return nil, false
+	}
+
+	buf, _ := w.store.Call("cache", "hgetall", map[string]any{
+		"key": "workflow-cache/" + hashName,
+	})
+	if len(buf) == 0 {
+		w.store.GetLogger().Warningf("[%s.%s] cache missing for %s", w.ID, w.CurrentMsg.Labels["cursor"], w.Workflow.CacheKey)
+
+		return nil, false
+	}
+
+	raw := map[string]any{}
+	dipper.Must(json.Unmarshal(buf, &raw))
+	if len(raw) == 0 {
+		w.store.GetLogger().Warningf("[%s.%s] cache missing for %s", w.ID, w.CurrentMsg.Labels["cursor"], w.Workflow.CacheKey)
+
+		return nil, false
+	}
+
+	data := make(map[string]any, len(raw))
+	for field, value := range raw {
+		data[field] = decodeCacheField(value)
+	}
+
+	return data, true
+}
+
 func (w *Session) processCheckCacheState() {
 	delete(w.Ctx, "cache-data")
 	delete(w.CurrentMsg.Labels, LabelFromCache)
@@ -60,17 +110,22 @@ func (w *Session) processCheckCacheState() {
 		return
 	}
 
+	hashName, field, mode := parseCacheKey(w.Workflow.CacheKey)
+
 	var data map[string]any
 
-	memcache := w.store.GetCache()
-	if memcache != nil {
-		if item := memcache.Get(w.Workflow.CacheKey); item != nil {
-			data = item.Value()
+	// Whole-hash ("name#") caching reads directly from Redis via hgetall and
+	// never touches the memcache; skip the memcache lookup for that mode.
+	if mode != cacheKeyModeWholeHash {
+		memcache := w.store.GetCache()
+		if memcache != nil {
+			if item := memcache.Get(w.Workflow.CacheKey); item != nil {
+				data = item.Value()
+			}
 		}
 	}
 
 	if data == nil {
-		hashName, field, mode := parseCacheKey(w.Workflow.CacheKey)
 		switch mode {
 		case cacheKeyModeHashField:
 			buf, _ := w.store.Call("cache", "hget", map[string]any{
@@ -83,9 +138,16 @@ func (w *Session) processCheckCacheState() {
 				return
 			}
 			dipper.Must(json.Unmarshal(buf, &data))
+		case cacheKeyModeWholeHash:
+			// Read-only aggregate view of the entire Redis hash. We never write
+			// back (see processSaveCacheState) and we ignore the memcache.
+			whole, ok := w.loadWholeHashCache(hashName)
+			if !ok {
+				return
+			}
+			data = whole
 		default:
-			// Normal keys and whole-hash ("name#") keys use the existing load
-			// behavior. Whole-hash read-only is implemented in a later phase.
+			// Normal keys use the existing load behavior.
 			buf, _ := w.store.Call("cache", "load", map[string]any{
 				"key": "workflow-cache/" + w.Workflow.CacheKey,
 			})
@@ -112,6 +174,14 @@ func (w *Session) processSaveCacheState() {
 	if ttl == "" {
 		ttl = "24h"
 	}
+
+	// Whole-hash ("name#") caching is strictly read-only: never write back to
+	// the memcache or to Redis, regardless of how the session was loaded (this
+	// also covers the force-refresh / empty-hash run path).
+	if _, _, mode := parseCacheKey(w.Workflow.CacheKey); mode == cacheKeyModeWholeHash {
+		return
+	}
+
 	if data, ok := w.Ctx["cache-data"]; ok && data != nil {
 		if memcache := w.store.GetCache(); memcache != nil {
 			t := dipper.Must(time.ParseDuration(ttl)).(time.Duration)
@@ -134,8 +204,7 @@ func (w *Session) processSaveCacheState() {
 				"ttl":   ttl,
 			}))
 		default:
-			// Normal keys and whole-hash ("name#") keys use the existing save
-			// behavior. Whole-hash read-only is implemented in a later phase.
+			// Normal keys use the existing save behavior.
 			buf := dipper.Must(json.Marshal(data)).([]byte)
 			dipper.Must(w.store.Call("cache", "save", map[string]any{
 				"key":   "workflow-cache/" + w.Workflow.CacheKey,

--- a/pkg/workflow/cache_test.go
+++ b/pkg/workflow/cache_test.go
@@ -463,12 +463,15 @@ func TestProcessSaveCacheState_NormalKeyUsesSave(t *testing.T) {
 	}
 }
 
-func TestProcessCheckCacheState_WholeHashFallsThrough(t *testing.T) {
+func TestProcessCheckCacheState_WholeHashHit(t *testing.T) {
 	s := makeExecuteSession()
-	es := &cacheTestStore{memcacheEnabled: false}
+	es := &cacheTestStore{memcacheEnabled: true}
+	// A stale memcache entry must be ignored for whole-hash keys.
+	es.GetCache().Set("myhash#", map[string]any{"stale": true}, time.Hour)
 	es.callReturn = func(feature, method string) ([]byte, error) {
-		if feature == "cache" && method == "load" {
-			return []byte(`{"data": "whole-hash-result"}`), nil
+		if feature == "cache" && method == "hgetall" {
+			// Each hash field stores a JSON-encoded value.
+			return []byte(`{"alpha":"{\"n\":1}","beta":"\"world\""}`), nil
 		}
 
 		return nil, nil
@@ -479,15 +482,109 @@ func TestProcessCheckCacheState_WholeHashFallsThrough(t *testing.T) {
 
 	s.processCheckCacheState()
 
-	if es.lastCallFeature != "cache" || es.lastCallMethod != "load" {
-		t.Errorf("expected cache load call for whole-hash key (phase 3 not implemented), got %s.%s", es.lastCallFeature, es.lastCallMethod)
-	}
 	if s.CurrentMsg.Labels[LabelFromCache] != "true" {
 		t.Error("expected from_cache label to be set")
 	}
+	if s.CurrentMsg.Labels["status"] != SessionStatusSuccess {
+		t.Error("expected status to be success")
+	}
+	if es.lastCallFeature != "cache" || es.lastCallMethod != "hgetall" {
+		t.Errorf("expected cache hgetall call, got %s.%s", es.lastCallFeature, es.lastCallMethod)
+	}
+	data, ok := s.Ctx["cache-data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected cache-data map, got %T", s.Ctx["cache-data"])
+	}
+	alpha, ok := data["alpha"].(map[string]any)
+	if !ok || alpha["n"] != float64(1) {
+		t.Errorf("expected alpha={n:1}, got %v", data["alpha"])
+	}
+	if data["beta"] != "world" {
+		t.Errorf("expected beta=world, got %v", data["beta"])
+	}
+	if _, stale := data["stale"]; stale {
+		t.Error("stale memcache entry should have been ignored for whole-hash key")
+	}
 }
 
-func TestProcessSaveCacheState_WholeHashFallsThrough(t *testing.T) {
+func TestProcessCheckCacheState_WholeHashNoData(t *testing.T) {
+	s := makeExecuteSession()
+	es := &cacheTestStore{memcacheEnabled: false}
+	es.callReturn = func(feature, method string) ([]byte, error) {
+		if feature == "cache" && method == "hgetall" {
+			return nil, nil
+		}
+
+		return nil, nil
+	}
+	s.store = es
+	s.Workflow.CacheKey = "myhash#"
+	s.CurrentMsg = &dipper.Message{Labels: map[string]string{}}
+
+	s.processCheckCacheState()
+
+	if s.CurrentMsg.Labels[LabelFromCache] == "true" {
+		t.Error("from_cache label should not be set on whole-hash miss")
+	}
+	if s.CurrentMsg.Labels["status"] == SessionStatusSuccess {
+		t.Error("status should not be success on whole-hash miss")
+	}
+	if s.Ctx["cache-data"] != nil {
+		t.Error("cache-data should not be set on whole-hash miss")
+	}
+}
+
+func TestProcessCheckCacheState_WholeHashForceRefresh(t *testing.T) {
+	s := makeExecuteSession()
+	es := &cacheTestStore{memcacheEnabled: false}
+	es.callReturn = func(feature, method string) ([]byte, error) {
+		if feature == "cache" && method == "hgetall" {
+			return []byte(`{"alpha":"1"}`), nil
+		}
+
+		return nil, nil
+	}
+	s.store = es
+	s.Workflow.CacheKey = "myhash#"
+	s.CurrentMsg = &dipper.Message{Labels: map[string]string{}}
+	s.Ctx["force-cache-refresh"] = true
+
+	s.processCheckCacheState()
+
+	if s.CurrentMsg.Labels[LabelFromCache] == "true" {
+		t.Error("from_cache label should not be set when force refresh")
+	}
+	if s.Ctx["cache-data"] != nil {
+		t.Error("cache-data should not be set when force refresh")
+	}
+}
+
+func TestProcessCheckCacheState_WholeHashEmptyName(t *testing.T) {
+	s := makeExecuteSession()
+	es := &cacheTestStore{memcacheEnabled: false}
+	calls := 0
+	es.callReturn = func(feature, method string) ([]byte, error) {
+		if feature == "cache" && method == "hgetall" {
+			calls++
+		}
+
+		return nil, nil
+	}
+	s.store = es
+	s.Workflow.CacheKey = "#"
+	s.CurrentMsg = &dipper.Message{Labels: map[string]string{}}
+
+	s.processCheckCacheState()
+
+	if calls != 0 {
+		t.Error("hgetall should not be called for empty hash name")
+	}
+	if s.Ctx["cache-data"] != nil {
+		t.Error("cache-data should not be set for empty hash name")
+	}
+}
+
+func TestProcessSaveCacheState_WholeHashNoWrite(t *testing.T) {
 	s := makeExecuteSession()
 	es := &cacheTestStore{memcacheEnabled: true}
 	s.store = es
@@ -497,7 +594,10 @@ func TestProcessSaveCacheState_WholeHashFallsThrough(t *testing.T) {
 
 	s.processSaveCacheState()
 
-	if es.lastCallFeature != "cache" || es.lastCallMethod != "save" {
-		t.Errorf("expected cache save call for whole-hash key (phase 3 not implemented), got %s.%s", es.lastCallFeature, es.lastCallMethod)
+	if es.lastCallFeature == "cache" {
+		t.Errorf("should not call cache for whole-hash save, got %s.%s", es.lastCallFeature, es.lastCallMethod)
+	}
+	if es.GetCache().Get("myhash#") != nil {
+		t.Error("should not write to memcache for whole-hash save")
 	}
 }


### PR DESCRIPTION
## Summary

Phase 3 of the Redis hashes caching feature. Adds whole-hash (`name#`) read-only caching to `pkg/workflow/cache.go`.

- `name#` (trailing `#`) cache keys now read the **entire** Redis hash directly via the cache feature's `hgetall` RPC and aggregate the decoded field values into `cache-data` (`field -> decoded value`), mirroring the shape produced by the normal/hash-field paths.
- The whole-hash path **skips the memcache entirely** (does not call `GetCache`).
- The whole-hash path is **strictly read-only**: `processSaveCacheState` returns early for `name#` keys so no memcache `Set` or Redis `save`/`hset` write ever occurs — even on the force-refresh / empty-hash run path.
- Empty `hashName` (key `"#"`) is handled gracefully (treated as a miss, no `hgetall` call).
- `force-cache-refresh` already short-circuits at the top of `processCheckCacheState`, so whole-hash (and all modes) run fresh without cache-data when force is set.

### Purely additive (verified against `v4`)

The non-`#` (normal) path and the `name#field` hash-field path are **unchanged** — confirmed via `git diff v4`:
- `cacheKeyModeHashField` case: identical `hget`/`json.Unmarshal` logic.
- `default` (normal) case: identical `cache` `load` with `key = "workflow-cache/" + CacheKey`.
- Common success path (`cache-data` set, `LabelFromCache=true`, `status=success`, `cache-data*` export): identical.
- Only additive changes: new `decodeCacheField`/`loadWholeHashCache` helpers, moving the pure `parseCacheKey` call earlier, guarding the memcache lookup with `if mode != cacheKeyModeWholeHash`, and the new `case cacheKeyModeWholeHash` in the read path + read-only guard in the save path.

### Transport note

`store.Call` returns raw `[]byte` (the daemon reads driver replies via `FetchRawMessage`, preserving bytes — that's why `load` works today with `resp.([]byte)`). So `hgetall`'s JSON payload is unmarshaled in `pkg/workflow` into `map[string]any` (field -> value string), then each value is JSON-decoded. The merged Phase 1 `hgetall` handler returns exactly this shape.

### Tests

- `TestProcessCheckCacheState_WholeHashHit` — aggregation correct; stale memcache entry ignored (proves memcache not read).
- `TestProcessCheckCacheState_WholeHashNoData` — empty/nil `hgetall` → no cache-data, workflow runs.
- `TestProcessCheckCacheState_WholeHashForceRefresh` — force-refresh → no cache-data even when data exists.
- `TestProcessCheckCacheState_WholeHashEmptyName` — `"#"` → no `hgetall` call, no cache-data.
- `TestProcessSaveCacheState_WholeHashNoWrite` — no memcache `Set`, no `cache` `save`/`hset`.
- Existing normal-key and `name#field` hash-field regression tests retained (and the obsolete pre-Phase-3 "falls through" tests replaced).

`go test ./...` passes; `golangci-lint run ./pkg/workflow/...` is clean for `cache.go`/`cache_test.go` (only pre-existing unrelated `govet` `slices.Contains` items remain on `v4`).