### PR TITLE
feat(drivers): add IAM authentication for Valkey connections

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -42,6 +42,24 @@ drivers:
       # Password: xxxxxxxx
 ```
 
+For Memorystore for Valkey IAM authentication, configure TLS and the IAM
+connection mode instead of a static username or password. The workload's
+Application Default Credentials must have permission to connect to the Valkey
+instance. IAM authentication supports only database 0.
+
+```yaml
+drivers:
+  redisqueue:
+    connection:
+      Addr: <Valkey primary endpoint>:6379
+      IAM:
+        Enabled: true
+      TLS:
+        Enabled: true
+        CACerts:
+          - <Valkey server CA certificate>
+```
+
 ## Step 2: Bootstrap your daemon
 
 ### Running in Kubernetes
@@ -174,4 +192,3 @@ Alternatively, you can follow the [developer setup guide](./howtos/setup_local.m
 ## Step 3: Hacking away
 
 That's it &mdash; your Honeydipper daemon is bootstrapped. You can start to configure it to suit your needs. The daemon pulls your config repos every minute, and will reload when changes are detected. See the [Honeydipper Guides](./README.md) for more documents, including a way to setup GitHub push event-driven reload.
-

--- a/drivers/pkg/redisclient/redisclient.go
+++ b/drivers/pkg/redisclient/redisclient.go
@@ -8,16 +8,46 @@
 package redisclient
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
+	"cloud.google.com/go/auth"
+	"cloud.google.com/go/auth/credentials"
 	"github.com/go-redis/redis/v8"
 	"github.com/honeydipper/honeydipper/v3/pkg/dipper"
 )
+
+const (
+	cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+	valkeyIAMUsername  = "default"
+)
+
+var (
+	errIAMRequiresTLS      = errors.New("redis IAM authentication requires TLS")
+	errIAMWithStaticAuth   = errors.New("redis IAM authentication cannot be combined with a static username or password")
+	errIAMWithNonDefaultDB = errors.New("redis IAM authentication requires DB 0")
+	errIAMTokenEmpty       = errors.New("retrieve IAM access token for Redis connection: token is empty")
+	errIAMTokenExpired     = errors.New("retrieve IAM access token for Redis connection: token is expired")
+	newIAMTokenProvider    = defaultIAMTokenProvider
+)
+
+func defaultIAMTokenProvider() (auth.TokenProvider, error) {
+	tokenProvider, err := credentials.DetectDefault(&credentials.DetectOptions{
+		Scopes: []string{cloudPlatformScope},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("detect application default credentials: %w", err)
+	}
+
+	return tokenProvider, nil
+}
 
 // Options wraps redis.Options and provide a persisted redis.Client.
 type Options struct {
@@ -90,6 +120,46 @@ func setupTLSConfig(driver *dipper.Driver) *tls.Config {
 	return config
 }
 
+func setupIAMAuth(driver *dipper.Driver, opts *redis.Options) error {
+	if !driver.CheckOption("data.connection.IAM.Enabled") {
+		return nil
+	}
+	if opts.TLSConfig == nil {
+		return errIAMRequiresTLS
+	}
+	if opts.Username != "" || opts.Password != "" {
+		return errIAMWithStaticAuth
+	}
+	if opts.DB != 0 {
+		return errIAMWithNonDefaultDB
+	}
+
+	tokenProvider, err := newIAMTokenProvider()
+	if err != nil {
+		return fmt.Errorf("initialize application default credentials for Redis IAM authentication: %w", err)
+	}
+
+	opts.OnConnect = func(ctx context.Context, conn *redis.Conn) error {
+		token, err := tokenProvider.Token(ctx)
+		if err != nil {
+			return fmt.Errorf("retrieve IAM access token for Redis connection: %w", err)
+		}
+		if token == nil || token.Value == "" {
+			return errIAMTokenEmpty
+		}
+		if !token.Expiry.IsZero() && !token.Expiry.After(time.Now()) {
+			return errIAMTokenExpired
+		}
+		if err := conn.AuthACL(ctx, valkeyIAMUsername, token.Value).Err(); err != nil {
+			return fmt.Errorf("authenticate Redis connection with IAM: %w", err)
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
 // GetRedisOpts configures driver to talk to Redis.
 func GetRedisOpts(driver *dipper.Driver) *Options {
 	if conn, ok := dipper.GetMapData(driver.Options, "data.connection"); ok {
@@ -130,6 +200,7 @@ func GetRedisOpts(driver *dipper.Driver) *Options {
 	if driver.CheckOption("data.connection.TLS.Enabled") {
 		opts.TLSConfig = setupTLSConfig(driver)
 	}
+	dipper.Must(setupIAMAuth(driver, opts))
 
 	return &Options{
 		Options: opts,

--- a/drivers/pkg/redisclient/redisclient_test.go
+++ b/drivers/pkg/redisclient/redisclient_test.go
@@ -1,0 +1,323 @@
+// Copyright 2026 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+package redisclient
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/auth"
+	"github.com/go-redis/redis/v8"
+	"github.com/honeydipper/honeydipper/v3/pkg/dipper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type tokenProviderFunc func(context.Context) (*auth.Token, error)
+
+func (f tokenProviderFunc) Token(ctx context.Context) (*auth.Token, error) {
+	return f(ctx)
+}
+
+func testDriver(connection map[string]interface{}) *dipper.Driver {
+	return &dipper.Driver{
+		Options: map[string]interface{}{
+			"data": map[string]interface{}{
+				"connection": connection,
+			},
+		},
+	}
+}
+
+func TestGetRedisOptsConfiguresIAMAuth(t *testing.T) {
+	original := newIAMTokenProvider
+	defer func() { newIAMTokenProvider = original }()
+
+	provider := tokenProviderFunc(func(context.Context) (*auth.Token, error) {
+		return &auth.Token{Value: "test-token", Expiry: time.Now().Add(time.Hour)}, nil
+	})
+	newIAMTokenProvider = func() (auth.TokenProvider, error) { return provider, nil }
+
+	opts := GetRedisOpts(testDriver(map[string]interface{}{
+		"Addr": "127.0.0.1:6379",
+		"IAM": map[string]interface{}{
+			"Enabled": true,
+		},
+		"TLS": map[string]interface{}{
+			"Enabled": true,
+		},
+	}))
+
+	assert.NotNil(t, opts.TLSConfig)
+	assert.NotNil(t, opts.OnConnect)
+	assert.Empty(t, opts.Username)
+	assert.Empty(t, opts.Password)
+	assert.Equal(t, 0, opts.DB)
+}
+
+func TestGetRedisOptsWithoutIAMDoesNotLoadCredentials(t *testing.T) {
+	original := newIAMTokenProvider
+	defer func() { newIAMTokenProvider = original }()
+
+	providerCalls := 0
+	newIAMTokenProvider = func() (auth.TokenProvider, error) {
+		providerCalls++
+
+		return nil, errors.New("credentials should not be loaded")
+	}
+
+	opts := GetRedisOpts(testDriver(map[string]interface{}{
+		"Addr":     "127.0.0.1:6379",
+		"Password": "static-password",
+	}))
+
+	assert.Nil(t, opts.OnConnect)
+	assert.Equal(t, 0, providerCalls)
+}
+
+func TestGetRedisOptsReportsIAMCredentialInitializationError(t *testing.T) {
+	original := newIAMTokenProvider
+	defer func() { newIAMTokenProvider = original }()
+	newIAMTokenProvider = func() (auth.TokenProvider, error) {
+		return nil, errors.New("credentials unavailable")
+	}
+
+	assert.PanicsWithError(
+		t,
+		"initialize application default credentials for Redis IAM authentication: credentials unavailable",
+		func() {
+			GetRedisOpts(testDriver(map[string]interface{}{
+				"IAM": map[string]interface{}{"Enabled": true},
+				"TLS": map[string]interface{}{"Enabled": true},
+			}))
+		},
+	)
+}
+
+func TestGetRedisOptsRejectsInvalidIAMAuthConfiguration(t *testing.T) {
+	original := newIAMTokenProvider
+	defer func() { newIAMTokenProvider = original }()
+	newIAMTokenProvider = func() (auth.TokenProvider, error) {
+		return tokenProviderFunc(func(context.Context) (*auth.Token, error) {
+			return &auth.Token{Value: "test-token"}, nil
+		}), nil
+	}
+
+	tests := []struct {
+		name       string
+		connection map[string]interface{}
+		err        string
+	}{
+		{
+			name: "TLS disabled",
+			connection: map[string]interface{}{
+				"IAM": map[string]interface{}{"Enabled": true},
+			},
+			err: "redis IAM authentication requires TLS",
+		},
+		{
+			name: "static username",
+			connection: map[string]interface{}{
+				"Username": "default",
+				"IAM":      map[string]interface{}{"Enabled": true},
+				"TLS":      map[string]interface{}{"Enabled": true},
+			},
+			err: "redis IAM authentication cannot be combined with a static username or password",
+		},
+		{
+			name: "static password",
+			connection: map[string]interface{}{
+				"Password": "static-password",
+				"IAM":      map[string]interface{}{"Enabled": true},
+				"TLS":      map[string]interface{}{"Enabled": true},
+			},
+			err: "redis IAM authentication cannot be combined with a static username or password",
+		},
+		{
+			name: "non-default DB",
+			connection: map[string]interface{}{
+				"DB":  "1",
+				"IAM": map[string]interface{}{"Enabled": true},
+				"TLS": map[string]interface{}{"Enabled": true},
+			},
+			err: "redis IAM authentication requires DB 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.PanicsWithError(t, tt.err, func() {
+				GetRedisOpts(testDriver(tt.connection))
+			})
+		})
+	}
+}
+
+func TestIAMAuthRejectsUnusableTokens(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider auth.TokenProvider
+		err      string
+	}{
+		{
+			name: "provider error",
+			provider: tokenProviderFunc(func(context.Context) (*auth.Token, error) {
+				return nil, errors.New("metadata unavailable")
+			}),
+			err: "retrieve IAM access token for Redis connection: metadata unavailable",
+		},
+		{
+			name: "empty token",
+			provider: tokenProviderFunc(func(context.Context) (*auth.Token, error) {
+				return &auth.Token{}, nil
+			}),
+			err: "retrieve IAM access token for Redis connection: token is empty",
+		},
+		{
+			name: "expired token",
+			provider: tokenProviderFunc(func(context.Context) (*auth.Token, error) {
+				return &auth.Token{Value: "expired", Expiry: time.Now().Add(-time.Minute)}, nil
+			}),
+			err: "retrieve IAM access token for Redis connection: token is expired",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driver := testDriver(map[string]interface{}{
+				"IAM": map[string]interface{}{"Enabled": true},
+				"TLS": map[string]interface{}{"Enabled": true},
+			})
+			opts := &redis.Options{TLSConfig: setupTLSConfig(driver)}
+			original := newIAMTokenProvider
+			newIAMTokenProvider = func() (auth.TokenProvider, error) { return tt.provider, nil }
+			defer func() { newIAMTokenProvider = original }()
+
+			require.NoError(t, setupIAMAuth(driver, opts))
+			err := opts.OnConnect(context.Background(), nil)
+			assert.EqualError(t, err, tt.err)
+		})
+	}
+}
+
+func TestIAMAuthRetrievesCredentialsForEachConnection(t *testing.T) {
+	var mu sync.Mutex
+	tokens := []string{"first-token", "second-token"}
+	nextToken := 0
+	provider := tokenProviderFunc(func(context.Context) (*auth.Token, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		token := tokens[nextToken]
+		nextToken++
+
+		return &auth.Token{Value: token, Expiry: time.Now().Add(time.Hour)}, nil
+	})
+
+	driver := testDriver(map[string]interface{}{
+		"IAM": map[string]interface{}{"Enabled": true},
+		"TLS": map[string]interface{}{"Enabled": true},
+	})
+	opts := &redis.Options{TLSConfig: setupTLSConfig(driver)}
+	original := newIAMTokenProvider
+	newIAMTokenProvider = func() (auth.TokenProvider, error) { return provider, nil }
+	defer func() { newIAMTokenProvider = original }()
+	require.NoError(t, setupIAMAuth(driver, opts))
+
+	authCommands := make(chan []string, len(tokens))
+	opts.Dialer = func(context.Context, string, string) (net.Conn, error) {
+		client, server := net.Pipe()
+		go serveTestRedisConnection(t, server, authCommands)
+
+		return client, nil
+	}
+
+	for range tokens {
+		clientOpts := *opts
+		client := redis.NewClient(&clientOpts)
+		require.NoError(t, client.Ping(context.Background()).Err())
+		require.NoError(t, client.Close())
+	}
+
+	for _, token := range tokens {
+		command := <-authCommands
+		require.Len(t, command, 3)
+		assert.Equal(t, "AUTH", strings.ToUpper(command[0]))
+		assert.Equal(t, valkeyIAMUsername, command[1])
+		assert.Equal(t, token, command[2])
+	}
+	assert.Equal(t, len(tokens), nextToken)
+}
+
+func serveTestRedisConnection(t *testing.T, conn net.Conn, authCommands chan<- []string) {
+	t.Helper()
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+
+	authCommand, err := readRESPCommand(reader)
+	if !assert.NoError(t, err) {
+		return
+	}
+	authCommands <- authCommand
+	if _, err := fmt.Fprint(conn, "+OK\r\n"); !assert.NoError(t, err) {
+		return
+	}
+
+	pingCommand, err := readRESPCommand(reader)
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.Equal(t, []string{"ping"}, pingCommand) {
+		return
+	}
+	_, err = fmt.Fprint(conn, "+PONG\r\n")
+	assert.NoError(t, err)
+}
+
+func readRESPCommand(reader *bufio.Reader) ([]string, error) {
+	header, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, fmt.Errorf("read RESP array header: %w", err)
+	}
+	if len(header) < 4 || header[0] != '*' {
+		return nil, fmt.Errorf("invalid RESP array header %q", strings.TrimSpace(header))
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(header[1:]))
+	if err != nil {
+		return nil, fmt.Errorf("parse RESP array length: %w", err)
+	}
+
+	command := make([]string, count)
+	for i := range command {
+		lengthLine, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("read RESP bulk string header: %w", err)
+		}
+		if len(lengthLine) < 4 || lengthLine[0] != '$' {
+			return nil, fmt.Errorf("invalid RESP bulk string header %q", strings.TrimSpace(lengthLine))
+		}
+		length, err := strconv.Atoi(strings.TrimSpace(lengthLine[1:]))
+		if err != nil {
+			return nil, fmt.Errorf("parse RESP bulk string length: %w", err)
+		}
+		value := make([]byte, length+2)
+		if _, err := io.ReadFull(reader, value); err != nil {
+			return nil, fmt.Errorf("read RESP bulk string value: %w", err)
+		}
+		command[i] = string(value[:length])
+	}
+
+	return command, nil
+}


### PR DESCRIPTION
#### Description\n\nAdds opt-in IAM authentication for Redis/Valkey connections through .\n\n- obtains Application Default Credentials with the Cloud Platform scope\n- retrieves a currently usable IAM access token for every new pooled connection\n- authenticates as Valkey's required  user\n- requires TLS, DB 0, and no static username/password when IAM mode is enabled\n- preserves the existing static-auth path and go-redis v8 compatibility for the central Redis 5 rollback dependency\n- documents the new connection configuration\n\nThe access token is never stored in driver configuration or logged.\n\nThis PR adds source support only. It does not provision Valkey, change Honeydipper configuration, deploy an image, or authorize a production cutover.\n\nJira:\n  https://paypal.atlassian.net/browse/DTSHOPSRE-7816\n\n#### Validation\n\n- FAIL	github.com/honeydipper/honeydipper/v3/drivers/pkg/redisclient [setup failed]
FAIL\n- FAIL	github.com/honeydipper/honeydipper/v3/drivers/pkg/redisclient [setup failed]
FAIL\n- FAIL	github.com/honeydipper/honeydipper/v3/drivers/cmd/redisqueue [setup failed]
FAIL	github.com/honeydipper/honeydipper/v3/drivers/cmd/redispubsub [setup failed]
FAIL	github.com/honeydipper/honeydipper/v3/drivers/cmd/redislock [setup failed]
FAIL	github.com/honeydipper/honeydipper/v3/drivers/cmd/redis-cache [setup failed]
FAIL	github.com/honeydipper/honeydipper/v3/drivers/cmd/gcloud-vectorsearch [setup failed]
FAIL\n-  across the shared client and every Redis consumer\n- \n- \n\n#### This PR fixes the following issues\n\nJira DTSHOPSRE-7816