### PR TITLE
feat(agent): Phase 1 — pin conversation recovery contract + regression test

### DIFF
--- a/docs/conversation-recovery-contract.md
+++ b/docs/conversation-recovery-contract.md
@@ -1,0 +1,97 @@
+# Conversation Recovery Contract (Phase 1 — research, pin, regression)
+
+This document is the Phase 1 deliverable for recovering an agent conversation
+whose `convo_state:<id>` Redis key has been reclaimed (TTL/eviction). It records
+every call site of `StartTurn`, `StartInference`, and `StartNewConvo` across the
+daemon (`honeydipper/honeydipper`, branch `v4`) and the UI (`Charles546/hd-ui`,
+branch `main`), pins the recovery contract, and points at the regression test
+that encodes today's broken behavior.
+
+> Phase 1 only researches, pins the contract, and adds a regression test. No
+> recovery logic is implemented here. Phases 2, 3, and 5 implement the fix.
+
+## Background
+
+When a conversation sits idle long enough, its `convo_state:<id>` key is
+reclaimed. Reopening it hits `StartTurn` (`internal/agent/agent_store.go`), which
+resolves the agent name from `ConvoState.LastSession`/`FirstSession`. When both
+are empty it logs `cannot determine agent name for convo ...` and returns
+silently. The API handler `handleConvoTurnAPI` (`internal/service/agent_apis.go`)
+still returns `{"ok":true}`, so the UI sees a false success: no turn starts, no
+message is appended to `convo_history`, and `ConvoState.ActiveSession` is never
+set.
+
+## Call-site map — daemon (`honeydipper/honeydipper`, `v4`)
+
+### `StartTurn(convoID, text, user, engine, driver string)`
+- **Definition / interface**: `internal/agent/agent_store.go:28` (interface `AgentStore`), impl `internal/agent/agent_store.go:237`.
+- **Primary revive path (UI turn API)**: `internal/service/agent_apis.go:141` — `handleConvoTurnAPI` calls `agentStore.StartTurn(convoID, body.Text, user, body.Engine, body.Driver)`.
+- **Route**: `POST /convos/:convoID/turn` registered in `internal/api/def.go:70` as `Name: "convoTurn"` (`AttachPrincipalUser: true`, `Service: "agent"`).
+
+### `StartInference(msg *dipper.Message)`
+- **Definition / interface**: `internal/agent/agent_store.go:18` (interface), impl `internal/agent/agent_store.go:102`.
+- **Call site**: `internal/service/agent_svc.go:132` — `handleAgentStart` (responder for `eventbus:agent_start`) calls `go agentStore.StartInference(msg)`. The agent name rides in `msg.Labels["agent_name"]` (set by `initNewSession`).
+- **Route / trigger**: registered responder `eventbus:agent_start` in `internal/service/agent_svc.go` (`StartAgent`). This is the workflow/orchestrated inference path, not the UI turn path.
+
+### `StartNewConvo(agentName, text, user, engine, driver string) string`
+- **Definition / interface**: `internal/agent/agent_store.go:32` (interface), impl `internal/agent/agent_store.go:272`.
+- **Call site**: `internal/service/agent_apis.go:164` — `handleConvoNewAPI` calls `agentStore.StartNewConvo(body.Agent, body.Text, user, body.Engine, body.Driver)` and returns the generated `convo_id` synchronously.
+- **Route**: `POST /convos` registered in `internal/api/def.go:53` as `Name: "convoNew"` (`AttachPrincipalUser: true`, `Service: "agent"`). Already agent-driven; Phase 2 reuses its `ConvoState` construction for recovery.
+
+## Call-site map — UI (`Charles546/hd-ui`, `main`)
+
+### Client functions in `src/api.js`
+- `startTurn(creds, convoID, text, engine, driver)` → `POST /convos/:convoID/turn` (daemon `convoTurn` API). `src/api.js:313`.
+- `startNewConvo(creds, agentName, text, engine, driver)` → `POST /convos` (daemon `convoNew` API). `src/api.js:322`.
+
+### Callers of those client functions
+- `src/components/ConvoHistoryPage.jsx:394` — `handleSendTurn` calls `startTurn(creds, convoId, text, finalEngine, finalDriver)` (turn on an open conversation).
+- `src/components/ConversationsPage.jsx:657` — calls `startTurn(creds, selectedID, text, finalEngine, finalDriver)` (turn on an existing conversation).
+- `src/components/ConversationsPage.jsx:671` — calls `startNewConvo(creds, agent, text, engine, driver)` (brand-new conversation).
+- `src/components/NewConvoInput.jsx` — `handleSubmit` invokes `onSend(selectedAgent, trimmed, engine, driver)`; the parent (`ConversationsPage`) wires `onSend` to a handler that calls `startNewConvo`.
+- Tests: `src/components/ConvoHistoryPage.test.jsx`, `src/api.test.js` mock `startTurn`/`startNewConvo`.
+
+## Recovery contract
+
+### Request — `POST /convos/:convoID/turn`
+Body gains two optional fields (scaffolded in `handleConvoTurnAPI`, not yet
+consulted):
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `agent` | string | `""` | Agent to use when recreating a reclaimed conversation. |
+| `agent_override` | bool | `false` | When `true`, allow `StartTurn` to recreate/overwrite the `ConvoState` even when one is present. When `false`, `StartTurn` must stick to the existing `ConvoState` and never overwrite it. |
+
+### Response
+- **Success** → `{"ok":true}` (unchanged).
+- **Unrecoverable** (cs missing and no agent supplied) → HTTP `409` with body
+  `{"ok":false,"error":"conversation_expired","message":"select an agent to continue"}`
+  (the `ConversationExpiredResponse` const in `internal/service/agent_apis.go`).
+
+### Truth table (recorded for Phase 2; NOT implemented in Phase 1)
+
+| cs present? | agent supplied? | agent_override | behavior |
+|---|---|---|---|
+| no | no | n/a | `409 conversation_expired` (UI prompts for agent) |
+| no | yes | false | recreate cs with supplied agent (nothing to stick to) |
+| no | yes | true | recreate cs with supplied agent |
+| yes | no | n/a | use existing cs (normal turn) |
+| yes | yes | false (stick) | use existing cs; do not overwrite |
+| yes | yes | true (override) | recreate/overwrite cs with supplied agent |
+
+## Regression test (Phase 1)
+
+- `internal/agent/agent_store_test.go::TestStartTurn_ConvoStateEvicted_RegressesToSilentNoOp`
+  seeds a conversation, evicts `convo_state:<id>` via `cache:del`, drives
+  `StartTurn`, and asserts all four symptoms of the broken behavior:
+  1. the `cannot determine agent name for convo <id>` log line is emitted;
+  2. `convo_state:<id>` is NOT recreated (no `cache:save`);
+  3. `convo_history:<id>` is NOT appended;
+  4. no message is emitted to the AI driver / `agent_response`.
+- `internal/service/agent_apis_test.go::TestHandleConvoTurnAPI_EvictedConvoReturnsOkTrue`
+  drives the broken path through `handleConvoTurnAPI` and asserts the
+  false-success `{"ok":true}` response, and that the convo state is not
+  recreated afterward.
+
+Both tests encode today's defect and are expected to be **inverted** by Phase 2's
+recovery fix.

--- a/internal/agent/agent_store_test.go
+++ b/internal/agent/agent_store_test.go
@@ -1,0 +1,292 @@
+// Copyright 2026 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package agent
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+	"github.com/op/go-logging"
+	"github.com/stretchr/testify/require"
+)
+
+// memCacheHelper is an in-process stand-in for the Redis-backed cache/locker
+// drivers. It is intentionally minimal: it only needs to faithfully model the
+// convo_state:<id> / convo_history:<id> keys and the lock operations that
+// PersistentAgentStore touches, so a test can deterministically create a
+// conversation, evict it, and observe the broken revive behavior.
+type memCacheHelper struct {
+	mu      sync.Mutex
+	cache   map[string]string
+	emitted []*dipper.Message
+	calls   []string
+	cfg     *config.Config
+}
+
+func newMemCacheHelper() *memCacheHelper {
+	return &memCacheHelper{
+		cache: map[string]string{},
+		cfg:   &config.Config{DataSet: &config.DataSet{Agents: map[string]config.Agent{}}},
+	}
+}
+
+func (h *memCacheHelper) record(call string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.calls = append(h.calls, call)
+}
+
+// Call implements dipper.RPCCaller for the subset of cache/locker methods the
+// agent store uses. Unknown methods return an empty JSON array so callers that
+// expect a slice are not surprised.
+func (h *memCacheHelper) Call(feature, method string, params interface{}, labelsKV ...string) ([]byte, error) {
+	key := feature + ":" + method
+	h.record(key)
+	p, _ := params.(map[string]interface{})
+	switch key {
+	case "cache:load":
+		k := p["key"].(string)
+		h.mu.Lock()
+		v, ok := h.cache[k]
+		h.mu.Unlock()
+		if !ok {
+			return []byte{}, nil
+		}
+
+		return []byte(v), nil
+	case "cache:save":
+		k := p["key"].(string)
+		v := p["value"].(string)
+		h.mu.Lock()
+		h.cache[k] = v
+		h.mu.Unlock()
+
+		return []byte("OK"), nil
+	case "cache:del":
+		k := p["key"].(string)
+		h.mu.Lock()
+		delete(h.cache, k)
+		h.mu.Unlock()
+
+		return []byte("1"), nil
+	case "cache:lrange":
+		k := p["key"].(string)
+		h.mu.Lock()
+		v, ok := h.cache[k]
+		h.mu.Unlock()
+		if !ok || v == "" {
+			return []byte("[]"), nil
+		}
+
+		return []byte(v), nil
+	case "cache:rpush":
+		k := p["key"].(string)
+		v := p["value"].(string)
+		h.mu.Lock()
+		if cur, ok := h.cache[k]; ok && cur != "" && cur != "[]" {
+			h.cache[k] = cur[:len(cur)-1] + "," + v + "]"
+		} else {
+			h.cache[k] = "[" + v + "]"
+		}
+		h.mu.Unlock()
+
+		return []byte("1"), nil
+	case "cache:ltrim", "cache:stream_hset":
+		return []byte("OK"), nil
+	case "locker:lock", "locker:unlock":
+		return []byte(""), nil
+	}
+
+	return []byte("[]"), nil
+}
+
+func (h *memCacheHelper) CallNoWait(feature, method string, params interface{}, labelsKV ...string) error {
+	h.record(feature + ":" + method)
+
+	return nil
+}
+
+func (h *memCacheHelper) CallRaw(feature, method string, params []byte, labelsKV ...string) ([]byte, error) {
+	return h.Call(feature, method, nil, labelsKV...)
+}
+
+func (h *memCacheHelper) CallRawNoWait(feature, method string, params []byte, rpcID string, labelsKV ...string) error {
+	h.record(feature + ":" + method)
+
+	return nil
+}
+
+func (h *memCacheHelper) GetName() string { return "mem-cache-helper" }
+
+func (h *memCacheHelper) GetConfig() *config.Config { return h.cfg }
+
+func (h *memCacheHelper) EmitMessage(msg dipper.Message) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.emitted = append(h.emitted, &msg)
+}
+
+func (h *memCacheHelper) getCache(key string) (string, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	v, ok := h.cache[key]
+
+	return v, ok
+}
+
+func (h *memCacheHelper) callCount(call string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n := 0
+	for _, c := range h.calls {
+		if c == call {
+			n++
+		}
+	}
+
+	return n
+}
+
+func (h *memCacheHelper) getEmitted() []*dipper.Message {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return append([]*dipper.Message(nil), h.emitted...)
+}
+
+// newCaptureLogger returns a logger that writes only ERROR (and above) records
+// as plain messages into buf. It is used to assert that a broken code path
+// emitted the expected error log line.
+func newCaptureLogger(buf *bytes.Buffer) *logging.Logger {
+	backend := logging.NewLogBackend(buf, "", 0)
+	format := logging.MustStringFormatter("%{message}")
+	formatted := logging.NewBackendFormatter(backend, format)
+	leveled := logging.AddModuleLevel(formatted)
+	leveled.SetLevel(logging.ERROR, "")
+	leveled.SetLevel(logging.ERROR, "agent-recovery-test")
+	logger := logging.MustGetLogger("agent-recovery-test")
+	logger.SetBackend(leveled)
+
+	return logger
+}
+
+// TestStartTurn_ConvoStateEvicted_RegressesToSilentNoOp is a PHASE-1 regression
+// test. It encodes TODAY'S BROKEN behavior so that Phase 2's recovery fix flips
+// it. When a conversation's convo_state:<id> key has been reclaimed by Redis
+// (TTL/eviction) and no agent is supplied, StartTurn cannot resolve an agent
+// name, logs "cannot determine agent name for convo <id>", returns silently,
+// and the API handler still answers {"ok":true}. No turn starts, no history is
+// appended, and ConvoState.ActiveSession is never set.
+func TestStartTurn_ConvoStateEvicted_RegressesToSilentNoOp(t *testing.T) {
+	helper := newMemCacheHelper()
+	convoID := "evicted-convo-1"
+
+	// (a) Seed an existing conversation so a convo_state:<id> exists.
+	seeded := &ConvoState{
+		ConvoID: convoID,
+		FirstSession: &ConvoSessionRef{
+			SessionID: "sess-prev",
+			AgentName: "test_agent",
+			Type:      AgentSessionTypeChatTurn,
+			Status:    ConvoSessionStatusComplete,
+		},
+		LastSession: &ConvoSessionRef{
+			SessionID: "sess-prev",
+			AgentName: "test_agent",
+			Type:      AgentSessionTypeChatTurn,
+			Status:    ConvoSessionStatusComplete,
+		},
+	}
+	helper.cache[ConvoStateKeyPrefix+convoID] = string(dipper.SerializeContent(seeded))
+
+	// Sanity: the seeded state is present before eviction.
+	if _, ok := helper.getCache(ConvoStateKeyPrefix + convoID); !ok {
+		t.Fatalf("test setup failed: seeded convo_state missing")
+	}
+
+	// (b) Evict the convo_state:<id> key to simulate Redis reclaim/TTL.
+	if _, err := helper.Call("cache", "del", map[string]interface{}{
+		"key": ConvoStateKeyPrefix + convoID,
+	}); err != nil {
+		t.Fatalf("eviction del failed: %v", err)
+	}
+	if _, ok := helper.getCache(ConvoStateKeyPrefix + convoID); ok {
+		t.Fatalf("eviction did not remove convo_state")
+	}
+
+	var logBuf bytes.Buffer
+	store := &PersistentAgentStore{
+		StoreHelper: helper,
+		Logger:      newCaptureLogger(&logBuf),
+	}
+
+	savesBefore := helper.callCount("cache:save")
+
+	// (c) Drive the broken revive path.
+	store.StartTurn(convoID, "are you still there?", "user1", "", "")
+	store.Wait()
+
+	// Assertion 1: the unresolvable-agent branch was hit.
+	logOut := logBuf.String()
+	require.Contains(t, logOut, "cannot determine agent name for convo "+convoID,
+		"expected StartTurn to hit the unresolvable-agent branch")
+
+	// Assertion 2: ConvoState was NOT recreated (no new convo_state persisted).
+	_, recreated := helper.getCache(ConvoStateKeyPrefix + convoID)
+	require.False(t, recreated, "broken behavior must NOT recreate convo_state")
+	require.Equal(t, savesBefore, helper.callCount("cache:save"),
+		"broken behavior must not persist a new convo_state")
+
+	// Assertion 3: no history appended to convo_history:<id>.
+	hist, _ := helper.getCache(ConvoHistoryKeyPrefix + convoID)
+	require.Empty(t, hist, "broken behavior must not append to convo_history")
+
+	// Assertion 4: no model/AI driver call nor agent_response emitted (no turn).
+	require.Empty(t, helper.getEmitted(), "broken behavior must not emit any message")
+}
+
+// TestStartTurn_ConvoStatePresent_UsesExistingAgent is the happy-path companion
+// that documents the NORMAL behavior the evicted case diverges from. With a live
+// ConvoState the agent name resolves and StartTurn proceeds past the guard (it
+// only fails afterward because this test provides no real AI driver). It exists
+// to make the eviction regression test's intent unambiguous.
+func TestStartTurn_ConvoStatePresent_UsesExistingAgent(t *testing.T) {
+	helper := newMemCacheHelper()
+	convoID := "live-convo-1"
+
+	seeded := &ConvoState{
+		ConvoID: convoID,
+		LastSession: &ConvoSessionRef{
+			SessionID: "sess-live",
+			AgentName: "test_agent",
+			Type:      AgentSessionTypeChatTurn,
+			Status:    ConvoSessionStatusComplete,
+		},
+	}
+	helper.cache[ConvoStateKeyPrefix+convoID] = string(dipper.SerializeContent(seeded))
+
+	var logBuf bytes.Buffer
+	store := &PersistentAgentStore{
+		StoreHelper: helper,
+		Logger:      newCaptureLogger(&logBuf),
+	}
+
+	// With a present ConvoState the guard is NOT triggered: StartTurn proceeds
+	// to runTurn, which eventually fails for lack of a real AI driver (not the
+	// "cannot determine agent name" log). We only assert the guard log is absent.
+	store.StartTurn(convoID, "hi", "user1", "", "")
+	store.Wait()
+
+	require.NotContains(t, logBuf.String(), "cannot determine agent name for convo "+convoID,
+		"present convo_state must resolve an agent and skip the guard")
+}

--- a/internal/service/agent_apis.go
+++ b/internal/service/agent_apis.go
@@ -21,6 +21,13 @@ import (
 // errConvoNotFound is returned when a conversation is not found.
 var errConvoNotFound = errors.New("conversation not found")
 
+// ConversationExpiredResponse is the JSON body returned (HTTP 409) when a
+// conversation's ConvoState has been reclaimed by Redis and no agent was
+// supplied to recreate it. It is declared as NON-FUNCTIONAL scaffolding so the
+// recovery contract lives in code; handleConvoTurnAPI does NOT consult it yet.
+// Phase 2 will surface it to the UI so the user can pick an agent to continue.
+const ConversationExpiredResponse = `{"ok":false,"error":"conversation_expired","message":"select an agent to continue"}`
+
 func setupAgentAPIs() {
 	agentSvc.APIs["convoList"] = handleConvoList
 	agentSvc.APIs["convoState"] = handleConvoState
@@ -123,6 +130,27 @@ func handleConvoCancelAPI(resp *api.Response) {
 // handleConvoTurnAPI starts a new chat turn on an existing conversation from the UI.
 // Expects convoID path param plus text (and optional user, engine, driver) in the
 // request body. The turn runs asynchronously; the API returns immediately with {"ok":true}.
+//
+// Recovery contract (see docs/conversation-recovery-contract.md). The request body
+// below may additionally carry:
+//   - agent (string, optional): the agent to use when recreating a reclaimed conversation.
+//   - agent_override (bool, optional, default false): when true, allow StartTurn to
+//     recreate/overwrite the ConvoState even when one is present; when false, StartTurn
+//     must stick to the existing ConvoState and never overwrite it.
+//
+// Truth table (implemented in Phase 2):
+//
+//	cs present | agent supplied | agent_override | behavior
+//	no         | no             | n/a            | 409 conversation_expired (UI prompts for agent)
+//	no         | yes            | false          | recreate cs with supplied agent (nothing to stick to)
+//	no         | yes            | true           | recreate cs with supplied agent
+//	yes        | no             | n/a            | use existing cs (normal turn)
+//	yes        | yes            | false (stick)  | use existing cs; do not overwrite
+//	yes        | yes            | true (override)| recreate/overwrite cs with supplied agent
+//
+// Today (pre-Phase-2) the handler always returns {"ok":true} and never surfaces a
+// reclaimed convo; the regression tests in internal/agent/agent_store_test.go and
+// internal/service/agent_apis_test.go pin that broken behavior.
 func handleConvoTurnAPI(resp *api.Response) {
 	resp.Request = dipper.DeserializePayload(resp.Request)
 	convoID := dipper.MustGetMapDataStr(resp.Request.Payload, "convoID")
@@ -132,6 +160,10 @@ func handleConvoTurnAPI(resp *api.Response) {
 		Text   string `json:"text"`
 		Engine string `json:"engine"`
 		Driver string `json:"driver"`
+		// Agent and AgentOverride are recovery-contract scaffolding (Phase 2). They
+		// are parsed here but not yet consulted by the handler.
+		Agent         string `json:"agent"`
+		AgentOverride bool   `json:"agent_override"`
 	}
 	if bodyStr, ok := dipper.GetMapDataStr(resp.Request.Payload, "body"); ok && bodyStr != "" {
 		_ = json.Unmarshal([]byte(bodyStr), &body)

--- a/internal/service/agent_apis_test.go
+++ b/internal/service/agent_apis_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package service
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/honeydipper/honeydipper/v4/internal/agent"
+	"github.com/honeydipper/honeydipper/v4/internal/api"
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+	"github.com/stretchr/testify/require"
+)
+
+// recoveryMemHelper is an in-process stand-in for the Redis-backed cache/locker
+// drivers, mirroring the helper used by the agent-package regression test. It
+// is enough to seed a conversation, evict it, and observe handleConvoTurnAPI.
+type recoveryMemHelper struct {
+	mu      sync.Mutex
+	cache   map[string]string
+	emitted []*dipper.Message
+	cfg     *config.Config
+}
+
+func newRecoveryMemHelper() *recoveryMemHelper {
+	return &recoveryMemHelper{
+		cache: map[string]string{},
+		cfg:   &config.Config{DataSet: &config.DataSet{Agents: map[string]config.Agent{}}},
+	}
+}
+
+func (h *recoveryMemHelper) Call(feature, method string, params interface{}, labelsKV ...string) ([]byte, error) {
+	p, _ := params.(map[string]interface{})
+	switch feature + ":" + method {
+	case "cache:load":
+		k := p["key"].(string)
+		h.mu.Lock()
+		v, ok := h.cache[k]
+		h.mu.Unlock()
+		if !ok {
+			return []byte{}, nil
+		}
+
+		return []byte(v), nil
+	case "cache:save":
+		k := p["key"].(string)
+		v := p["value"].(string)
+		h.mu.Lock()
+		h.cache[k] = v
+		h.mu.Unlock()
+
+		return []byte("OK"), nil
+	case "cache:del":
+		k := p["key"].(string)
+		h.mu.Lock()
+		delete(h.cache, k)
+		h.mu.Unlock()
+
+		return []byte("1"), nil
+	case "cache:lrange":
+		k := p["key"].(string)
+		h.mu.Lock()
+		v, ok := h.cache[k]
+		h.mu.Unlock()
+		if !ok || v == "" {
+			return []byte("[]"), nil
+		}
+
+		return []byte(v), nil
+	case "locker:lock", "locker:unlock":
+		return []byte(""), nil
+	}
+
+	return []byte("[]"), nil
+}
+
+func (h *recoveryMemHelper) CallNoWait(feature, method string, params interface{}, labelsKV ...string) error {
+	return nil
+}
+
+func (h *recoveryMemHelper) CallRaw(feature, method string, params []byte, labelsKV ...string) ([]byte, error) {
+	return h.Call(feature, method, nil, labelsKV...)
+}
+
+func (h *recoveryMemHelper) CallRawNoWait(feature, method string, params []byte, rpcID string, labelsKV ...string) error {
+	return nil
+}
+
+func (h *recoveryMemHelper) GetName() string { return "recovery-mem-helper" }
+
+func (h *recoveryMemHelper) GetConfig() *config.Config { return h.cfg }
+
+func (h *recoveryMemHelper) EmitMessage(msg dipper.Message) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.emitted = append(h.emitted, &msg)
+}
+
+func (h *recoveryMemHelper) hasCache(key string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	_, ok := h.cache[key]
+
+	return ok
+}
+
+// captureReceiver records the single message sent through the response.
+type captureReceiver struct {
+	mu       sync.Mutex
+	captured *dipper.Message
+}
+
+func (c *captureReceiver) SendMessage(m *dipper.Message) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.captured = m
+}
+
+// TestHandleConvoTurnAPI_EvictedConvoReturnsOkTrue is a PHASE-1 regression
+// test. It encodes TODAY'S BROKEN behavior: when convo_state:<id> has been
+// reclaimed by Redis and no agent is supplied, handleConvoTurnAPI still returns
+// {"ok":true} (a false success) instead of surfacing the failure. Phase 2 will
+// change this to a 409 conversation_expired so the UI can prompt for an agent.
+func TestHandleConvoTurnAPI_EvictedConvoReturnsOkTrue(t *testing.T) {
+	helper := newRecoveryMemHelper()
+	convoID := "evicted-convo-svc-1"
+
+	// (a) Seed an existing conversation, then (b) evict it.
+	seeded := map[string]interface{}{
+		"convo_id":     convoID,
+		"last_session": map[string]interface{}{"agent_name": "test_agent", "type": "chat_turn"},
+	}
+	seededBytes, err := json.Marshal(seeded)
+	require.NoError(t, err)
+	helper.cache[agent.ConvoStateKeyPrefix+convoID] = string(seededBytes)
+	if _, err := helper.Call("cache", "del", map[string]interface{}{
+		"key": agent.ConvoStateKeyPrefix + convoID,
+	}); err != nil {
+		t.Fatalf("eviction del failed: %v", err)
+	}
+	if ok := helper.hasCache(agent.ConvoStateKeyPrefix + convoID); ok {
+		t.Fatalf("eviction did not remove convo_state")
+	}
+
+	realStore := agent.NewAgentStore(helper, "")
+	prev := agentStore
+	agentStore = realStore
+	defer func() { agentStore = prev }()
+
+	receiver := &captureReceiver{}
+	resp := &api.Response{
+		EventBus: receiver,
+		Request: &dipper.Message{
+			Labels: map[string]string{"user": "u", "user_provider": "p"},
+			Payload: map[string]interface{}{
+				"convoID": convoID,
+				"body":    `{"text":"hi"}`,
+			},
+		},
+		Factrory: api.NewResponseFactory(),
+	}
+	// Return() calls Factrory.Live.Done(); balance it to avoid a panic.
+	resp.Factrory.Live.Add(1)
+
+	// (c) Drive the broken revive path through the real API handler.
+	handleConvoTurnAPI(resp)
+
+	receiver.mu.Lock()
+	captured := receiver.captured
+	receiver.mu.Unlock()
+	require.NotNil(t, captured, "expected handleConvoTurnAPI to return a result")
+
+	payload, ok := captured.Payload.([]byte)
+	require.True(t, ok, "expected raw byte payload")
+	require.JSONEq(t, `{"ok":true}`, string(payload),
+		"broken behavior returns false-success {\"ok\":true}")
+
+	// After the goroutine completes, the convo_state must remain absent (no
+	// recreation) which confirms the turn never actually started.
+	realStore.Wait()
+	recreated := helper.hasCache(agent.ConvoStateKeyPrefix + convoID)
+	require.False(t, recreated, "broken behavior must not recreate convo_state on evicted convo")
+}


### PR DESCRIPTION
## Phase 1 — Recovery contract pin + regression test (research only, no recovery logic)

This is the **first phase** of the recovery-first plan for conversations whose
`convo_state:<id>` Redis key has been reclaimed (TTL/eviction).

**Problem:** Reopening an evicted conversation hits `StartTurn`
(`internal/agent/agent_store.go`), which resolves the agent name from
`ConvoState.LastSession`/`FirstSession`. When both are empty it logs
`cannot determine agent name for convo ...` and returns silently, while
`handleConvoTurnAPI` still returns `{"ok":true}` — a **false success**: no turn
starts, no message is appended to `convo_history`, and `ConvoState.ActiveSession`
is never set.

Phase 1 only **locates call sites, pins the contract, and adds a regression
test**. No recovery logic is implemented (Phases 2, 3, 5 do that).

### Call-site map

**Daemon (`honeydipper/honeydipper`, `v4`)**

| Function | Definition | Caller(s) | Route |
|---|---|---|---|
| `StartTurn(convoID, text, user, engine, driver)` | `internal/agent/agent_store.go:237` | `handleConvoTurnAPI` — `internal/service/agent_apis.go:141` | `POST /convos/:convoID/turn` (`internal/api/def.go:70`, name `convoTurn`) — **primary revive path** |
| `StartInference(msg *dipper.Message)` | `internal/agent/agent_store.go:102` | `handleAgentStart` — `internal/service/agent_svc.go:132` (responder for `eventbus:agent_start`); agent name via `msg.Labels["agent_name"]` | eventbus-driven (workflow/orchestrated path) |
| `StartNewConvo(agentName, text, user, engine, driver) string` | `internal/agent/agent_store.go:272` | `handleConvoNewAPI` — `internal/service/agent_apis.go:164` | `POST /convos` (`internal/api/def.go:53`, name `convoNew`) — already agent-driven; Phase 2 reuses its `ConvoState` construction |

**UI (`Charles546/hd-ui`, `main`)**

- `src/api.js:313` `startTurn(creds, convoID, text, engine, driver)` → `POST /convos/:convoID/turn` (daemon `convoTurn`)
- `src/api.js:322` `startNewConvo(creds, agentName, text, engine, driver)` → `POST /convos` (daemon `convoNew`)
- Callers: `src/components/ConvoHistoryPage.jsx:394` (`handleSendTurn` → `startTurn`), `src/components/ConversationsPage.jsx:657` (`startTurn`), `src/components/ConversationsPage.jsx:671` (`startNewConvo`); `src/components/NewConvoInput.jsx` `onSend` is wired by `ConversationsPage` to call `startNewConvo`. Tests mock these in `ConvoHistoryPage.test.jsx` / `api.test.js`.

### Recovery contract (pinned, not implemented)

- `POST /convos/:convoID/turn` body gains `agent` (string, optional) and
  `agent_override` (bool, optional, default false).
- Success → `{"ok":true}` (unchanged). Unrecoverable (cs missing + no agent) →
  `409 {"ok":false,"error":"conversation_expired","message":"select an agent to continue"}`.
- Truth table (recorded for Phase 2):
  | cs present? | agent supplied? | agent_override | behavior |
  |---|---|---|---|
  | no | no | n/a | 409 conversation_expired (UI prompts) |
  | no | yes | false | recreate cs with supplied agent |
  | no | yes | true | recreate cs with supplied agent |
  | yes | no | n/a | use existing cs (normal turn) |
  | yes | yes | false (stick) | use existing cs; do not overwrite |
  | yes | yes | true (override) | recreate/overwrite cs with supplied agent |

Implemented as **non-functional scaffolding** in `handleConvoTurnAPI`:
request struct fields `Agent`/`AgentOverride` (parsed, not consulted) and the
`ConversationExpiredResponse` const. No behavior changed.

### Regression test (encodes today's broken behavior; Phase 2 will invert it)

- `internal/agent/agent_store_test.go::TestStartTurn_ConvoStateEvicted_RegressesToSilentNoOp`
  seeds a conversation, evicts `convo_state:<id>` via `cache:del`, drives the
  real `StartTurn` (with an in-memory cache standing in for Redis), and asserts:
  1. the `cannot determine agent name for convo <id>` log line is emitted;
  2. `convo_state:<id>` is **not** recreated (no `cache:save`);
  3. `convo_history:<id>` is **not** appended;
  4. no message is emitted to the AI driver / `agent_response`.
  (`TestStartTurn_ConvoStatePresent_UsesExistingAgent` documents the normal
  path the evicted case diverges from.)
- `internal/service/agent_apis_test.go::TestHandleConvoTurnAPI_EvictedConvoReturnsOkTrue`
  drives the broken path through `handleConvoTurnAPI` and asserts the
  false-success `{"ok":true}` response, plus that the convo state is not
  recreated afterward.

Deterministic (in-memory cache + `Wait()` on the store), passes under
`go test ./...`, and `golangci-lint run` is clean on the touched packages.

Full call-site map + contract also captured in
`docs/conversation-recovery-contract.md`.

### Out of scope for Phase 1 (deferred)
Actual recreate/overwrite logic, `handleConvoTurnAPI` error mapping, eventbus
label plumbing, and the hd-ui agent picker (Phases 2, 3, 5).