### PR TITLE
feat(agent): filter trailing incomplete assistant messages before sending to model

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -595,6 +595,45 @@ func (s *AgentSession) getConvoContextTokens() int {
 	return cs.ContextTokens
 }
 
+// filterHistoryForModel removes trailing incomplete/empty agent messages from history
+// before sending to the model. Some models don't support assistant message prefill,
+// so we ensure the last message sent to the model is never an incomplete agent message.
+//
+// It removes trailing messages where:
+//   - Role == RoleAgent AND
+//   - (IsComplete == false OR IsThinking == true OR (Content == "" AND len(ToolCalls) == 0))
+//
+// All other messages are preserved. Returns a copy of the history with trailing
+// incomplete agent messages stripped.
+func filterHistoryForModel(history []AgentMessage) []AgentMessage {
+	if len(history) == 0 {
+		return history
+	}
+
+	// Find the last index that should be kept (non-trailing or non-agent or complete agent)
+	lastKeep := len(history) - 1
+	for lastKeep >= 0 {
+		msg := history[lastKeep]
+		if msg.Role == RoleAgent &&
+			(!msg.IsComplete || msg.IsThinking || (msg.Content == "" && len(msg.ToolCalls) == 0)) {
+			lastKeep--
+		} else {
+			break
+		}
+	}
+
+	// If all messages are filtered out, return empty slice
+	if lastKeep < 0 {
+		return []AgentMessage{}
+	}
+
+	// Return a copy up to lastKeep (inclusive)
+	result := make([]AgentMessage, lastKeep+1)
+	copy(result, history[:lastKeep+1])
+
+	return result
+}
+
 func (s *AgentSession) sendToDriver() {
 	tools := s.BuildTools()
 	timeout := s.CurrentMsg.Labels["timeout"]
@@ -628,7 +667,7 @@ func (s *AgentSession) sendToDriver() {
 	// messages so the driver always sees exactly one, up-to-date system entry.
 	history := make([]AgentMessage, 0, len(s.history)+1)
 	history = append(history, AgentMessage{Role: RoleSystem, Content: systemPrompt})
-	history = append(history, s.history...)
+	history = append(history, filterHistoryForModel(s.history)...)
 
 	if log := s.log(); log != nil {
 		log.Infof("[agent] session [%s] sending to driver=%s engine=%s history_len=%d tools=%d",

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -634,6 +634,36 @@ func filterHistoryForModel(history []AgentMessage) []AgentMessage {
 	return result
 }
 
+// shouldInjectContinueMessage checks if the last non-empty message in history
+// is an incomplete agent message with content. It skips trailing empty agent
+// messages (Content=="" AND ToolCalls empty) to find the last meaningful message.
+func shouldInjectContinueMessage(history []AgentMessage) bool {
+	if len(history) == 0 {
+		return false
+	}
+
+	// Find the last non-empty message (skip trailing empty agent messages)
+	lastMeaningfulIdx := len(history) - 1
+	for lastMeaningfulIdx >= 0 {
+		msg := history[lastMeaningfulIdx]
+		// Skip empty agent messages (no content, no tool calls)
+		if msg.Role == RoleAgent && msg.Content == "" && len(msg.ToolCalls) == 0 {
+			lastMeaningfulIdx--
+		} else {
+			break
+		}
+	}
+
+	// Check if the last meaningful message is an incomplete agent message with content
+	if lastMeaningfulIdx < 0 {
+		return false
+	}
+
+	lastMsg := history[lastMeaningfulIdx]
+
+	return lastMsg.Role == RoleAgent && !lastMsg.IsComplete && lastMsg.Content != ""
+}
+
 func (s *AgentSession) sendToDriver() {
 	tools := s.BuildTools()
 	timeout := s.CurrentMsg.Labels["timeout"]
@@ -663,15 +693,29 @@ func (s *AgentSession) sendToDriver() {
 		}
 	}
 
+	// Determine if we should inject a "continue" user message.
+	// This happens when the last non-empty message in history is an incomplete
+	// agent message with content (meaning the model produced meaningful output
+	// but didn't finish). We skip over trailing empty agent messages
+	// (Content=="" AND ToolCalls empty) to find the last meaningful message.
+	shouldInjectContinue := shouldInjectContinueMessage(s.history)
+
 	// Prepend the system prompt ephemerally; filter any legacy persisted system
 	// messages so the driver always sees exactly one, up-to-date system entry.
 	history := make([]AgentMessage, 0, len(s.history)+1)
 	history = append(history, AgentMessage{Role: RoleSystem, Content: systemPrompt})
 	history = append(history, filterHistoryForModel(s.history)...)
 
+	// Inject "continue" user message if the last non-empty message was an
+	// incomplete agent message with content. This prompts the model to continue
+	// its response rather than starting fresh.
+	if shouldInjectContinue {
+		history = append(history, AgentMessage{Role: RoleUser, Content: "Please continue."})
+	}
+
 	if log := s.log(); log != nil {
-		log.Infof("[agent] session [%s] sending to driver=%s engine=%s history_len=%d tools=%d",
-			s.ID, s.Agent.Driver, s.Agent.Engine, len(history), len(tools))
+		log.Infof("[agent] session [%s] sending to driver=%s engine=%s history_len=%d tools=%d inject_continue=%v",
+			s.ID, s.Agent.Driver, s.Agent.Engine, len(history), len(tools), shouldInjectContinue)
 	}
 	s.InputTokens = 0
 	dipper.Must(s.store.CallNoWait("driver:"+s.Agent.Driver, "send_to_model", map[string]interface{}{

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -605,12 +605,45 @@ func (s *AgentSession) getConvoContextTokens() int {
 //
 // All other messages are preserved. Returns a copy of the history with trailing
 // incomplete agent messages stripped.
-func filterHistoryForModel(history []AgentMessage) []AgentMessage {
+// prepareHistoryForModel filters trailing incomplete/empty agent messages from history
+// AND determines if a "continue" user message should be injected.
+// It returns both the filtered history and a boolean indicating whether to inject "continue".
+//
+// Filtering criteria (trailing messages removed):
+//   - Role == RoleAgent AND (IsComplete == false OR IsThinking == true OR (Content == "" AND len(ToolCalls) == 0))
+//
+// "Continue" injection criteria:
+//   - After skipping trailing empty agent messages (Content=="" AND ToolCalls empty AND not IsThinking),
+//     if the last meaningful message is an incomplete agent message that has either
+//     content (Content != "") OR is a thinking message (IsThinking == true),
+//     then inject "Please continue." to prompt the model to continue its response.
+func prepareHistoryForModel(history []AgentMessage) (filteredHistory []AgentMessage, injectContinue bool) {
 	if len(history) == 0 {
-		return history
+		return []AgentMessage{}, false
 	}
 
-	// Find the last index that should be kept (non-trailing or non-agent or complete agent)
+	// Find the last meaningful message index (skip trailing empty agent messages only)
+	// Empty agent message = Content=="" AND ToolCalls empty AND not IsThinking
+	// Thinking messages (IsThinking==true) are NOT skipped - they are meaningful
+	lastMeaningfulIdx := len(history) - 1
+	for lastMeaningfulIdx >= 0 {
+		msg := history[lastMeaningfulIdx]
+		if msg.Role == RoleAgent && msg.Content == "" && len(msg.ToolCalls) == 0 && !msg.IsThinking {
+			lastMeaningfulIdx--
+		} else {
+			break
+		}
+	}
+
+	// Determine if we should inject "continue"
+	// This is true if the last meaningful message is an incomplete agent message
+	// that has either content OR is a thinking message
+	if lastMeaningfulIdx >= 0 {
+		lastMsg := history[lastMeaningfulIdx]
+		injectContinue = lastMsg.Role == RoleAgent && !lastMsg.IsComplete && (lastMsg.Content != "" || lastMsg.IsThinking)
+	}
+
+	// Filter history: find last index to keep (remove trailing incomplete/empty/thinking agent messages)
 	lastKeep := len(history) - 1
 	for lastKeep >= 0 {
 		msg := history[lastKeep]
@@ -624,44 +657,30 @@ func filterHistoryForModel(history []AgentMessage) []AgentMessage {
 
 	// If all messages are filtered out, return empty slice
 	if lastKeep < 0 {
-		return []AgentMessage{}
+		return []AgentMessage{}, injectContinue
 	}
 
 	// Return a copy up to lastKeep (inclusive)
 	result := make([]AgentMessage, lastKeep+1)
 	copy(result, history[:lastKeep+1])
 
-	return result
+	return result, injectContinue
 }
 
-// shouldInjectContinueMessage checks if the last non-empty message in history
-// is an incomplete agent message with content. It skips trailing empty agent
-// messages (Content=="" AND ToolCalls empty) to find the last meaningful message.
-func shouldInjectContinueMessage(history []AgentMessage) bool {
-	if len(history) == 0 {
-		return false
-	}
+// filterHistoryForModel removes trailing incomplete/empty agent messages from history
+// before sending to the model. Some models don't support assistant message prefill,
+// so we ensure the last message sent to the model is never an incomplete agent message.
+//
+// It removes trailing messages where:
+//   - Role == RoleAgent AND
+//   - (IsComplete == false OR IsThinking == true OR (Content == "" AND len(ToolCalls) == 0))
+//
+// All other messages are preserved. Returns a copy of the history with trailing
+// incomplete agent messages stripped.
+func filterHistoryForModel(history []AgentMessage) []AgentMessage {
+	filtered, _ := prepareHistoryForModel(history)
 
-	// Find the last non-empty message (skip trailing empty agent messages)
-	lastMeaningfulIdx := len(history) - 1
-	for lastMeaningfulIdx >= 0 {
-		msg := history[lastMeaningfulIdx]
-		// Skip empty agent messages (no content, no tool calls)
-		if msg.Role == RoleAgent && msg.Content == "" && len(msg.ToolCalls) == 0 {
-			lastMeaningfulIdx--
-		} else {
-			break
-		}
-	}
-
-	// Check if the last meaningful message is an incomplete agent message with content
-	if lastMeaningfulIdx < 0 {
-		return false
-	}
-
-	lastMsg := history[lastMeaningfulIdx]
-
-	return lastMsg.Role == RoleAgent && !lastMsg.IsComplete && lastMsg.Content != ""
+	return filtered
 }
 
 func (s *AgentSession) sendToDriver() {
@@ -693,22 +712,21 @@ func (s *AgentSession) sendToDriver() {
 		}
 	}
 
-	// Determine if we should inject a "continue" user message.
-	// This happens when the last non-empty message in history is an incomplete
-	// agent message with content (meaning the model produced meaningful output
-	// but didn't finish). We skip over trailing empty agent messages
-	// (Content=="" AND ToolCalls empty) to find the last meaningful message.
-	shouldInjectContinue := shouldInjectContinueMessage(s.history)
+	// Prepare history for the model: filter trailing incomplete messages and
+	// determine if we should inject a "continue" user message.
+	// This happens when the last meaningful message (skipping empty agent messages)
+	// is an incomplete agent message with content OR a thinking message.
+	filteredHistory, shouldInjectContinue := prepareHistoryForModel(s.history)
 
 	// Prepend the system prompt ephemerally; filter any legacy persisted system
 	// messages so the driver always sees exactly one, up-to-date system entry.
-	history := make([]AgentMessage, 0, len(s.history)+1)
+	history := make([]AgentMessage, 0, len(filteredHistory)+2)
 	history = append(history, AgentMessage{Role: RoleSystem, Content: systemPrompt})
-	history = append(history, filterHistoryForModel(s.history)...)
+	history = append(history, filteredHistory...)
 
-	// Inject "continue" user message if the last non-empty message was an
-	// incomplete agent message with content. This prompts the model to continue
-	// its response rather than starting fresh.
+	// Inject "continue" user message if the last meaningful message was an
+	// incomplete agent message with content or a thinking message. This prompts
+	// the model to continue its response rather than starting fresh.
 	if shouldInjectContinue {
 		history = append(history, AgentMessage{Role: RoleUser, Content: "Please continue."})
 	}

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -595,16 +595,6 @@ func (s *AgentSession) getConvoContextTokens() int {
 	return cs.ContextTokens
 }
 
-// filterHistoryForModel removes trailing incomplete/empty agent messages from history
-// before sending to the model. Some models don't support assistant message prefill,
-// so we ensure the last message sent to the model is never an incomplete agent message.
-//
-// It removes trailing messages where:
-//   - Role == RoleAgent AND
-//   - (IsComplete == false OR IsThinking == true OR (Content == "" AND len(ToolCalls) == 0))
-//
-// All other messages are preserved. Returns a copy of the history with trailing
-// incomplete agent messages stripped.
 // prepareHistoryForModel filters trailing incomplete/empty agent messages from history
 // AND determines if a "continue" user message should be injected.
 // It returns both the filtered history and a boolean indicating whether to inject "continue".
@@ -622,61 +612,56 @@ func prepareHistoryForModel(history []AgentMessage) (filteredHistory []AgentMess
 		return []AgentMessage{}, false
 	}
 
-	// Find the last meaningful message index (skip trailing empty agent messages only)
-	// Empty agent message = Content=="" AND ToolCalls empty AND not IsThinking
-	// Thinking messages (IsThinking==true) are NOT skipped - they are meaningful
-	lastMeaningfulIdx := len(history) - 1
-	for lastMeaningfulIdx >= 0 {
-		msg := history[lastMeaningfulIdx]
-		if msg.Role == RoleAgent && msg.Content == "" && len(msg.ToolCalls) == 0 && !msg.IsThinking {
-			lastMeaningfulIdx--
-		} else {
+	// Single backward pass to find both:
+	// - lastMeaningfulIdx: last message that is NOT an empty agent (Content=="" && ToolCalls=0 && !IsThinking)
+	// - lastKeepIdx: last message to KEEP (non-agent OR complete non-thinking agent with content/toolCalls)
+	lastMeaningfulIdx := -1
+	lastKeepIdx := -1
+
+	for i := len(history) - 1; i >= 0; i-- {
+		msg := history[i]
+		isEmptyAgent := msg.Role == RoleAgent && msg.Content == "" && len(msg.ToolCalls) == 0 && !msg.IsThinking
+
+		// Track last meaningful message (skip only empty non-thinking agents)
+		if lastMeaningfulIdx == -1 && !isEmptyAgent {
+			lastMeaningfulIdx = i
+		}
+
+		// Track last message to keep (skip incomplete, thinking, or empty agents)
+		if lastKeepIdx == -1 {
+			if msg.Role != RoleAgent {
+				lastKeepIdx = i
+			} else if msg.IsComplete && !msg.IsThinking && (msg.Content != "" || len(msg.ToolCalls) > 0) {
+				lastKeepIdx = i
+			}
+			// else: incomplete/thinking/empty agent -> continue searching
+		}
+
+		// Early exit if both found
+		if lastMeaningfulIdx != -1 && lastKeepIdx != -1 {
 			break
 		}
 	}
 
 	// Determine if we should inject "continue"
-	// This is true if the last meaningful message is an incomplete agent message
-	// that has either content OR is a thinking message
+	// True if the last meaningful message is an incomplete agent with content or thinking
 	if lastMeaningfulIdx >= 0 {
 		lastMsg := history[lastMeaningfulIdx]
 		injectContinue = lastMsg.Role == RoleAgent && !lastMsg.IsComplete && (lastMsg.Content != "" || lastMsg.IsThinking)
 	}
 
-	// Filter history: find last index to keep (remove trailing incomplete/empty/thinking agent messages)
-	lastKeep := len(history) - 1
-	for lastKeep >= 0 {
-		msg := history[lastKeep]
-		if msg.Role == RoleAgent &&
-			(!msg.IsComplete || msg.IsThinking || (msg.Content == "" && len(msg.ToolCalls) == 0)) {
-			lastKeep--
-		} else {
-			break
-		}
-	}
-
-	// If all messages are filtered out, return empty slice
-	if lastKeep < 0 {
+	// If no message to keep, return empty slice
+	if lastKeepIdx < 0 {
 		return []AgentMessage{}, injectContinue
 	}
 
-	// Return a copy up to lastKeep (inclusive)
-	result := make([]AgentMessage, lastKeep+1)
-	copy(result, history[:lastKeep+1])
+	// Return a copy up to lastKeepIdx (inclusive)
+	result := make([]AgentMessage, lastKeepIdx+1)
+	copy(result, history[:lastKeepIdx+1])
 
 	return result, injectContinue
 }
 
-// filterHistoryForModel removes trailing incomplete/empty agent messages from history
-// before sending to the model. Some models don't support assistant message prefill,
-// so we ensure the last message sent to the model is never an incomplete agent message.
-//
-// It removes trailing messages where:
-//   - Role == RoleAgent AND
-//   - (IsComplete == false OR IsThinking == true OR (Content == "" AND len(ToolCalls) == 0))
-//
-// All other messages are preserved. Returns a copy of the history with trailing
-// incomplete agent messages stripped.
 func filterHistoryForModel(history []AgentMessage) []AgentMessage {
 	filtered, _ := prepareHistoryForModel(history)
 

--- a/internal/agent/agent_session_test.go
+++ b/internal/agent/agent_session_test.go
@@ -209,6 +209,133 @@ func TestFilterHistoryForModel_SendToDriverIntegration(t *testing.T) {
 	}
 }
 
+// TestPrepareHistoryForModel tests the combined prepareHistoryForModel function.
+func TestPrepareHistoryForModel(t *testing.T) {
+	tests := []struct {
+		name                 string
+		history              []agent.Message
+		expectedFiltered     []agent.Message
+		expectInjectContinue bool
+	}{
+		{
+			name:                 "empty history returns empty",
+			history:              []agent.Message{},
+			expectedFiltered:     []agent.Message{},
+			expectInjectContinue: false,
+		},
+		{
+			name: "empty assistant message at end - filtered, no continue",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+			},
+			expectedFiltered: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+			},
+			expectInjectContinue: false,
+		},
+		{
+			name: "thinking-only assistant message at end - filtered, injects continue",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsThinking: true, Thoughts: "Let me think..."},
+			},
+			expectedFiltered: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+			},
+			expectInjectContinue: true, // Changed: thinking messages now trigger continue
+		},
+		{
+			name: "complete assistant message with content - preserved, no continue",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Hi there!", IsComplete: true},
+			},
+			expectedFiltered: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Hi there!", IsComplete: true},
+			},
+			expectInjectContinue: false,
+		},
+		{
+			name: "incomplete agent with content at end - filtered, injects continue",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Partial response", IsComplete: false},
+			},
+			expectedFiltered: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+			},
+			expectInjectContinue: true,
+		},
+		{
+			name: "thinking agent with content - filtered, injects continue",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Let me think...", IsThinking: true, Thoughts: "internal thoughts"},
+			},
+			expectedFiltered: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+			},
+			expectInjectContinue: true, // thinking with content also triggers continue
+		},
+		{
+			name: "multiple trailing incomplete agent messages - all filtered",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Thinking...", IsThinking: true},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+			},
+			expectedFiltered: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+			},
+			expectInjectContinue: true, // last meaningful is thinking message
+		},
+		{
+			name: "all messages filtered - injects continue",
+			history: []agent.Message{
+				{Role: RoleAgent, Content: "Partial", IsComplete: false},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+			},
+			expectedFiltered:     []agent.Message{},
+			expectInjectContinue: true,
+		},
+		{
+			name: "incomplete agent with tool calls but no content - filtered, no continue",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: false, ToolCalls: []agent.ToolCall{{FuncName: "test_func"}}},
+			},
+			expectedFiltered: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+			},
+			expectInjectContinue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered, injectContinue := prepareHistoryForModel(tt.history)
+
+			if !reflect.DeepEqual(filtered, tt.expectedFiltered) {
+				t.Errorf("filtered = %v, want %v", filtered, tt.expectedFiltered)
+			}
+
+			if injectContinue != tt.expectInjectContinue {
+				t.Errorf("injectContinue = %v, want %v", injectContinue, tt.expectInjectContinue)
+			}
+
+			// Verify it returns a copy, not the original slice
+			if len(tt.history) > 0 && len(filtered) > 0 {
+				if &filtered[0] == &tt.history[0] {
+					t.Errorf("prepareHistoryForModel returned original slice, not a copy")
+				}
+			}
+		})
+	}
+}
+
 // TestSendToDriver_ContinueInjection tests the "continue" user message injection logic.
 func TestSendToDriver_ContinueInjection(t *testing.T) {
 	tests := []struct {
@@ -227,13 +354,13 @@ func TestSendToDriver_ContinueInjection(t *testing.T) {
 			expectedLastMsg:      nil,
 		},
 		{
-			name: "thinking agent at end -> no inject (skips to user)",
+			name: "thinking agent at end -> injects continue (changed behavior)",
 			history: []agent.Message{
 				{Role: RoleUser, Content: "Hello"},
 				{Role: RoleAgent, Content: "", IsThinking: true, Thoughts: "Let me think..."},
 			},
-			expectInjectContinue: false,
-			expectedLastMsg:      nil,
+			expectInjectContinue: true, // CHANGED: now injects continue for thinking messages
+			expectedLastMsg:      &agent.Message{Role: RoleUser, Content: "Please continue."},
 		},
 		{
 			name: "incomplete agent with content at end -> injects continue",
@@ -311,39 +438,30 @@ func TestSendToDriver_ContinueInjection(t *testing.T) {
 			expectInjectContinue: true,
 			expectedLastMsg:      &agent.Message{Role: RoleUser, Content: "Please continue."},
 		},
+		{
+			name: "thinking agent with content and tool calls -> injects continue",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Let me think and call a tool", IsThinking: true, Thoughts: "thinking...", ToolCalls: []agent.ToolCall{{FuncName: "test_func"}}},
+			},
+			expectInjectContinue: true, // thinking with content triggers continue
+			expectedLastMsg:      &agent.Message{Role: RoleUser, Content: "Please continue."},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Simulate what sendToDriver does
-			shouldInjectContinue := false
-			if len(tt.history) > 0 {
-				lastMeaningfulIdx := len(tt.history) - 1
-				for lastMeaningfulIdx >= 0 {
-					msg := tt.history[lastMeaningfulIdx]
-					if msg.Role == RoleAgent && msg.Content == "" && len(msg.ToolCalls) == 0 {
-						lastMeaningfulIdx--
-					} else {
-						break
-					}
-				}
-
-				if lastMeaningfulIdx >= 0 {
-					lastMsg := tt.history[lastMeaningfulIdx]
-					if lastMsg.Role == RoleAgent && !lastMsg.IsComplete && lastMsg.Content != "" {
-						shouldInjectContinue = true
-					}
-				}
-			}
+			// Use the new combined function to simulate what sendToDriver does
+			filteredHistory, shouldInjectContinue := prepareHistoryForModel(tt.history)
 
 			if shouldInjectContinue != tt.expectInjectContinue {
 				t.Errorf("shouldInjectContinue = %v, want %v", shouldInjectContinue, tt.expectInjectContinue)
 			}
 
 			// Build history as sendToDriver would
-			history := make([]agent.Message, 0, len(tt.history)+1)
+			history := make([]agent.Message, 0, len(filteredHistory)+2)
 			history = append(history, agent.Message{Role: RoleSystem, Content: "System prompt"})
-			history = append(history, filterHistoryForModel(tt.history)...)
+			history = append(history, filteredHistory...)
 
 			if shouldInjectContinue {
 				history = append(history, agent.Message{Role: RoleUser, Content: "Please continue."})

--- a/internal/agent/agent_session_test.go
+++ b/internal/agent/agent_session_test.go
@@ -1,0 +1,210 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/honeydipper/honeydipper/v4/pkg/agent"
+)
+
+// TestFilterHistoryForModel tests the filterHistoryForModel helper function.
+func TestFilterHistoryForModel(t *testing.T) {
+	tests := []struct {
+		name     string
+		history  []agent.Message
+		expected []agent.Message
+	}{
+		{
+			name:     "empty history returns empty",
+			history:  []agent.Message{},
+			expected: []agent.Message{},
+		},
+		{
+			name: "empty assistant message at end is filtered",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+			},
+			expected: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+			},
+		},
+		{
+			name: "thinking-only assistant message at end is filtered",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsThinking: true, Thoughts: "Let me think..."},
+			},
+			expected: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+			},
+		},
+		{
+			name: "complete assistant message with content is preserved",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Hi there!", IsComplete: true},
+			},
+			expected: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Hi there!", IsComplete: true},
+			},
+		},
+		{
+			name: "complete assistant message with tool calls is preserved",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: true, ToolCalls: []agent.ToolCall{{FuncName: "test_func"}}},
+			},
+			expected: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: true, ToolCalls: []agent.ToolCall{{FuncName: "test_func"}}},
+			},
+		},
+		{
+			name: "user messages are always preserved",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+				{Role: RoleUser, Content: "Are you there?"},
+			},
+			expected: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+				{Role: RoleUser, Content: "Are you there?"},
+			},
+		},
+		{
+			name: "tool result messages are always preserved",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+				{Role: RoleToolResult, ToolResult: []map[string]interface{}{{"status": "success"}}},
+			},
+			expected: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+				{Role: RoleToolResult, ToolResult: []map[string]interface{}{{"status": "success"}}},
+			},
+		},
+		{
+			name: "system prompt is always preserved when prepended",
+			history: []agent.Message{
+				{Role: RoleSystem, Content: "System prompt"},
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+			},
+			expected: []agent.Message{
+				{Role: RoleSystem, Content: "System prompt"},
+				{Role: RoleUser, Content: "Hello"},
+			},
+		},
+		{
+			name: "multiple trailing incomplete agent messages all filtered",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Thinking...", IsThinking: true},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+			},
+			expected: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+			},
+		},
+		{
+			name: "incomplete agent message followed by complete one preserves both",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Thinking...", IsThinking: true},
+				{Role: RoleAgent, Content: "Final answer", IsComplete: true},
+			},
+			expected: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Thinking...", IsThinking: true},
+				{Role: RoleAgent, Content: "Final answer", IsComplete: true},
+			},
+		},
+		{
+			name: "agent message with tool calls but not complete is filtered",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: false, ToolCalls: []agent.ToolCall{{FuncName: "test_func"}}},
+			},
+			expected: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+			},
+		},
+		{
+			name: "agent message with content but not complete is filtered",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Partial response", IsComplete: false},
+			},
+			expected: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+			},
+		},
+		{
+			name: "all agent messages filtered when all are incomplete",
+			history: []agent.Message{
+				{Role: RoleAgent, Content: "", IsComplete: false},
+				{Role: RoleAgent, Content: "Thinking...", IsThinking: true},
+			},
+			expected: []agent.Message{},
+		},
+		{
+			name: "returns copy not original slice",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+			},
+			expected: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterHistoryForModel(tt.history)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("filterHistoryForModel(%v) = %v, want %v", tt.history, result, tt.expected)
+			}
+
+			// Verify it returns a copy, not the original slice
+			if len(tt.history) > 0 && len(result) > 0 {
+				if &result[0] == &tt.history[0] {
+					t.Errorf("filterHistoryForModel returned original slice, not a copy")
+				}
+			}
+		})
+	}
+}
+
+// TestFilterHistoryForModel_SendToDriverIntegration tests that sendToDriver uses filtered history.
+func TestFilterHistoryForModel_SendToDriverIntegration(t *testing.T) {
+	// This test verifies the integration by checking that the history
+	// passed to the driver would be filtered. We can't easily test the
+	// actual driver call without a full mock setup, but we can verify
+	// the filter function works correctly in context.
+
+	// Setup a session-like history
+	history := []agent.Message{
+		{Role: RoleUser, Content: "Hello"},
+		{Role: RoleAgent, Content: "", IsComplete: false, IsThinking: true},
+	}
+
+	// Filter as sendToDriver would
+	filtered := filterHistoryForModel(history)
+
+	// The filtered history should not have the incomplete agent message
+	if len(filtered) != 1 {
+		t.Errorf("expected filtered history length 1, got %d", len(filtered))
+	}
+	if filtered[0].Role != RoleUser {
+		t.Errorf("expected first message role %s, got %s", RoleUser, filtered[0].Role)
+	}
+	if filtered[0].Content != "Hello" {
+		t.Errorf("expected first message content 'Hello', got %s", filtered[0].Content)
+	}
+}

--- a/internal/agent/agent_session_test.go
+++ b/internal/agent/agent_session_test.go
@@ -208,3 +208,166 @@ func TestFilterHistoryForModel_SendToDriverIntegration(t *testing.T) {
 		t.Errorf("expected first message content 'Hello', got %s", filtered[0].Content)
 	}
 }
+
+// TestSendToDriver_ContinueInjection tests the "continue" user message injection logic.
+func TestSendToDriver_ContinueInjection(t *testing.T) {
+	tests := []struct {
+		name                 string
+		history              []agent.Message
+		expectInjectContinue bool
+		expectedLastMsg      *agent.Message // nil means no continue injection expected
+	}{
+		{
+			name: "empty agent at end -> no inject (skips to user)",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+			},
+			expectInjectContinue: false,
+			expectedLastMsg:      nil,
+		},
+		{
+			name: "thinking agent at end -> no inject (skips to user)",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsThinking: true, Thoughts: "Let me think..."},
+			},
+			expectInjectContinue: false,
+			expectedLastMsg:      nil,
+		},
+		{
+			name: "incomplete agent with content at end -> injects continue",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Partial response", IsComplete: false},
+			},
+			expectInjectContinue: true,
+			expectedLastMsg:      &agent.Message{Role: RoleUser, Content: "Please continue."},
+		},
+		{
+			name: "complete agent at end -> no inject",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Complete response", IsComplete: true},
+			},
+			expectInjectContinue: false,
+			expectedLastMsg:      nil,
+		},
+		{
+			name: "user at end -> no inject",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Response", IsComplete: true},
+				{Role: RoleUser, Content: "Follow up"},
+			},
+			expectInjectContinue: false,
+			expectedLastMsg:      nil,
+		},
+		{
+			name: "tool result at end -> no inject",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Response", IsComplete: true},
+				{Role: RoleToolResult, ToolResult: []map[string]interface{}{{"status": "success"}}},
+			},
+			expectInjectContinue: false,
+			expectedLastMsg:      nil,
+		},
+		{
+			name: "multiple empty agents then incomplete with content -> injects",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+				{Role: RoleAgent, Content: "", IsThinking: true, Thoughts: "Thinking..."},
+				{Role: RoleAgent, Content: "Partial but meaningful", IsComplete: false},
+			},
+			expectInjectContinue: true,
+			expectedLastMsg:      &agent.Message{Role: RoleUser, Content: "Please continue."},
+		},
+		{
+			name: "all messages filtered (only incomplete agent messages) -> injects continue after system prompt",
+			history: []agent.Message{
+				{Role: RoleAgent, Content: "Partial", IsComplete: false},
+				{Role: RoleAgent, Content: "", IsComplete: false},
+			},
+			expectInjectContinue: true,
+			expectedLastMsg:      &agent.Message{Role: RoleUser, Content: "Please continue."},
+		},
+		{
+			name: "incomplete agent with tool calls but no content -> no inject (no meaningful content)",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "", IsComplete: false, ToolCalls: []agent.ToolCall{{FuncName: "test_func"}}},
+			},
+			expectInjectContinue: false,
+			expectedLastMsg:      nil,
+		},
+		{
+			name: "incomplete agent with content and tool calls -> injects continue",
+			history: []agent.Message{
+				{Role: RoleUser, Content: "Hello"},
+				{Role: RoleAgent, Content: "Let me call a tool", IsComplete: false, ToolCalls: []agent.ToolCall{{FuncName: "test_func"}}},
+			},
+			expectInjectContinue: true,
+			expectedLastMsg:      &agent.Message{Role: RoleUser, Content: "Please continue."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate what sendToDriver does
+			shouldInjectContinue := false
+			if len(tt.history) > 0 {
+				lastMeaningfulIdx := len(tt.history) - 1
+				for lastMeaningfulIdx >= 0 {
+					msg := tt.history[lastMeaningfulIdx]
+					if msg.Role == RoleAgent && msg.Content == "" && len(msg.ToolCalls) == 0 {
+						lastMeaningfulIdx--
+					} else {
+						break
+					}
+				}
+
+				if lastMeaningfulIdx >= 0 {
+					lastMsg := tt.history[lastMeaningfulIdx]
+					if lastMsg.Role == RoleAgent && !lastMsg.IsComplete && lastMsg.Content != "" {
+						shouldInjectContinue = true
+					}
+				}
+			}
+
+			if shouldInjectContinue != tt.expectInjectContinue {
+				t.Errorf("shouldInjectContinue = %v, want %v", shouldInjectContinue, tt.expectInjectContinue)
+			}
+
+			// Build history as sendToDriver would
+			history := make([]agent.Message, 0, len(tt.history)+1)
+			history = append(history, agent.Message{Role: RoleSystem, Content: "System prompt"})
+			history = append(history, filterHistoryForModel(tt.history)...)
+
+			if shouldInjectContinue {
+				history = append(history, agent.Message{Role: RoleUser, Content: "Please continue."})
+			}
+
+			// Check the last message
+			if tt.expectedLastMsg != nil {
+				if len(history) == 0 {
+					t.Errorf("expected at least one message in history")
+				} else {
+					lastMsg := history[len(history)-1]
+					if lastMsg.Role != tt.expectedLastMsg.Role || lastMsg.Content != tt.expectedLastMsg.Content {
+						t.Errorf("last message = %+v, want %+v", lastMsg, *tt.expectedLastMsg)
+					}
+				}
+			} else {
+				// Should not have "Please continue." as last message
+				if len(history) > 0 {
+					lastMsg := history[len(history)-1]
+					if lastMsg.Content == "Please continue." {
+						t.Errorf("unexpected 'continue' message injected, last message = %+v", lastMsg)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes an issue where honeydipper agent sends history to the model again for retrying when receiving empty or thought-only messages, but some models throw errors about "not supporting assistant message prefill". The fix ensures only user messages (or complete assistant messages) are sent as the last message to the model.

## Changes

1. **Added `filterHistoryForModel()` helper function** in `internal/agent/agent_session.go`:
   - Removes trailing messages where `Role == RoleAgent` AND (`IsComplete == false` OR `IsThinking == true` OR (`Content == ""` AND `len(ToolCalls) == 0`))
   - Preserves all other messages (user, tool result, system, complete agent messages)
   - Returns a copy of the history with trailing incomplete agent messages stripped

2. **Modified `sendToDriver()`** to use the filtered history:
   - Replaced `history = append(history, s.history...)` with `history = append(history, filterHistoryForModel(s.history)...)`

3. **Added comprehensive unit tests** in `internal/agent/agent_session_test.go`:
   - Empty assistant message at end is filtered
   - Thinking-only assistant message at end is filtered
   - Complete assistant message with content is preserved
   - Complete assistant message with tool calls is preserved
   - User messages are always preserved
   - Tool result messages are always preserved
   - System prompt is always prepended
   - Multiple trailing incomplete agent messages all filtered
   - Incomplete agent message followed by complete one preserves both
   - Agent message with tool calls but not complete is filtered
   - Agent message with content but not complete is filtered
   - All agent messages filtered when all are incomplete
   - Returns copy not original slice

## Testing

All existing tests pass, and new tests cover all the required scenarios.