### PR TITLE
feat(agent): ensure last message sent to model is always a user message

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -630,6 +630,12 @@ func (s *AgentSession) sendToDriver() {
 	history = append(history, AgentMessage{Role: RoleSystem, Content: systemPrompt})
 	history = append(history, s.history...)
 
+	// Ensure the last message is a user message to avoid "assistant message prefill not supported" errors.
+	// Some models reject requests where the last message is from the assistant (agent), tool, or system.
+	if len(history) > 0 && history[len(history)-1].Role != RoleUser {
+		history = append(history, AgentMessage{Role: RoleUser, Content: "Please continue."})
+	}
+
 	if log := s.log(); log != nil {
 		log.Infof("[agent] session [%s] sending to driver=%s engine=%s history_len=%d tools=%d",
 			s.ID, s.Agent.Driver, s.Agent.Engine, len(history), len(tools))

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -2970,3 +2970,193 @@ func TestCancelConvo_ReleasesUnifiedConvoTurnLock(t *testing.T) {
 	// The last call should be for the unified convo turn lock (called second)
 	assert.Equal(t, ConvoTurnLockPrefix+"unified-convo", params["name"])
 }
+
+// ---------------------------------------------------------------------------
+// AgentSession.sendToDriver tests - ensure last message is user
+// ---------------------------------------------------------------------------
+
+func TestSendToDriver_EnsuresLastMessageIsUser_AgentLast(t *testing.T) {
+	store := newMockStore(nil)
+	agentA := config.Agent{
+		Name:         "a",
+		Driver:       "openai",
+		Engine:       "gpt-4",
+		SystemPrompt: "sys prompt",
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{
+		store:      store,
+		Agent:      &agentA,
+		ID:         "test-session",
+		CurrentMsg: &dipper.Message{Labels: map[string]string{}, Payload: map[string]interface{}{"text": "input"}},
+		history: []AgentMessage{
+			{Role: RoleUser, Content: "hello"},
+			{Role: RoleAgent, Content: "incomplete response", IsComplete: false},
+		},
+		Type: AgentSessionTypeChatTurn,
+	}
+
+	s.sendToDriver()
+
+	assert.True(t, store.hasCall("driver:openai:send_to_model"))
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	driverHistory := params["history"].([]AgentMessage)
+
+	// History should have: system prompt + user + agent + "Please continue."
+	require.Len(t, driverHistory, 4)
+	assert.Equal(t, RoleSystem, driverHistory[0].Role)
+	assert.Equal(t, RoleUser, driverHistory[1].Role)
+	assert.Equal(t, RoleAgent, driverHistory[2].Role)
+	assert.Equal(t, RoleUser, driverHistory[3].Role)
+	assert.Equal(t, "Please continue.", driverHistory[3].Content)
+}
+
+func TestSendToDriver_EnsuresLastMessageIsUser_ToolLast(t *testing.T) {
+	store := newMockStore(nil)
+	agentA := config.Agent{
+		Name:         "a",
+		Driver:       "openai",
+		Engine:       "gpt-4",
+		SystemPrompt: "sys prompt",
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{
+		store:      store,
+		Agent:      &agentA,
+		ID:         "test-session",
+		CurrentMsg: &dipper.Message{Labels: map[string]string{}, Payload: map[string]interface{}{"text": "input"}},
+		history: []AgentMessage{
+			{Role: RoleUser, Content: "hello"},
+			{Role: RoleTool, Content: "tool output"},
+		},
+		Type: AgentSessionTypeChatTurn,
+	}
+
+	s.sendToDriver()
+
+	assert.True(t, store.hasCall("driver:openai:send_to_model"))
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	driverHistory := params["history"].([]AgentMessage)
+
+	require.Len(t, driverHistory, 4)
+	assert.Equal(t, RoleSystem, driverHistory[0].Role)
+	assert.Equal(t, RoleUser, driverHistory[1].Role)
+	assert.Equal(t, RoleTool, driverHistory[2].Role)
+	assert.Equal(t, RoleUser, driverHistory[3].Role)
+	assert.Equal(t, "Please continue.", driverHistory[3].Content)
+}
+
+func TestSendToDriver_EnsuresLastMessageIsUser_SystemLast(t *testing.T) {
+	store := newMockStore(nil)
+	agentA := config.Agent{
+		Name:         "a",
+		Driver:       "openai",
+		Engine:       "gpt-4",
+		SystemPrompt: "sys prompt",
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{
+		store:      store,
+		Agent:      &agentA,
+		ID:         "test-session",
+		CurrentMsg: &dipper.Message{Labels: map[string]string{}, Payload: map[string]interface{}{"text": "input"}},
+		history: []AgentMessage{
+			{Role: RoleUser, Content: "hello"},
+			{Role: RoleSystem, Content: "legacy system message"},
+		},
+		Type: AgentSessionTypeChatTurn,
+	}
+
+	s.sendToDriver()
+
+	assert.True(t, store.hasCall("driver:openai:send_to_model"))
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	driverHistory := params["history"].([]AgentMessage)
+
+	require.Len(t, driverHistory, 4)
+	assert.Equal(t, RoleSystem, driverHistory[0].Role)
+	assert.Equal(t, RoleUser, driverHistory[1].Role)
+	assert.Equal(t, RoleSystem, driverHistory[2].Role)
+	assert.Equal(t, RoleUser, driverHistory[3].Role)
+	assert.Equal(t, "Please continue.", driverHistory[3].Content)
+}
+
+func TestSendToDriver_EnsuresLastMessageIsUser_UserLast_NoExtra(t *testing.T) {
+	store := newMockStore(nil)
+	agentA := config.Agent{
+		Name:         "a",
+		Driver:       "openai",
+		Engine:       "gpt-4",
+		SystemPrompt: "sys prompt",
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{
+		store:      store,
+		Agent:      &agentA,
+		ID:         "test-session",
+		CurrentMsg: &dipper.Message{Labels: map[string]string{}, Payload: map[string]interface{}{"text": "input"}},
+		history: []AgentMessage{
+			{Role: RoleUser, Content: "hello"},
+			{Role: RoleAgent, Content: "complete response", IsComplete: true},
+			{Role: RoleUser, Content: "follow up"},
+		},
+		Type: AgentSessionTypeChatTurn,
+	}
+
+	s.sendToDriver()
+
+	assert.True(t, store.hasCall("driver:openai:send_to_model"))
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	driverHistory := params["history"].([]AgentMessage)
+
+	// History should have: system prompt + 3 user/agent messages, NO extra "Please continue."
+	require.Len(t, driverHistory, 4)
+	assert.Equal(t, RoleSystem, driverHistory[0].Role)
+	assert.Equal(t, RoleUser, driverHistory[1].Role)
+	assert.Equal(t, RoleAgent, driverHistory[2].Role)
+	assert.Equal(t, RoleUser, driverHistory[3].Role)
+	assert.Equal(t, "follow up", driverHistory[3].Content)
+}
+
+func TestSendToDriver_EnsuresLastMessageIsUser_EmptyHistory(t *testing.T) {
+	store := newMockStore(nil)
+	agentA := config.Agent{
+		Name:         "a",
+		Driver:       "openai",
+		Engine:       "gpt-4",
+		SystemPrompt: "sys prompt",
+	}
+	store.cfg.DataSet.Agents["a"] = agentA
+
+	s := &AgentSession{
+		store:      store,
+		Agent:      &agentA,
+		ID:         "test-session",
+		CurrentMsg: &dipper.Message{Labels: map[string]string{}, Payload: map[string]interface{}{"text": "input"}},
+		history:    []AgentMessage{},
+		Type:       AgentSessionTypeChatTurn,
+	}
+
+	s.sendToDriver()
+
+	assert.True(t, store.hasCall("driver:openai:send_to_model"))
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	driverHistory := params["history"].([]AgentMessage)
+
+	// Even with empty history, system prompt is added first, making last message
+	// a system message (not user), so "Please continue." is appended.
+	require.Len(t, driverHistory, 2)
+	assert.Equal(t, RoleSystem, driverHistory[0].Role)
+	assert.Equal(t, "sys prompt", driverHistory[0].Content)
+	assert.Equal(t, RoleUser, driverHistory[1].Role)
+	assert.Equal(t, "Please continue.", driverHistory[1].Content)
+}


### PR DESCRIPTION
Fixes issue where some AI models reject requests with "assistant message prefill not supported" errors when the last message in history is from the assistant, tool, or system.

## Changes

### `internal/agent/agent_session.go`
Modified `sendToDriver()` to check if the last message in the history (system prompt + conversation history) is a user message. If not, append a "Please continue." user message to prompt the model to continue its response.

```go
// Ensure the last message is a user message to avoid "assistant message prefill not supported" errors.
// Some models reject requests where the last message is from the assistant (agent), tool, or system.
if len(history) > 0 && history[len(history)-1].Role != RoleUser {
    history = append(history, AgentMessage{Role: RoleUser, Content: "Please continue."})
}
```

### `internal/agent/agent_test.go`
Added comprehensive unit tests covering:
- `TestSendToDriver_EnsuresLastMessageIsUser_AgentLast` - Agent message as last (incomplete response)
- `TestSendToDriver_EnsuresLastMessageIsUser_ToolLast` - Tool message as last
- `TestSendToDriver_EnsuresLastMessageIsUser_SystemLast` - System message as last (legacy)
- `TestSendToDriver_EnsuresLastMessageIsUser_UserLast_NoExtra` - User message as last (no extra message added)
- `TestSendToDriver_EnsuresLastMessageIsUser_EmptyHistory` - Empty history (system prompt + "Please continue.")

All tests pass and linting is clean.