### PR TITLE
docs(workflow): document redis-hash cache-key syntax and redis-cache per_field_expiration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,6 +169,46 @@ drivers:
         ...
 ```
 
+### redis-cache
+
+The `redis-cache` driver provides the `cache` feature used by workflow data
+caching (see [Caching](./workflow.md#caching)). It stores cache entries in
+Redis and supports both plain keys and Redis hashes (the `#` cache-key syntax
+documented in the workflow guide).
+
+#### Configuration
+
+ - `data.per_field_expiration` *(boolean, default `false`)* &mdash; Controls how TTLs
+   are applied to Redis hashes written by the `hset` RPC (used for `name#field`
+   cache keys).
+
+    - When `true`, each hash field gets its **own** expiration via Redis
+      `HEXPIRE`. This requires **Redis >= 7.4** (per-field expiration was
+      introduced in Redis 7.4); expired fields are removed automatically by
+      Redis.
+    - When `false` (the default), per-field `HEXPIRE` is **not** used.
+      Instead the whole hash key receives a single shared TTL via `EXPIRE`,
+      which is compatible with **Redis versions older than 7.4**.
+
+   Plain (non-`#`) cache keys are always stored as whole keys and are unaffected
+   by this option.
+
+#### RPCs
+
+The driver exposes the following RPCs, called internally by the workflow
+caching engine through the `cache` feature:
+
+ - `load` / `save` &mdash; read/write a whole plain cache key (the legacy, non-`#`
+   path).
+ - `hget` &mdash; `HGET key field`; returns the raw value of a single hash field (or
+   empty on a miss).
+ - `hgetall` &mdash; `HGETALL key`; returns a `map[string]any` of `field -> value`
+   for the entire hash (or empty on a miss). Used by the `name#` whole-hash
+   read-only cache path.
+ - `hset` &mdash; write one or more hash fields with a TTL, applying per-field
+   `HEXPIRE` or whole-hash `EXPIRE` according to the `per_field_expiration`
+   option (used by the `name#field` cache path).
+
 ## Systems
 
 As defined, systems are a group of triggers and actions and some data that can be re-used.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -242,6 +242,40 @@ workflows:
       - call_workflow: notify_cached_result
 ```
 
+#### Hash-based cache keys (Redis)
+
+When the `cache` feature is backed by the `redis-cache` driver, the
+`cache_key` accepts a `#` syntax for storing and reading entries inside a
+single Redis hash. This is handy when several workflows need to share one
+logical cache object whose fields are populated independently.
+
+The caching mode is selected by the presence and position of `#` in the key:
+
+ - **Normal key** (for example `myapp:data:{{ .ctx.key }}` &mdash; no `#`): behaves
+   exactly as described above. The entry is stored and read as a single value
+   via the `cache` `save`/`load` RPCs, and is additionally held in the
+   in-memory memcache. *This mode is unchanged by the hash feature.*
+
+ - **Single hash field** (`name#field`): caches only the field `field` within
+   the Redis hash `name` as an independent, TTL'd entry. It is written via the
+   `cache` `hset` RPC and read via `hget`. Each field carries its own TTL
+   (controlled by the driver's `per_field_expiration` option &mdash; see
+   [Redis cache driver](./configuration.md#redis-cache)). Use this when several
+   workflows contribute different pieces of data to one shared cache object.
+
+ - **Whole hash** (`name#` &mdash; a trailing `#` with an empty field): reads the
+   **entire** Redis hash `name` into `cache-data` as a map of
+   `field -> decoded value`. It is a **read-only aggregate view**: it is read
+   directly from Redis via the `cache` `hgetall` RPC, it does **not** consult
+   or populate the in-memory memcache, and it **never writes back** to Redis or
+   the memcache &mdash; even when `force-cache-refresh` is set or the hash is
+   empty. This makes it ideal for reading a shared cache object that other
+   workflows populate through `name#field` keys.
+
+In every `#` mode the underlying Redis key is `workflow-cache/<name>`, and
+field values are JSON-encoded, so `cache-data` has the same shape regardless of
+which mode populated it.
+
 ### Iterations
 Any of the actions can be combined with an `iterate` or `iterate_parallel` field to be executed multiple times with different values from a list. The current element of the list will be stored in a local contextual data item named `current`. Optionally, you can also customize the name of contextual data item using `iterate_as`. The elements of the lists to be iterated don't have to be simple strings, it can be a map or other complex data structures.
 

--- a/drivers/cmd/redis-cache/functions.yaml
+++ b/drivers/cmd/redis-cache/functions.yaml
@@ -1,0 +1,70 @@
+# Driver metadata for the redis-cache driver.
+#
+# The redis-cache driver provides the `cache` feature consumed by the
+# workflow engine for workflow data caching (including the `#` hash-key
+# syntax documented in docs/workflow.md). This file documents the driver's
+# configuration options and the RPCs it exposes through the `cache` feature.
+meta:
+  description:
+    - The redis-cache driver uses Redis as an external, temporary cache store.
+      It backs the `cache` feature used for workflow data caching, including
+      plain keys and Redis hashes (the `#` cache-key syntax).
+  configurations:
+    - name: per_field_expiration
+      description: >
+        Boolean. When true, each field of a Redis hash written by the `hset`
+        RPC is given its own expiration via Redis HEXPIRE, which requires
+        Redis >= 7.4. When false (the default), the whole hash key receives a
+        single shared TTL via EXPIRE, which is compatible with Redis versions
+        older than 7.4. Plain (non-#) cache keys are always stored as whole
+        keys and are unaffected by this option.
+  RPCs:
+    - name: load
+      description:
+        - Read a whole plain cache key (the legacy, non-# path).
+      parameters:
+        - name: key
+          description: The cache key.
+      returns:
+        - name: value
+          description: The raw cached value (empty on a miss).
+    - name: save
+      description:
+        - Write a whole plain cache key (the legacy, non-# path).
+      parameters:
+        - name: key
+          description: The cache key.
+        - name: value
+          description: The value to store.
+        - name: ttl
+          description: Optional TTL (duration string or seconds).
+    - name: hget
+      description:
+        - HGET key field. Returns the raw value of a single hash field, or an empty payload on a miss. Used by the name#field cache path.
+      parameters:
+        - name: key
+          description: The Redis hash key (workflow-cache/<name>).
+        - name: field
+          description: The hash field to read.
+      returns:
+        - name: value
+          description: The raw field value (empty on a miss).
+    - name: hgetall
+      description:
+        - HGETALL key. Returns a map of field -> value for the entire hash, or an empty payload on a miss. Used by the name# whole-hash read-only cache path.
+      parameters:
+        - name: key
+          description: The Redis hash key (workflow-cache/<name>).
+      returns:
+        - name: fields
+          description: A map[string]any of field -> value for the whole hash.
+    - name: hset
+      description:
+        - Write one or more hash fields with a TTL, applying per-field HEXPIRE or whole-hash EXPIRE according to the per_field_expiration option. Used by the name#field cache path.
+      parameters:
+        - name: key
+          description: The Redis hash key (workflow-cache/<name>).
+        - name: value
+          description: A map of field -> value to write.
+        - name: ttl
+          description: Optional TTL (duration string or seconds).


### PR DESCRIPTION
## Summary

Phase 4 (documentation only) of the Redis hashes workflow-caching feature. Records the `#` cache-key syntax and the `redis-cache` driver's `per_field_expiration` option so users understand the new behavior. No feature/behavior change.

### `docs/workflow.md` — new "Hash-based cache keys (Redis)" subsection under `### Caching`
Documents how the `cache_key` `#` syntax selects the caching mode:
- **Normal key** (no `#`): unchanged legacy behavior (`save`/`load` RPCs + memcache).
- **`name#field`**: caches a single hash field as an independent, TTL'd entry (`hset`/`hget`); each field's TTL follows the driver's `per_field_expiration` toggle.
- **`name#`** (trailing `#`): reads the **entire** hash `name` into `cache-data` as `field -> decoded value`. It is a **read-only aggregate view** — reads directly via `hgetall`, does **not** use the memcache, and **never writes back** to Redis or memcache (even on `force-cache-refresh` or empty hash).
- Notes the underlying Redis key is `workflow-cache/<name>` and field values are JSON-encoded, so `cache-data` shape is consistent across modes.

### `docs/configuration.md` — new `### redis-cache` subsection under `## Drivers`
- Documents `data.per_field_expiration` **(boolean, default `false`)**:
  - `true` → per-field `HEXPIRE` (requires **Redis >= 7.4**); expired fields auto-removed by Redis.
  - `false` (default) → whole-hash `EXPIRE` (compatible with **Redis < 7.4**).
  - Plain (non-`#`) keys are unaffected.
- Lists the cache-feature RPCs: `load`/`save`, `hget`, `hgetall`, `hset`.

### `drivers/cmd/redis-cache/functions.yaml` (new)
Canonical driver metadata documenting the `per_field_expiration` configuration and the `load`/`save`/`hget`/`hgetall`/`hset` RPCs (follows the repo's `DipperCL` `meta`/`RPCs`/`configurations` convention from `docs/documenting.md`).

### Verification
- `go build ./...` passes.
- `golangci-lint run ./...` shows only pre-existing baseline issues (in `pkg/dipper/mapUtils.go`, `pkg/dipper/driver.go`, `pkg/workflow/session_init.go`); none are in the touched files (only `.md`/`.yaml` changed).
- `functions.yaml` validated with `yq` (parses; RPCs + config enumerated).
- Cross-links between `docs/workflow.md` and `docs/configuration.md` use the correct `#redis-cache` / `#caching` anchors.

Docs-only; the feature remains purely additive as implemented in PRs #802–#804.