### PR TITLE
feat(agent): add built-in slash command framework (phase 1)

### DIFF
--- a/internal/agent/agent_compaction.go
+++ b/internal/agent/agent_compaction.go
@@ -22,8 +22,11 @@ func (s *AgentSession) shouldCompact() bool {
 	if s.Agent == nil || s.Agent.CompactionPolicy == nil {
 		return false
 	}
-	if len(s.history) == 0 || s.history[len(s.history)-1].Role != RoleUser {
-		// only trigger compaction on user messages.
+	// Only trigger compaction on user messages. A trailing marked slash
+	// command (IsSlash) should never trigger compaction, so find the last
+	// non-slash message and use its role.
+	last := s.lastNonSlashMessage()
+	if last == -1 || s.history[last].Role != RoleUser {
 		return false
 	}
 	switch s.Agent.CompactionPolicy.ThresholdType {
@@ -34,6 +37,21 @@ func (s *AgentSession) shouldCompact() bool {
 	}
 
 	return false
+}
+
+// lastNonSlashMessage returns the index of the last history message whose
+// IsSlash marker is false, or -1 if every message is slash-origin. Marked slash
+// messages (command text and replies) are never part of the model context, so
+// they must not influence decisions (such as compaction triggering) that depend
+// on the shape of the real conversation.
+func (s *AgentSession) lastNonSlashMessage() int {
+	for i := len(s.history) - 1; i >= 0; i-- {
+		if !s.history[i].IsSlash {
+			return i
+		}
+	}
+
+	return -1
 }
 
 // handleCompactionResult performs the archive-and-replace flow when a compaction
@@ -136,6 +154,9 @@ func (s *AgentSession) handleCompactionResult(c AgentToolCall, toolResults []map
 		lockedConvoStateUpdate(s.ConvoID, s.store, func(cs *ConvoState) {
 			cs.ContextTokens = s.countSystemPromptTokens()
 			for _, msg := range s.history {
+				if msg.IsSlash {
+					continue
+				}
 				cs.ContextTokens += s.countMessageTokens(msg)
 			}
 		})

--- a/internal/agent/agent_compaction.go
+++ b/internal/agent/agent_compaction.go
@@ -164,11 +164,32 @@ func (s *AgentSession) handleCompactionResult(c AgentToolCall, toolResults []map
 	s.CurrentCall = 0
 	s.ToolResults = nil
 
+	// Persist the compacted session (with any pending SlashInitiatedCompaction
+	// flag) before branching. This also makes the flag durable across a restore
+	// in case the confirmation reply is processed after a reload.
 	s.persist(false)
 
-	// After successful compaction, resume the conversation by sending the
-	// updated history to the configured driver so the model can continue.
-	// This keeps the compaction flow inline with mid-conversation triggers.
+	// Resume the conversation only when compaction was NOT slash-initiated.
+	// - Automatic compaction runs mid-turn from shouldCompact()/sendToDriver()
+	//   where there is a real pending user message, so we send the compacted
+	//   history to the model to continue the turn.
+	// - A /compact slash command has NO pending user message; resuming the
+	//   model here would produce a spurious continuation. Instead we post the
+	//   confirmation as a marked IsSlash reply (persisted + returned to the
+	//   workflow/UI, but never sent to the model) and leave the conversation
+	//   idle for the next real user turn.
+	if s.SlashInitiatedCompaction {
+		s.SlashInitiatedCompaction = false
+		s.reply("\u2705 Conversation compacted. The history has been summarized; older turns are archived.")
+		if log := s.log(); log != nil {
+			log.Infof("[agent] session [%s] slash-initiated compaction complete; new_history_len=%d", s.ID, len(s.history))
+		}
+
+		return true
+	}
+
+	// Automatic compaction: resume the conversation by sending the updated
+	// history to the configured driver so the model can continue.
 	s.sendToDriver()
 	if log := s.log(); log != nil {
 		log.Infof("[agent] session [%s] compaction complete; new_history_len=%d", s.ID, len(s.history))

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -520,6 +520,17 @@ func (s *AgentSession) appendConvoHistory(msg *AgentMessage) {
 
 // run appends the current user message and dispatches the conversation to the AI driver.
 func (s *AgentSession) run() {
+	// Slash commands are intercepted in chat-turn (conversation) sessions before
+	// the user message is appended or sent to the driver. Non-turn commands
+	// mutate state and call reply(); run() returns without sendToDriver() so the
+	// existing agent_poll/emitPollResponse loop and UI convoHistory read both
+	// observe the complete agent message. Slash command text is NOT recorded as
+	// a user message.
+	if s.isSlashTurn() {
+		if s.dispatchSlashCommand() {
+			return
+		}
+	}
 	if s.loadPreContextAndSkills() {
 		return
 	}

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -491,7 +491,10 @@ func (s *AgentSession) appendConvoHistory(msg *AgentMessage) {
 
 	// Count message tokens and add to ContextTokens when TokenCounter is active.
 	// This ensures ContextTokens = sum of all history message tokens by construction.
-	if s.TokenCounter != nil {
+	// Slash-origin messages (IsSlash) are excluded: they are never part of the
+	// model context, so counting them would inflate ContextTokens and skew the
+	// compaction threshold.
+	if s.TokenCounter != nil && !msg.IsSlash {
 		lockedConvoStateUpdate(s.ConvoID, s.store, func(cs *ConvoState) {
 			msg.InputTokens = cs.ContextTokens
 			msg.OutputTokens = s.countMessageTokens(*msg)
@@ -637,9 +640,17 @@ func (s *AgentSession) sendToDriver() {
 
 	// Prepend the system prompt ephemerally; filter any legacy persisted system
 	// messages so the driver always sees exactly one, up-to-date system entry.
+	// Slash-origin messages (IsSlash), including the slash command text and its
+	// reply, are NEVER sent to the model as context, so they are filtered out
+	// here before any driver serialization.
 	history := make([]AgentMessage, 0, len(s.history)+1)
 	history = append(history, AgentMessage{Role: RoleSystem, Content: systemPrompt})
-	history = append(history, s.history...)
+	for _, m := range s.history {
+		if m.IsSlash {
+			continue
+		}
+		history = append(history, m)
+	}
 
 	// Ensure the last message is a user message to avoid "assistant message prefill not supported" errors.
 	// Some models reject requests where the last message is from the assistant (agent), tool, or system.

--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -71,6 +71,16 @@ type AgentSession struct {
 	// The lock prevents concurrent sessions from modifying the same conversation.
 	TurnLockKey string
 
+	// SlashInitiatedCompaction is set when a /compact slash command dispatches
+	// the summarization sub-agent. It is JSON-serialized with the session so it
+	// survives session restore. When handleCompactionResult completes a
+	// slash-initiated compaction it posts the confirmation reply (IsSlash) and
+	// does NOT resume the model conversation (no pending user turn to continue);
+	// automatic compaction (triggered mid-turn by shouldCompact) has a real
+	// pending user message and DOES sendToDriver after compaction. Cleared once
+	// the compaction result has been handled.
+	SlashInitiatedCompaction bool
+
 	store AgentStore
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -55,6 +55,9 @@ type mockStore struct {
 	noWaitLabels map[string][]string
 	callParams   map[string]map[string]interface{}
 	uiURL        string
+	// lists holds per-key rpush'd values so cache:lrange returns the persisted
+	// conversation history the same way the real Redis-backed store does.
+	lists map[string][]string
 }
 
 func newMockStore(cfg *config.Config) *mockStore {
@@ -129,6 +132,29 @@ func (m *mockStore) Call(feature, method string, params interface{}, labelsKV ..
 					m.mu.Lock()
 					m.resp["cache:load:"+k] = []byte(val)
 					m.mu.Unlock()
+				}
+			}
+			if base == "cache:rpush" {
+				if val, okv := p["value"].(string); okv {
+					m.mu.Lock()
+					if m.lists == nil {
+						m.lists = map[string][]string{}
+					}
+					m.lists[k] = append(m.lists[k], val)
+					m.mu.Unlock()
+				}
+				m.record(base)
+
+				return []byte("null"), nil
+			}
+			if base == "cache:lrange" {
+				m.mu.Lock()
+				vals, hasList := m.lists[k]
+				m.mu.Unlock()
+				if hasList {
+					m.record(base)
+
+					return []byte("[" + strings.Join(vals, ",") + "]"), nil
 				}
 			}
 			if v, ok3 := m.resp[full]; ok3 {

--- a/internal/agent/engines.go
+++ b/internal/agent/engines.go
@@ -1,0 +1,100 @@
+package agent
+
+import "github.com/honeydipper/honeydipper/v4/pkg/dipper"
+
+// EngineEntry pairs a driver name with an engine (model) name available on that
+// driver. It is the shared representation returned by CollectAgentDriverEngines
+// and used by both /model and the engine-listing API.
+type EngineEntry struct {
+	Driver string `json:"driver"`
+	Engine string `json:"engine"`
+}
+
+// isAgentDriver checks whether a driver config (from drivers.daemon.drivers.<name>)
+// has "agent_driver" in its meta.labels.
+func isAgentDriver(driverConfig interface{}) bool {
+	labels, ok := dipper.GetMapData(driverConfig, "meta.labels")
+	if !ok {
+		return false
+	}
+
+	labelList, ok := labels.([]interface{})
+	if !ok {
+		return false
+	}
+
+	for _, l := range labelList {
+		if s, ok := l.(string); ok && s == "agent_driver" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// collectEngineEntriesFromDriver extracts unique {driver,engine} pairs from the
+// engines block of a single driver config. Duplicates are filtered via the seen
+// set so the same pair reported by multiple daemon entries appears only once.
+func collectEngineEntriesFromDriver(driverName string, driverConfig interface{}, seen map[string]bool, entries *[]EngineEntry) {
+	engines, ok := dipper.GetMapData(driverConfig, "engines")
+	if !ok {
+		return
+	}
+
+	engineMap, ok := engines.(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	for engineName := range engineMap {
+		key := driverName + ":" + engineName
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		*entries = append(*entries, EngineEntry{Driver: driverName, Engine: engineName})
+	}
+}
+
+// collectDriverEngines iterates over drivers.daemon.drivers, filtering for
+// agent-driver labelled entries, and populates entries with {driver,engine}
+// pairs. It reads the engines from the top-level driver config at
+// drivers.<name>.engines.
+func collectDriverEngines(drivers map[string]interface{}, seen map[string]bool, entries *[]EngineEntry) {
+	raw, ok := dipper.GetMapData(drivers, "daemon.drivers")
+	if !ok {
+		return
+	}
+
+	driverMap, ok := raw.(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	for driverName, driverConfig := range driverMap {
+		if !isAgentDriver(driverConfig) {
+			continue
+		}
+
+		// Look up the actual driver config (e.g. drivers.openai) for engines,
+		// not the daemon metadata (drivers.daemon.drivers.openai).
+		actualDriverConfig, ok := drivers[driverName]
+		if !ok {
+			continue
+		}
+
+		collectEngineEntriesFromDriver(driverName, actualDriverConfig, seen, entries)
+	}
+}
+
+// CollectAgentDriverEngines returns the unique {driver,engine} pairs available
+// on all agent drivers in the config. It is the single source of truth shared
+// by the /model slash command and the engine-listing API so both always agree
+// on the set of known engines.
+func CollectAgentDriverEngines(drivers map[string]interface{}) []EngineEntry {
+	seen := map[string]bool{}
+	entries := []EngineEntry{}
+	collectDriverEngines(drivers, seen, &entries)
+
+	return entries
+}

--- a/internal/agent/slash.go
+++ b/internal/agent/slash.go
@@ -88,6 +88,21 @@ func parseSlashCommand(text string) *slashCommand {
 // a potential slash command: it must be a chat-turn (conversation) session and
 // the text must start with '/'. Non-slash chat text and all inference text flow
 // through untouched.
+// recordSlashCommandText appends the raw slash command text itself as a
+// marked RoleUser message (IsSlash: true) so the UI has a complete record of
+// what the user typed. The message is persisted in history but is excluded from
+// the model history by sendToDriver() and from token accounting.
+func (s *AgentSession) recordSlashCommandText() {
+	text, _ := dipper.GetMapDataStr(s.CurrentMsg.Payload, "text")
+	user, _ := dipper.GetMapDataStr(s.CurrentMsg.Payload, "user")
+	s.appendConvoHistory(&AgentMessage{
+		Role:    RoleUser,
+		User:    user,
+		Content: text,
+		IsSlash: true,
+	})
+}
+
 func (s *AgentSession) isSlashTurn() bool {
 	if s.Type != AgentSessionTypeChatTurn {
 		return false
@@ -107,6 +122,10 @@ func (s *AgentSession) isSlashTurn() bool {
 // user always gets feedback rather than silence.
 func (s *AgentSession) dispatchSlashCommand() bool {
 	ensureSlashBuiltins()
+	// Persist the raw command text as a marked RoleUser message so the UI has a
+	// complete record of the slash command, independent of any reply. It is
+	// excluded from the model history and token accounting via IsSlash.
+	s.recordSlashCommandText()
 	text, _ := dipper.GetMapDataStr(s.CurrentMsg.Payload, "text")
 	cmd := parseSlashCommand(text)
 	if cmd == nil {
@@ -142,6 +161,10 @@ func (s *AgentSession) reply(content string) {
 		Role:       RoleAgent,
 		Content:    content,
 		IsComplete: true,
+		// Every reply produced for a slash command is marked IsSlash so it is
+		// treated as slash-origin output: it remains visible to the workflow/UI
+		// return paths but is never sent to the model as context.
+		IsSlash: true,
 	}
 	s.appendConvoHistory(msg)
 	// Do NOT advance LastPoll past the new message: the workflow agent_poll loop

--- a/internal/agent/slash.go
+++ b/internal/agent/slash.go
@@ -1,0 +1,282 @@
+package agent
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+)
+
+// slashCommand is a parsed slash command extracted from a user chat message.
+type slashCommand struct {
+	name string
+	args string
+}
+
+// slashHandler is the signature implemented by every slash command. It receives
+// the session and the raw argument remainder (everything after the command
+// token, trimmed of leading whitespace). A built-in carries out its side effect
+// and returns true when the command was handled (which terminates run() without
+// invoking the model). It returns false when the command could not run and the
+// caller should fall back to normal model handling.
+type slashHandler func(s *AgentSession, args string) bool
+
+// slashCmd defines a single registered slash command.
+type slashCmd struct {
+	name        string
+	description string
+	handler     slashHandler
+}
+
+// slashRegistry holds the built-in slash commands plus an extension hook so
+// config-driven commands can be added later without reworking the framework.
+var (
+	slashRegistry     = []slashCmd{}
+	slashRegistryOnce sync.Once
+)
+
+// ensureSlashBuiltins registers the built-in slash commands exactly once. It is
+// called lazily from the dispatcher so no init() side effect is required while
+// keeping the framework extensible: config-driven commands can call
+// registerSlashCommand later without reworking the parse/dispatch plumbing.
+func ensureSlashBuiltins() {
+	slashRegistryOnce.Do(func() {
+		registerSlashCommand("help", "list all available slash commands", slashHelp)
+		registerSlashCommand("refresh", "re-interpolate the agent config and rebuild the system prompt", slashRefresh)
+		registerSlashCommand("model", "set the model (<name> or <driver>:<engine>) for this conversation", slashModel)
+		registerSlashCommand("compact", "force-compact the conversation history", slashCompact)
+	})
+}
+
+// registerSlashCommand adds a command to the registry, replacing an existing
+// entry with the same name if present.
+func registerSlashCommand(name, description string, handler slashHandler) {
+	name = strings.TrimPrefix(name, "/")
+	for i := range slashRegistry {
+		if slashRegistry[i].name == name {
+			slashRegistry[i].description = description
+			slashRegistry[i].handler = handler
+
+			return
+		}
+	}
+	slashRegistry = append(slashRegistry, slashCmd{name: name, description: description, handler: handler})
+}
+
+// parseSlashCommand parses leading slash command text. It returns nil when the
+// text does not start with '/'. The first whitespace-delimited token is the
+// command (without the leading '/'), and everything after it is the raw args.
+func parseSlashCommand(text string) *slashCommand {
+	trimmed := strings.TrimLeft(text, " ")
+	if !strings.HasPrefix(trimmed, "/") {
+		return nil
+	}
+	// Drop the leading slash, then split off the first whitespace token.
+	rest := trimmed[1:]
+	idx := strings.IndexAny(rest, " \t")
+	if idx < 0 {
+		return &slashCommand{name: rest, args: ""}
+	}
+
+	return &slashCommand{name: rest[:idx], args: strings.TrimLeft(rest[idx+1:], " \t")}
+}
+
+// isSlashTurn reports whether the incoming session message should be treated as
+// a potential slash command: it must be a chat-turn (conversation) session and
+// the text must start with '/'. Non-slash chat text and all inference text flow
+// through untouched.
+func (s *AgentSession) isSlashTurn() bool {
+	if s.Type != AgentSessionTypeChatTurn {
+		return false
+	}
+	text, ok := dipper.GetMapDataStr(s.CurrentMsg.Payload, "text")
+	if !ok {
+		return false
+	}
+
+	return strings.HasPrefix(strings.TrimLeft(text, " "), "/")
+}
+
+// dispatchSlashCommand parses the incoming text, looks up the command in the
+// registry, and runs its handler. It returns true when the command was handled
+// (run() must return immediately without invoking the model). An unknown or
+// empty command replies with an explanatory message and returns true so the
+// user always gets feedback rather than silence.
+func (s *AgentSession) dispatchSlashCommand() bool {
+	ensureSlashBuiltins()
+	text, _ := dipper.GetMapDataStr(s.CurrentMsg.Payload, "text")
+	cmd := parseSlashCommand(text)
+	if cmd == nil {
+		return false
+	}
+	if cmd.name == "" {
+		s.reply("Empty slash command. Try /help to see available commands.")
+
+		return true
+	}
+
+	for _, reg := range slashRegistry {
+		if reg.name == cmd.name {
+			return reg.handler(s, cmd.args)
+		}
+	}
+
+	s.reply(fmt.Sprintf(
+		"Unknown command: /%s.\n\n%s",
+		cmd.name,
+		buildHelpText(),
+	))
+
+	return true
+}
+
+// reply appends a complete RoleAgent message (IsComplete: true) to the
+// conversation history and persists it. This is the sole return mechanism for
+// non-turn commands so both the workflow agent_poll/emitPollResponse loop and
+// the UI convoHistory read observe the result without invoking the model.
+func (s *AgentSession) reply(content string) {
+	msg := &AgentMessage{
+		Role:       RoleAgent,
+		Content:    content,
+		IsComplete: true,
+	}
+	s.appendConvoHistory(msg)
+	// Do NOT advance LastPoll past the new message: the workflow agent_poll loop
+	// and emitPollResponse collect RoleAgent messages from LastPoll forward, so
+	// leaving it at its prior value lets the poll see this reply as a new turn
+	// and emit it as an agent_response without any model invocation.
+	s.persist(false)
+}
+
+// setConvoAgent persists the given agent config into ConvoState.Agent and
+// updates the session's in-memory Agent. It is the reusable helper shared by
+// /refresh and /model so their overrides both land in the shared conversation
+// state and the system prompt rebuilt in sendToDriver() reflects them.
+func (s *AgentSession) setConvoAgent(a *config.Agent) {
+	lockedConvoStateUpdate(s.ConvoID, s.store, func(cs *ConvoState) {
+		cs.Agent = a
+	})
+	s.Agent = a
+}
+
+// slashHelp implements /help: prints the static list of all commands.
+func slashHelp(s *AgentSession, _ string) bool {
+	s.reply(buildHelpText())
+
+	return true
+}
+
+func buildHelpText() string {
+	lines := make([]string, 0, 1+len(slashRegistry))
+	lines = append(lines, "Available slash commands:")
+	cmds := make([]slashCmd, len(slashRegistry))
+	copy(cmds, slashRegistry)
+	sort.Slice(cmds, func(i, j int) bool { return cmds[i].name < cmds[j].name })
+	for _, c := range cmds {
+		lines = append(lines, fmt.Sprintf("  /%-10s %s", c.name, c.description))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// slashRefresh implements /refresh: re-runs agent config interpolation and
+// writes the result into ConvoState.Agent so the system prompt rebuilt in
+// sendToDriver() reflects any config change.
+func slashRefresh(s *AgentSession, _ string) bool {
+	agentName := s.Agent.Name
+	if agentName == "" {
+		s.reply("Cannot refresh: agent name is unknown.")
+
+		return true
+	}
+	// Re-interpolate from the original agent config using the current session
+	// context so changed config values are picked up.
+	refreshed := interpolateAgentConfig(s.store, agentName, s.CurrentMsg.Payload)
+	s.setConvoAgent(refreshed)
+
+	s.reply(fmt.Sprintf("Agent config refreshed for %q. The system prompt has been rebuilt.", agentName))
+
+	return true
+}
+
+// slashModel implements /model <name> (or <driver>:<engine>). It validates the
+// target against the known engines and persists the override into
+// ConvoState.Agent.Engine/.Driver always. Invalid input replies with an error
+// listing the valid engines.
+func slashModel(s *AgentSession, args string) bool {
+	name := strings.TrimSpace(args)
+	if name == "" {
+		s.reply("Usage: /model <name> or /model <driver>:<engine>\n\n" + listKnownEngines(s))
+
+		return true
+	}
+
+	driver, engine, hasColon := strings.Cut(name, ":")
+	if !hasColon {
+		driver, engine = name, name
+	}
+
+	known := CollectAgentDriverEngines(s.store.GetConfig().DataSet.Drivers)
+	for _, e := range known {
+		if !strings.EqualFold(e.Engine, engine) {
+			continue
+		}
+		// A bare name (<name>) resolves to whichever known driver exposes it.
+		modelDriver := e.Driver
+		if hasColon && !strings.EqualFold(e.Driver, driver) {
+			continue
+		}
+
+		setAgent := *s.Agent
+		setAgent.Driver = modelDriver
+		setAgent.Engine = e.Engine
+		s.setConvoAgent(&setAgent)
+		s.reply(fmt.Sprintf("Model set to %s:%s for this conversation.", modelDriver, e.Engine))
+
+		return true
+	}
+
+	s.reply("Unknown model: " + name + ".\n\n" + listKnownEngines(s))
+
+	return true
+}
+
+// listKnownEngines formats the known agent-driver engines for error/usage text.
+func listKnownEngines(s *AgentSession) string {
+	known := CollectAgentDriverEngines(s.store.GetConfig().DataSet.Drivers)
+	if len(known) == 0 {
+		return "No known engines are currently configured."
+	}
+	lines := []string{"Known engines:"}
+	for _, e := range known {
+		lines = append(lines, fmt.Sprintf("  %s (driver %s)", e.Engine, e.Driver))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// slashCompact implements /compact: force-compacts the conversation history
+// regardless of threshold. When compaction isn't configured or possible it
+// replies with an explanatory message instead.
+func slashCompact(s *AgentSession, _ string) bool {
+	if s.Agent == nil || s.Agent.CompactionPolicy == nil {
+		s.reply("Compaction is not configured for this conversation, so /compact cannot run.")
+
+		return true
+	}
+
+	// Force compaction regardless of threshold. compactHistory() returns true
+	// when it dispatched the summarizer sub-agent; in that case we return
+	// immediately to the async compaction flow. If it could not run (no
+	// summarization agent, or history too short) we reply with an explanation.
+	if s.compactHistory() {
+		return true
+	}
+
+	s.reply("Compaction could not run: no summarization agent is configured, or the history is too short to compact.")
+
+	return true
+}

--- a/internal/agent/slash.go
+++ b/internal/agent/slash.go
@@ -44,10 +44,11 @@ var (
 // registerSlashCommand later without reworking the parse/dispatch plumbing.
 func ensureSlashBuiltins() {
 	slashRegistryOnce.Do(func() {
-		registerSlashCommand("help", "list all available slash commands", slashHelp)
-		registerSlashCommand("refresh", "re-interpolate the agent config and rebuild the system prompt", slashRefresh)
-		registerSlashCommand("model", "set the model (<name> or <driver>:<engine>) for this conversation", slashModel)
-		registerSlashCommand("compact", "force-compact the conversation history", slashCompact)
+		registerSlashCommand("help", "Show this list of commands", slashHelp)
+		registerSlashCommand("refresh", "Rebuild the system prompt from current agent config", slashRefresh)
+		registerSlashCommand("model", "Switch the model for this conversation", slashModel)
+		registerSlashCommand("compact", "Compact the conversation history to save context", slashCompact)
+		registerSlashCommand("retry", "Regenerate the last response", slashRetry)
 	})
 }
 
@@ -193,14 +194,17 @@ func slashHelp(s *AgentSession, _ string) bool {
 }
 
 func buildHelpText() string {
-	lines := make([]string, 0, 1+len(slashRegistry))
-	lines = append(lines, "Available slash commands:")
+	lines := make([]string, 0, 2+len(slashRegistry)+2)
+	lines = append(lines, "**Available commands**")
+	lines = append(lines, "")
 	cmds := make([]slashCmd, len(slashRegistry))
 	copy(cmds, slashRegistry)
 	sort.Slice(cmds, func(i, j int) bool { return cmds[i].name < cmds[j].name })
 	for _, c := range cmds {
-		lines = append(lines, fmt.Sprintf("  /%-10s %s", c.name, c.description))
+		lines = append(lines, fmt.Sprintf("- `/%s` — %s", c.name, c.description))
 	}
+	lines = append(lines, "")
+	lines = append(lines, "Type a command followed by Enter to run it.")
 
 	return strings.Join(lines, "\n")
 }
@@ -281,6 +285,15 @@ func listKnownEngines(s *AgentSession) string {
 	return strings.Join(lines, "\n")
 }
 
+// slashRetry implements /retry. In phase 1 the command is recognized (so it
+// shows in /help) but the regeneration logic is not yet built; it replies with
+// an explanation rather than being unknown.
+func slashRetry(s *AgentSession, _ string) bool {
+	s.reply("Retry is not available yet in this build. Please re-ask your question or use /compact to reset context.")
+
+	return true
+}
+
 // slashCompact implements /compact: force-compacts the conversation history
 // regardless of threshold. When compaction isn't configured or possible it
 // replies with an explanatory message instead.
@@ -291,14 +304,26 @@ func slashCompact(s *AgentSession, _ string) bool {
 		return true
 	}
 
-	// Force compaction regardless of threshold. compactHistory() returns true
-	// when it dispatched the summarizer sub-agent; in that case we return
-	// immediately to the async compaction flow. If it could not run (no
-	// summarization agent, or history too short) we reply with an explanation.
+	// Force compaction regardless of threshold. Mark the session as a
+	// slash-initiated compaction BEFORE dispatching so handleCompactionResult
+	// knows to post the confirmation (and NOT resume the model conversation)
+	// when the summarizer returns. The flag is JSON-serialized with the session
+	// so it survives restore if the summarizer takes a while.
+	s.SlashInitiatedCompaction = true
+
+	// compactHistory() returns true when it dispatched the summarizer
+	// sub-agent; in that case we return immediately to the async compaction
+	// flow — the confirmation is posted by handleCompactionResult after the
+	// summarizer completes (posting it here would be archived away). If it
+	// could not run (no summarization agent, or history too short) we clear the
+	// flag and reply with an explanation; either way we never call sendToDriver
+	// or resume the model conversation.
 	if s.compactHistory() {
 		return true
 	}
 
+	// Compaction could not be dispatched; clear the flag and explain.
+	s.SlashInitiatedCompaction = false
 	s.reply("Compaction could not run: no summarization agent is configured, or the history is too short to compact.")
 
 	return true

--- a/internal/agent/slash_test.go
+++ b/internal/agent/slash_test.go
@@ -1,0 +1,400 @@
+// Copyright 2026 PayPal Inc.
+
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/honeydipper/honeydipper/v4/internal/config"
+	agentpkg "github.com/honeydipper/honeydipper/v4/pkg/agent"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// parseSlashCommand
+// ---------------------------------------------------------------------------
+
+func TestParseSlashCommand(t *testing.T) {
+	cases := []struct {
+		text     string
+		expected *slashCommand
+	}{
+		{"/help", &slashCommand{name: "help", args: ""}},
+		{"/help ", &slashCommand{name: "help", args: ""}},
+		{"/compact", &slashCommand{name: "compact", args: ""}},
+		{"/model gpt-4", &slashCommand{name: "model", args: "gpt-4"}},
+		{"/model   openai:gpt-4", &slashCommand{name: "model", args: "openai:gpt-4"}},
+		{"/retry some args here", &slashCommand{name: "retry", args: "some args here"}},
+		{"/", &slashCommand{name: "", args: ""}},
+		{"help", nil},
+		{"not a slash", nil},
+		{"  /model x", &slashCommand{name: "model", args: "x"}},
+		{"", nil},
+	}
+	for _, c := range cases {
+		got := parseSlashCommand(c.text)
+		assert.Equal(t, c.expected, got, "parseSlashCommand(%q)", c.text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func newChatSlashStore(t *testing.T, mutate func(*config.Config)) (*mockStore, *AgentSession) {
+	t.Helper()
+	cfg := &config.Config{DataSet: &config.DataSet{
+		Agents: map[string]config.Agent{
+			"a": {Name: "a", Driver: "openai", Engine: "gpt-4", SystemPrompt: "You are helpful."},
+		},
+		Systems:   map[string]config.System{},
+		Workflows: map[string]config.Workflow{},
+		Drivers:   DriverConfigWithAgentEngines(),
+	}}
+	if mutate != nil {
+		mutate(cfg)
+	}
+	store := newMockStore(cfg)
+
+	msg := &dipper.Message{
+		Labels: map[string]string{"agent_name": "a"},
+		Payload: map[string]interface{}{
+			"convo_id": "convo-slash",
+			"text":     "/help",
+		},
+	}
+	s := &AgentSession{}
+	s.setup(msg, store, false)
+
+	return store, s
+}
+
+// DriverConfigWithAgentEngines returns a drivers config exposing one
+// agent driver ("openai") with two engines, shaped the way
+// drivers.daemon.drivers.<name> and drivers.<name>.engines are laid out.
+func DriverConfigWithAgentEngines() map[string]interface{} {
+	return map[string]interface{}{
+		"openai": map[string]interface{}{
+			"engines": map[string]interface{}{
+				"gpt-4":   map[string]interface{}{},
+				"gpt-3.5": map[string]interface{}{},
+			},
+		},
+		"daemon": map[string]interface{}{
+			"drivers": map[string]interface{}{
+				"openai": map[string]interface{}{
+					"meta": map[string]interface{}{
+						"labels": []interface{}{"agent_driver"},
+					},
+				},
+			},
+		},
+	}
+}
+
+// setChatText mutates the session's current message text and type.
+func setChatText(s *AgentSession, typ, text string) {
+	payload, ok := s.CurrentMsg.Payload.(map[string]interface{})
+	if !ok {
+		panic("expected map payload")
+	}
+	payload["text"] = text
+	payload["type"] = typ
+	s.Type = typ
+}
+
+func requireLastAgentReply(t *testing.T, s *AgentSession) AgentMessage {
+	t.Helper()
+	require.NotEmpty(t, s.history)
+	last := s.history[len(s.history)-1]
+	assert.Equal(t, RoleAgent, last.Role)
+	assert.True(t, last.IsComplete)
+	assert.Empty(t, last.ToolCalls)
+
+	return last
+}
+
+// ---------------------------------------------------------------------------
+// gating tests
+// ---------------------------------------------------------------------------
+
+func TestSlashRun_ChatTurnHelp_DoesNotSendToDriver(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+
+	s.run()
+
+	// No model invocation; slash command text is NOT recorded as a user message.
+	assert.False(t, store.hasCall("driver:openai:send_to_model"))
+	require.Len(t, s.history, 1)
+	last := requireLastAgentReply(t, s)
+	assert.Contains(t, last.Content, "/help")
+	assert.Contains(t, last.Content, "/compact")
+	assert.Contains(t, last.Content, "/model")
+	assert.Contains(t, last.Content, "/refresh")
+
+	for _, m := range s.history {
+		assert.NotEqual(t, RoleUser, m.Role, "slash command text must not be recorded as a user message")
+	}
+}
+
+func TestSlashRun_InferenceTextPassesThrough(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	setChatText(s, AgentSessionTypeInference, "/help")
+
+	s.run()
+
+	// Inference sessions always flow through untouched, even with a leading slash.
+	assert.True(t, store.hasCall("driver:openai:send_to_model"))
+	require.Len(t, s.history, 1)
+	assert.Equal(t, RoleUser, s.history[0].Role)
+	assert.Equal(t, "/help", s.history[0].Content)
+}
+
+func TestSlashRun_NonSlashChatPassesThrough(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	setChatText(s, AgentSessionTypeChatTurn, "hello there")
+
+	s.run()
+
+	// Non-slash chat text flows through untouched.
+	assert.True(t, store.hasCall("driver:openai:send_to_model"))
+	require.Len(t, s.history, 1)
+	assert.Equal(t, RoleUser, s.history[0].Role)
+	assert.Equal(t, "hello there", s.history[0].Content)
+}
+
+func TestSlashRun_UnknownCommand_Replies(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	setChatText(s, AgentSessionTypeChatTurn, "/bogus")
+
+	s.run()
+
+	assert.False(t, store.hasCall("driver:openai:send_to_model"))
+	last := requireLastAgentReply(t, s)
+	assert.Contains(t, last.Content, "Unknown command")
+	assert.Contains(t, last.Content, "/help")
+}
+
+// ---------------------------------------------------------------------------
+// /help
+// ---------------------------------------------------------------------------
+
+func TestSlashHelp_ListsAllCommands(t *testing.T) {
+	_, s := newChatSlashStore(t, nil)
+	s.run()
+
+	last := requireLastAgentReply(t, s)
+	for _, cmd := range []string{"/help", "/refresh", "/model", "/compact"} {
+		assert.Contains(t, last.Content, cmd)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// /refresh
+// ---------------------------------------------------------------------------
+
+func TestSlashRefresh_ReinterpolatesAndPersistsAgent(t *testing.T) {
+	store, s := newChatSlashStore(t, func(cfg *config.Config) {
+		a := cfg.DataSet.Agents["a"]
+		a.SystemPrompt = "Prompt for {{ .agent_name }}"
+		cfg.DataSet.Agents["a"] = a
+	})
+	setChatText(s, AgentSessionTypeChatTurn, "/refresh")
+
+	s.run()
+
+	// reply confirms the refresh and persists the re-interpolated agent.
+	last := requireLastAgentReply(t, s)
+	assert.Contains(t, last.Content, "refreshed")
+
+	cs := &ConvoState{}
+	cs.load(s.ConvoID, store)
+	require.NotNil(t, cs.Agent)
+	assert.Equal(t, "a", cs.Agent.Name)
+}
+
+// ---------------------------------------------------------------------------
+// /model
+// ---------------------------------------------------------------------------
+
+func TestSlashModel_BareName_PersistsDriverAndEngine(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	setChatText(s, AgentSessionTypeChatTurn, "/model gpt-4")
+
+	s.run()
+
+	assert.False(t, store.hasCall("driver:openai:send_to_model"))
+	last := requireLastAgentReply(t, s)
+	assert.Contains(t, last.Content, "openai:gpt-4")
+
+	cs := &ConvoState{}
+	cs.load(s.ConvoID, store)
+	require.NotNil(t, cs.Agent)
+	assert.Equal(t, "gpt-4", cs.Agent.Engine)
+	assert.Equal(t, "openai", cs.Agent.Driver)
+}
+
+func TestSlashModel_DriverEngineForm_Persists(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	setChatText(s, AgentSessionTypeChatTurn, "/model openai:gpt-3.5")
+
+	s.run()
+
+	last := requireLastAgentReply(t, s)
+	assert.Contains(t, last.Content, "openai:gpt-3.5")
+
+	cs := &ConvoState{}
+	cs.load(s.ConvoID, store)
+	require.NotNil(t, cs.Agent)
+	assert.Equal(t, "gpt-3.5", cs.Agent.Engine)
+	assert.Equal(t, "openai", cs.Agent.Driver)
+}
+
+func TestSlashModel_Invalid_RepliesErrorWithEngines(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	setChatText(s, AgentSessionTypeChatTurn, "/model nope")
+
+	s.run()
+
+	assert.False(t, store.hasCall("driver:openai:send_to_model"))
+	last := requireLastAgentReply(t, s)
+	assert.Contains(t, last.Content, "Unknown model: nope")
+	assert.Contains(t, last.Content, "gpt-4")
+	assert.Contains(t, last.Content, "gpt-3.5")
+}
+
+func TestSlashModel_NoArgs_RepliesUsage(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	setChatText(s, AgentSessionTypeChatTurn, "/model")
+
+	s.run()
+
+	assert.False(t, store.hasCall("driver:openai:send_to_model"))
+	last := requireLastAgentReply(t, s)
+	assert.Contains(t, last.Content, "Usage")
+}
+
+// ---------------------------------------------------------------------------
+// /compact
+// ---------------------------------------------------------------------------
+
+func TestSlashCompact_NotConfigured_Replies(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	setChatText(s, AgentSessionTypeChatTurn, "/compact")
+
+	s.run()
+
+	assert.False(t, store.hasCall("driver:openai:send_to_model"))
+	last := requireLastAgentReply(t, s)
+	assert.Contains(t, last.Content, "not configured")
+	assert.Empty(t, store.getEmitted())
+}
+
+func TestSlashCompact_ForceDispatchesSummarizer(t *testing.T) {
+	store := newMockStore(&config.Config{DataSet: &config.DataSet{
+		Agents: map[string]config.Agent{
+			"a": {
+				Name:   "a",
+				Driver: "openai",
+				Engine: "gpt-4",
+				CompactionPolicy: &agentpkg.CompactionPolicy{
+					Strategy:           "summarize",
+					SummarizationAgent: "summ",
+					PreserveRecent:     2,
+				},
+			},
+			"summ": {Name: "summ", Driver: "openai", Engine: "gpt-4"},
+		},
+		Systems:   map[string]config.System{},
+		Workflows: map[string]config.Workflow{},
+		Drivers:   DriverConfigWithAgentEngines(),
+	}})
+
+	msg := &dipper.Message{
+		Labels: map[string]string{"agent_name": "a"},
+		Payload: map[string]interface{}{
+			"convo_id": "convo-compact",
+			"text":     "/compact",
+		},
+	}
+	s := &AgentSession{}
+	s.setup(msg, store, false)
+
+	// Seed a history long enough to compact.
+	s.history = make([]AgentMessage, 12)
+	for i := range s.history {
+		s.history[i] = AgentMessage{Role: RoleUser, Content: "m" + string(rune('a'+i))}
+	}
+
+	s.run()
+
+	// compactHistory dispatched a summarizer sub-agent: it returns immediately
+	// to the async compaction flow and never calls sendToDriver or reply().
+	assert.False(t, store.hasCall("driver:openai:send_to_model"))
+
+	emitted := store.getEmitted()
+	require.NotEmpty(t, emitted, "expected an agent_call to the summarizer")
+	assert.Equal(t, "agent_call", emitted[0].Subject)
+
+	// The slash text must NOT have been recorded as a user message: the history
+	// length is unchanged from the seeded history plus the summarizer tool-call
+	// entry (no extra RoleUser message was appended).
+	require.NotEmpty(t, s.history)
+	last := s.history[len(s.history)-1]
+	assert.Equal(t, RoleAgent, last.Role)
+	assert.NotEmpty(t, last.ToolCalls)
+	for _, m := range s.history {
+		if strings.HasPrefix(m.Content, "/compact") {
+			t.Fatalf("slash text leaked into history as a user message")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// reply returned via history + poll
+// ---------------------------------------------------------------------------
+
+func TestSlashRun_NonTurnReply_ObservableViaHistoryAndPoll(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+
+	s.run()
+
+	// The complete RoleAgent message is persisted in the conversation history.
+	last := requireLastAgentReply(t, s)
+	assert.True(t, last.IsComplete)
+	require.True(t, store.hasCall("cache:rpush"), "reply must be persisted to convo history")
+
+	// The poll loop must observe the reply as an agent_response without any
+	// model invocation. Start LastPoll at 0 so the poll collects the reply.
+	s.LastPoll = 0
+	pollMsg := &dipper.Message{
+		Labels: map[string]string{
+			"resume_key":       "wf.0",
+			"agent_session_id": s.ID,
+		},
+	}
+	emittedBefore := len(store.getEmitted())
+	handled := s.emitPollResponse(pollMsg)
+	assert.True(t, handled, "emitPollResponse should emit the non-turn reply")
+
+	emitted := store.getEmitted()
+	require.Greater(t, len(emitted), emittedBefore)
+	lastEmitted := emitted[len(emitted)-1]
+	assert.Equal(t, "agent_response", lastEmitted.Subject)
+	assert.Equal(t, "success", pollMsg.Labels["status"], "poll loop should mark the response successful")
+
+	fullMessages, ok := lastEmitted.Payload.(map[string]interface{})["full_messages"].([]map[string]string)
+	require.True(t, ok, "expected full_messages in poll response")
+	require.NotEmpty(t, fullMessages)
+	assert.Contains(t, fullMessages[0]["content"], "/help")
+}

--- a/internal/agent/slash_test.go
+++ b/internal/agent/slash_test.go
@@ -10,7 +10,6 @@
 package agent
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/honeydipper/honeydipper/v4/internal/config"
@@ -120,6 +119,9 @@ func requireLastAgentReply(t *testing.T, s *AgentSession) AgentMessage {
 	assert.Equal(t, RoleAgent, last.Role)
 	assert.True(t, last.IsComplete)
 	assert.Empty(t, last.ToolCalls)
+	// Every reply produced for a slash command must be marked IsSlash so it is
+	// excluded from the model context (this helper is only used for slash tests).
+	assert.True(t, last.IsSlash, "slash reply must be marked IsSlash")
 
 	return last
 }
@@ -133,18 +135,19 @@ func TestSlashRun_ChatTurnHelp_DoesNotSendToDriver(t *testing.T) {
 
 	s.run()
 
-	// No model invocation; slash command text is NOT recorded as a user message.
+	// No model invocation for a slash command.
 	assert.False(t, store.hasCall("driver:openai:send_to_model"))
-	require.Len(t, s.history, 1)
+	// History: the marked slash command text (RoleUser) followed by the marked reply.
+	require.Len(t, s.history, 2)
+	assert.Equal(t, RoleUser, s.history[0].Role)
+	assert.Equal(t, "/help", s.history[0].Content)
+	assert.True(t, s.history[0].IsSlash, "slash command text must be marked IsSlash")
 	last := requireLastAgentReply(t, s)
+	assert.True(t, last.IsSlash, "reply to a slash command must be marked IsSlash")
 	assert.Contains(t, last.Content, "/help")
 	assert.Contains(t, last.Content, "/compact")
 	assert.Contains(t, last.Content, "/model")
 	assert.Contains(t, last.Content, "/refresh")
-
-	for _, m := range s.history {
-		assert.NotEqual(t, RoleUser, m.Role, "slash command text must not be recorded as a user message")
-	}
 }
 
 func TestSlashRun_InferenceTextPassesThrough(t *testing.T) {
@@ -346,18 +349,26 @@ func TestSlashCompact_ForceDispatchesSummarizer(t *testing.T) {
 	require.NotEmpty(t, emitted, "expected an agent_call to the summarizer")
 	assert.Equal(t, "agent_call", emitted[0].Subject)
 
-	// The slash text must NOT have been recorded as a user message: the history
-	// length is unchanged from the seeded history plus the summarizer tool-call
-	// entry (no extra RoleUser message was appended).
+	// The slash command text IS recorded as a marked RoleUser message (IsSlash)
+	// so the UI has a complete record; it is excluded from the model context via
+	// the IsSlash marker. The summarizer tool-call entry is REAL model context
+	// and must NOT be marked IsSlash.
 	require.NotEmpty(t, s.history)
 	last := s.history[len(s.history)-1]
 	assert.Equal(t, RoleAgent, last.Role)
 	assert.NotEmpty(t, last.ToolCalls)
-	for _, m := range s.history {
-		if strings.HasPrefix(m.Content, "/compact") {
-			t.Fatalf("slash text leaked into history as a user message")
+	assert.False(t, last.IsSlash, "summarizer tool-call is real model context and must not be marked IsSlash")
+
+	// The slash text entry itself is marked IsSlash.
+	var slashEntry *AgentMessage
+	for i := range s.history {
+		if s.history[i].Content == "/compact" {
+			slashEntry = &s.history[i]
 		}
 	}
+	require.NotNil(t, slashEntry, "expected the /compact command text in history")
+	assert.Equal(t, RoleUser, slashEntry.Role)
+	assert.True(t, slashEntry.IsSlash, "slash command text must be marked IsSlash")
 }
 
 // ---------------------------------------------------------------------------
@@ -397,4 +408,212 @@ func TestSlashRun_NonTurnReply_ObservableViaHistoryAndPoll(t *testing.T) {
 	require.True(t, ok, "expected full_messages in poll response")
 	require.NotEmpty(t, fullMessages)
 	assert.Contains(t, fullMessages[0]["content"], "/help")
+}
+
+// ---------------------------------------------------------------------------
+// IsSlash refinement tests
+// ---------------------------------------------------------------------------
+
+func TestSlash_ReplyIsMarked_NormalModelMessageIsNot(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+
+	// A slash command reply must be marked IsSlash.
+	s.appendConvoHistory(&AgentMessage{Role: RoleUser, User: "u", Content: "/help", IsSlash: true})
+	s.reply("some help output")
+	require.NotEmpty(t, s.history)
+	reply := s.history[len(s.history)-1]
+	assert.Equal(t, RoleAgent, reply.Role)
+	assert.True(t, reply.IsSlash, "slash reply must be marked IsSlash")
+
+	// A normal model message via processAgentMessage must NOT be marked.
+	s.TokenCounter = nil
+	modelMsg := &AgentMessage{Role: RoleAgent, Content: "normal model output", IsComplete: true}
+	s.processAgentMessage(modelMsg)
+	last := s.history[len(s.history)-1]
+	assert.Equal(t, "normal model output", last.Content)
+	assert.False(t, last.IsSlash, "normal model message must not be marked IsSlash")
+	_ = store
+}
+
+func TestSlash_ModelNeverSeesSlashMessages(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+
+	// Interleave normal conversation messages with slash-origin messages.
+	s.history = []AgentMessage{
+		{Role: RoleUser, User: "u", Content: "hello"},
+		{Role: RoleAgent, Content: "hi there", IsComplete: true},
+		{Role: RoleUser, User: "u", Content: "/help", IsSlash: true},
+		{Role: RoleAgent, Content: "Available slash commands...", IsComplete: true, IsSlash: true},
+		{Role: RoleUser, User: "u", Content: "next question"},
+	}
+
+	// Call sendToDriver directly and inspect the history passed to the driver.
+	s.sendToDriver()
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params, "sendToDriver must invoke the driver")
+	driverHistory, ok := params["history"].([]AgentMessage)
+	require.True(t, ok)
+
+	// Build expected: system prompt plus only the non-slash messages in order.
+	expected := []string{"You are helpful.", "hello", "hi there", "next question"}
+	require.Len(t, driverHistory, len(expected))
+	for i, want := range expected {
+		assert.Equal(t, want, driverHistory[i].Content, "driver history[%d]", i)
+		assert.False(t, driverHistory[i].IsSlash, "driver must never see slash-origin messages")
+	}
+}
+
+func TestSlash_MarkedReplyStillReturnedViaPoll(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	s.run()
+
+	// The marked reply is still returned via emitPollResponse/agent_response on poll.
+	require.Len(t, s.history, 2)
+	assert.True(t, s.history[1].IsSlash, "reply should be marked IsSlash")
+	s.LastPoll = 0
+	pollMsg := &dipper.Message{Labels: map[string]string{
+		"resume_key":       "wf.0",
+		"agent_session_id": s.ID,
+	}}
+	emittedBefore := len(store.getEmitted())
+	handled := s.emitPollResponse(pollMsg)
+	assert.True(t, handled, "emitPollResponse should emit the marked reply")
+	emitted := store.getEmitted()
+	require.Greater(t, len(emitted), emittedBefore)
+	lastEmitted := emitted[len(emitted)-1]
+	assert.Equal(t, "agent_response", lastEmitted.Subject)
+	fullMessages, ok := lastEmitted.Payload.(map[string]interface{})["full_messages"].([]map[string]string)
+	require.True(t, ok)
+	require.NotEmpty(t, fullMessages)
+	assert.Contains(t, fullMessages[0]["content"], "/help")
+}
+
+func TestSlash_MarkedMessageVisibleInConvoHistory(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	s.run()
+
+	// The slash command text and reply are persisted to the shared convo history.
+	require.Len(t, s.history, 2)
+	assert.True(t, s.history[0].IsSlash)
+	assert.True(t, s.history[1].IsSlash)
+
+	// loadConvoHistory must read them back unchanged (UI read path).
+	s2 := &AgentSession{ConvoID: s.ConvoID, store: store}
+	s2.loadConvoHistory()
+	require.Len(t, s2.history, 2)
+	assert.Equal(t, "/help", s2.history[0].Content)
+	assert.True(t, s2.history[0].IsSlash, "slash command text must survive loadConvoHistory")
+	assert.Equal(t, RoleAgent, s2.history[1].Role)
+	assert.True(t, s2.history[1].IsSlash, "slash reply must survive loadConvoHistory")
+}
+
+func TestSlash_TokenCountingSkipsSlashMessages(t *testing.T) {
+	s := makeTokenCountingSession(makeTestAgent())
+	// Reset ContextTokens to known state.
+	cs := &ConvoState{}
+	cs.load(s.ConvoID, s.store)
+	cs.ContextTokens = 0
+	cs.persist(s.store)
+
+	// Append a normal user message -> tokens counted.
+	s.appendConvoHistory(&AgentMessage{Role: RoleUser, Content: "normal long message here"})
+	// Append a slash message -> tokens NOT counted.
+	s.appendConvoHistory(&AgentMessage{Role: RoleUser, Content: "/help", IsSlash: true})
+	// Append a slash reply -> tokens NOT counted.
+	s.appendConvoHistory(&AgentMessage{Role: RoleAgent, Content: "Available commands", IsComplete: true, IsSlash: true})
+
+	// ContextTokens should only reflect the normal message.
+	cs2 := &ConvoState{}
+	cs2.load(s.ConvoID, s.store)
+	assert.True(t, cs2.ContextTokens > 0, "normal message tokens should count")
+	onlyNormal := s.countMessageTokens(AgentMessage{Role: RoleUser, Content: "normal long message here"})
+	assert.Equal(t, onlyNormal, cs2.ContextTokens, "ContextTokens must skip slash messages")
+}
+
+func TestSlash_ShouldCompactIgnoresTrailingSlashUserMessage(t *testing.T) {
+	// Agent with history_len compaction policy, threshold 3.
+	store, s := newChatSlashStore(t, func(cfg *config.Config) {
+		a := cfg.DataSet.Agents["a"]
+		a.CompactionPolicy = &agentpkg.CompactionPolicy{
+			Strategy:      "summarize",
+			ThresholdType: "history_len",
+			Threshold:     3,
+		}
+		cfg.DataSet.Agents["a"] = a
+	})
+	// Point the session at the compaction-enabled agent config.
+	pol := *s.Agent.CompactionPolicy
+	s.Agent = &config.Agent{
+		Name:             s.Agent.Name,
+		Driver:           s.Agent.Driver,
+		Engine:           s.Agent.Engine,
+		SystemPrompt:     s.Agent.SystemPrompt,
+		CompactionPolicy: &pol,
+	}
+
+	// Three normal messages + a trailing slash user message. The threshold (3)
+	// is reached by the normal messages, but the last non-slash message is a
+	// RoleUser so compaction IS due here.
+	s.history = []AgentMessage{
+		{Role: RoleUser, Content: "m1"},
+		{Role: RoleAgent, Content: "a1", IsComplete: true},
+		{Role: RoleUser, Content: "m2"},
+		{Role: RoleUser, Content: "/model x", IsSlash: true},
+	}
+	assert.True(t, s.shouldCompact(), "normal-user tail triggers compaction when threshold reached")
+
+	// Now make the trailing normal message an agent message, so the last
+	// non-slash message is not a user message and compaction must NOT trigger,
+	// even though a trailing slash user command is present.
+	s.history = []AgentMessage{
+		{Role: RoleUser, Content: "m1"},
+		{Role: RoleAgent, Content: "a1", IsComplete: true},
+		{Role: RoleAgent, Content: "a2", IsComplete: true},
+		{Role: RoleUser, Content: "/help", IsSlash: true},
+	}
+	assert.False(t, s.shouldCompact(), "trailing slash command must not trigger compaction")
+
+	// With no slash messages at all, the last non-slash user message governs.
+	s.history = []AgentMessage{
+		{Role: RoleUser, Content: "m1"},
+		{Role: RoleAgent, Content: "a1", IsComplete: true},
+		{Role: RoleAgent, Content: "a2", IsComplete: true},
+		{Role: RoleUser, Content: "real question"},
+	}
+	assert.True(t, s.shouldCompact())
+	_ = store
+}
+
+func TestSlash_MarkersSurvivePersistLoadAndFilterNextTurn(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	s.run()
+	require.Len(t, s.history, 2)
+
+	// Persist the session; the markers are part of the serialized history.
+	s.persist(false)
+
+	// Restore a fresh session from cache (restore path).
+	restored := &AgentSession{}
+	restored.setup(&dipper.Message{Labels: map[string]string{
+		"agent_session_id": s.ID,
+	}}, store, false)
+	restored.loadConvoHistory()
+	require.Len(t, restored.history, 2)
+	assert.True(t, restored.history[0].IsSlash, "slash marker must survive persist+load")
+	assert.True(t, restored.history[1].IsSlash, "slash reply marker must survive persist+load")
+
+	// Next turn: append a normal user message and send to driver; the slash
+	// messages must still be filtered out.
+	restored.history = append(restored.history, AgentMessage{Role: RoleUser, Content: "next turn"})
+	restored.sendToDriver()
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	driverHistory, ok := params["history"].([]AgentMessage)
+	require.True(t, ok)
+	expected := []string{"You are helpful.", "next turn"}
+	require.Len(t, driverHistory, len(expected))
+	for i, want := range expected {
+		assert.Equal(t, want, driverHistory[i].Content, "driver history[%d]", i)
+		assert.False(t, driverHistory[i].IsSlash)
+	}
 }

--- a/internal/agent/slash_test.go
+++ b/internal/agent/slash_test.go
@@ -197,9 +197,27 @@ func TestSlashHelp_ListsAllCommands(t *testing.T) {
 	s.run()
 
 	last := requireLastAgentReply(t, s)
-	for _, cmd := range []string{"/help", "/refresh", "/model", "/compact"} {
+	for _, cmd := range []string{"/help", "/refresh", "/model", "/compact", "/retry"} {
 		assert.Contains(t, last.Content, cmd)
 	}
+}
+
+func TestSlashHelp_IsMarkdown(t *testing.T) {
+	_, s := newChatSlashStore(t, nil)
+	s.run()
+
+	last := requireLastAgentReply(t, s)
+	content := last.Content
+	// The help output is proper markdown: a bold header, blank-line separated
+	// bullet lines, and a trailing instruction line joined with newlines.
+	assert.Contains(t, content, "**Available commands**")
+	assert.Contains(t, content, "\n- `/help`")
+	assert.Contains(t, content, "- `/help` — Show this list of commands")
+	assert.Contains(t, content, "- `/compact` — Compact the conversation history to save context")
+	assert.Contains(t, content, "- `/retry` — Regenerate the last response")
+	assert.Contains(t, content, "- `/refresh` — Rebuild the system prompt from current agent config")
+	assert.Contains(t, content, "- `/model` — Switch the model for this conversation")
+	assert.Contains(t, content, "Type a command followed by Enter to run it.")
 }
 
 // ---------------------------------------------------------------------------
@@ -300,6 +318,7 @@ func TestSlashCompact_NotConfigured_Replies(t *testing.T) {
 	assert.False(t, store.hasCall("driver:openai:send_to_model"))
 	last := requireLastAgentReply(t, s)
 	assert.Contains(t, last.Content, "not configured")
+	assert.False(t, s.SlashInitiatedCompaction, "flag must be cleared when compaction cannot run")
 	assert.Empty(t, store.getEmitted())
 }
 
@@ -344,6 +363,10 @@ func TestSlashCompact_ForceDispatchesSummarizer(t *testing.T) {
 	// compactHistory dispatched a summarizer sub-agent: it returns immediately
 	// to the async compaction flow and never calls sendToDriver or reply().
 	assert.False(t, store.hasCall("driver:openai:send_to_model"))
+	// The session is marked as a slash-initiated compaction so
+	// handleCompactionResult knows to post the confirmation and NOT resume the
+	// model conversation when the summarizer returns.
+	assert.True(t, s.SlashInitiatedCompaction, "slash-initiated compaction flag must be set before dispatch")
 
 	emitted := store.getEmitted()
 	require.NotEmpty(t, emitted, "expected an agent_call to the summarizer")
@@ -616,4 +639,194 @@ func TestSlash_MarkersSurvivePersistLoadAndFilterNextTurn(t *testing.T) {
 		assert.Equal(t, want, driverHistory[i].Content, "driver history[%d]", i)
 		assert.False(t, driverHistory[i].IsSlash)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Finding 2: slash-initiated compaction must NOT resume the model conversation
+// ---------------------------------------------------------------------------
+
+// makeCompactionResultSession builds a session with enough history for
+// handleCompactionResult to run, with or without the slash-initiated flag.
+func makeCompactionResultSession(t *testing.T, slashInitiated bool) (*mockStore, *AgentSession) {
+	t.Helper()
+	store := newMockStore(&config.Config{DataSet: &config.DataSet{
+		Agents: map[string]config.Agent{
+			"summ": {Name: "summ", Driver: "openai", Engine: "gpt-4"},
+		},
+		Systems:   map[string]config.System{},
+		Workflows: map[string]config.Workflow{},
+		Drivers:   DriverConfigWithAgentEngines(),
+	}})
+	agentA := config.Agent{
+		Name: "bot", Driver: "openai", Engine: "gpt-4",
+		CompactionPolicy: &agentpkg.CompactionPolicy{
+			Strategy:           agentpkg.CompactionStrategySummarize,
+			PreserveRecent:     2,
+			SummarizationAgent: "summ",
+		},
+	}
+	s := &AgentSession{store: store, Agent: &agentA, ID: "s2", ConvoID: "convo-2"}
+	s.CurrentMsg = &dipper.Message{Labels: map[string]string{}, Payload: map[string]interface{}{"convo_id": s.ConvoID}}
+	s.SlashInitiatedCompaction = slashInitiated
+	s.history = []AgentMessage{
+		{Role: RoleUser, Content: "old1"},
+		{Role: RoleUser, Content: "old2"},
+		{Role: RoleUser, Content: "old3"},
+		{Role: RoleUser, Content: "old4"},
+		{Role: RoleUser, Content: "old5"},
+	}
+
+	return store, s
+}
+
+func TestHandleCompactionResult_SlashInitiated_DoesNotSendToDriver(t *testing.T) {
+	store, s := makeCompactionResultSession(t, true)
+
+	call := AgentToolCall{
+		FuncName: "ag__summ",
+		Params: map[string]interface{}{
+			"compaction_id": "convo-2_g1",
+			"preserve":      2,
+		},
+	}
+	got := s.handleCompactionResult(call, []map[string]interface{}{{"data": "COMPACTED SUMMARY"}})
+	assert.True(t, got, "handleCompactionResult must take over the result for a compaction call")
+
+	// The flag is cleared once the result is handled.
+	assert.False(t, s.SlashInitiatedCompaction, "slash-initiated flag must be cleared after handling")
+
+	// The model is NOT resumed: sendToDriver must not be invoked.
+	assert.False(t, store.hasCall("driver:openai:send_to_model"), "slash-initiated compaction must NOT call sendToDriver")
+
+	// The in-memory history is summary system message + preserved tail +
+	// the marked confirmation reply appended by handleCompactionResult.
+	require.GreaterOrEqual(t, len(s.history), 3)
+	// 0: summary system message
+	assert.Equal(t, RoleSystem, s.history[0].Role)
+	assert.Contains(t, s.history[0].Content, "COMPACTED SUMMARY")
+	// 1..2: preserved tail (old3, old4) - the last old5 is the tool-call slot
+	// handled by handleCompactionResult (toolIndex = total-1).
+	assert.Equal(t, "old3", s.history[len(s.history)-3].Content)
+
+	// Last message: the confirmation reply, marked IsSlash + IsComplete.
+	last := s.history[len(s.history)-1]
+	assert.Equal(t, RoleAgent, last.Role)
+	assert.True(t, last.IsSlash, "compaction confirmation reply must be marked IsSlash")
+	assert.True(t, last.IsComplete, "compaction confirmation reply must be complete")
+	assert.Contains(t, last.Content, "Conversation compacted")
+}
+
+func TestHandleCompactionResult_Automatic_StillSendsToDriver(t *testing.T) {
+	store, s := makeCompactionResultSession(t, false)
+
+	call := AgentToolCall{
+		FuncName: "ag__summ",
+		Params: map[string]interface{}{
+			"compaction_id": "convo-2_g1",
+			"preserve":      2,
+		},
+	}
+	got := s.handleCompactionResult(call, []map[string]interface{}{{"data": "COMPACTED SUMMARY"}})
+	assert.True(t, got)
+
+	// Automatic compaction (no slash-initiated flag) still resumes the model
+	// conversation - this is the regression guard for unchanged behavior.
+	assert.True(t, store.hasCall("driver:openai:send_to_model"), "automatic compaction must still call sendToDriver")
+	assert.False(t, s.SlashInitiatedCompaction)
+}
+
+func TestSlashCompact_Confirmation_ObservableViaHistoryAndPoll(t *testing.T) {
+	store, s := makeCompactionResultSession(t, true)
+
+	// Simulate the full slash flow: dispatch /compact (sets the flag), then the
+	// summarizer returns and handleCompactionResult posts the confirmation.
+	call := AgentToolCall{
+		FuncName: "ag__summ",
+		Params: map[string]interface{}{
+			"compaction_id": "convo-2_g1",
+			"preserve":      2,
+		},
+	}
+	s.handleCompactionResult(call, []map[string]interface{}{{"data": "COMPACTED SUMMARY"}})
+
+	// The confirmation is returned via the poll/emitPollResponse path.
+	s.LastPoll = 0
+	pollMsg := &dipper.Message{Labels: map[string]string{
+		"resume_key":       "wf.0",
+		"agent_session_id": s.ID,
+	}}
+	emittedBefore := len(store.getEmitted())
+	handled := s.emitPollResponse(pollMsg)
+	assert.True(t, handled, "emitPollResponse should emit the compaction confirmation")
+	emitted := store.getEmitted()
+	require.Greater(t, len(emitted), emittedBefore)
+	lastEmitted := emitted[len(emitted)-1]
+	assert.Equal(t, "agent_response", lastEmitted.Subject)
+	fullMessages, ok := lastEmitted.Payload.(map[string]interface{})["full_messages"].([]map[string]string)
+	require.True(t, ok, "expected full_messages in poll response")
+	require.NotEmpty(t, fullMessages)
+	assert.Contains(t, fullMessages[0]["content"], "Conversation compacted")
+}
+
+func TestSlashCompact_HandlerDispatchesWithoutSendToDriver(t *testing.T) {
+	store := newMockStore(&config.Config{DataSet: &config.DataSet{
+		Agents: map[string]config.Agent{
+			"a": {
+				Name:   "a",
+				Driver: "openai",
+				Engine: "gpt-4",
+				CompactionPolicy: &agentpkg.CompactionPolicy{
+					Strategy:           "summarize",
+					SummarizationAgent: "summ",
+					PreserveRecent:     2,
+				},
+			},
+			"summ": {Name: "summ", Driver: "openai", Engine: "gpt-4"},
+		},
+		Systems:   map[string]config.System{},
+		Workflows: map[string]config.Workflow{},
+		Drivers:   DriverConfigWithAgentEngines(),
+	}})
+
+	msg := &dipper.Message{
+		Labels: map[string]string{"agent_name": "a"},
+		Payload: map[string]interface{}{
+			"convo_id": "convo-compact2",
+			"text":     "/compact",
+		},
+	}
+	s := &AgentSession{}
+	s.setup(msg, store, false)
+	// Seed a history long enough to compact.
+	s.history = make([]AgentMessage, 12)
+	for i := range s.history {
+		s.history[i] = AgentMessage{Role: RoleUser, Content: "m" + string(rune('a'+i))}
+	}
+
+	// Invoke the slash handler directly (not via run, so we can observe the
+	// return value and the emitted agent_call).
+	ok := slashCompact(s, "")
+	assert.True(t, ok)
+	assert.True(t, s.SlashInitiatedCompaction, "flag set when compaction dispatched")
+	// Dispatches the summarizer without any model invocation.
+	assert.False(t, store.hasCall("driver:openai:send_to_model"), "compact handler must not call sendToDriver")
+	emitted := store.getEmitted()
+	require.NotEmpty(t, emitted)
+	assert.Equal(t, "agent_call", emitted[0].Subject)
+	// No reply posted at dispatch time (confirmation comes from the result path).
+	last := s.history[len(s.history)-1]
+	assert.Equal(t, RoleAgent, last.Role)
+	assert.NotEmpty(t, last.ToolCalls)
+}
+
+func TestSlashCompact_HandlerNoPolicy_RepliesNoModel(t *testing.T) {
+	store, s := newChatSlashStore(t, nil) // no compaction policy
+	setChatText(s, AgentSessionTypeChatTurn, "/compact")
+
+	s.run()
+
+	assert.False(t, store.hasCall("driver:openai:send_to_model"), "no model call when compaction not configured")
+	last := requireLastAgentReply(t, s)
+	assert.Contains(t, last.Content, "not configured")
+	assert.Empty(t, store.getEmitted())
 }

--- a/internal/service/agent_apis.go
+++ b/internal/service/agent_apis.go
@@ -216,67 +216,13 @@ func handleAgentListAPI(resp *api.Response) {
 	resp.Return(data)
 }
 
-// isAgentDriver checks whether a driver config (from drivers.daemon.drivers.<name>)
-// has "agent_driver" in its meta.labels.
-func isAgentDriver(driverConfig interface{}) bool {
-	labels, ok := dipper.GetMapData(driverConfig, "meta.labels")
-	if !ok {
-		return false
-	}
-
-	labelList, ok := labels.([]interface{})
-	if !ok {
-		return false
-	}
-
-	for _, l := range labelList {
-		if s, ok := l.(string); ok && s == "agent_driver" {
-			return true
-		}
-	}
-
-	return false
-}
-
-// collectEngineEntriesFromDriver extracts unique {driver,engine} pairs from the
-// engines block of a single driver config. Duplicates are filtered via the seen set.
-func collectEngineEntriesFromDriver(driverName string, driverConfig interface{}, seen map[string]bool, entries *[]engineEntry) {
-	engines, ok := dipper.GetMapData(driverConfig, "engines")
-	if !ok {
-		return
-	}
-
-	engineMap, ok := engines.(map[string]interface{})
-	if !ok {
-		return
-	}
-
-	for engineName := range engineMap {
-		key := driverName + ":" + engineName
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-		*entries = append(*entries, engineEntry{Driver: driverName, Engine: engineName})
-	}
-}
-
-type engineEntry struct {
-	Driver string `json:"driver"`
-	Engine string `json:"engine"`
-}
-
 // handleAgentListEnginesAPI returns a sorted JSON array of unique {driver, engine}
 // pairs from the driver configuration. It scans drivers.daemon.drivers for any
 // driver whose meta.labels include "agent_driver", then collects all engine keys
 // from that driver's engines block. The UI uses this to populate the engine/driver
 // override dropdown.
 func handleAgentListEnginesAPI(resp *api.Response) {
-	seen := map[string]bool{}
-	entries := []engineEntry{}
-
-	// Collect engines from all drivers that have the "agent_driver" label.
-	collectDriverEngines(agentStore.GetConfig().DataSet.Drivers, seen, &entries)
+	entries := agent.CollectAgentDriverEngines(agentStore.GetConfig().DataSet.Drivers)
 
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Driver+":"+entries[i].Engine < entries[j].Driver+":"+entries[j].Engine
@@ -284,36 +230,4 @@ func handleAgentListEnginesAPI(resp *api.Response) {
 
 	data := dipper.Must(json.Marshal(entries)).([]byte)
 	resp.Return(data)
-}
-
-// collectDriverEngines iterates over drivers.daemon.drivers, filtering for
-// agent-driver labelled entries, and populates entries with {driver,engine} pairs.
-// collectDriverEngines iterates over drivers.daemon.drivers, filtering for
-// agent-driver labelled entries, and populates entries with {driver,engine} pairs.
-// It reads engines from the top-level driver config at drivers.<name>.engines.
-func collectDriverEngines(drivers map[string]interface{}, seen map[string]bool, entries *[]engineEntry) {
-	raw, ok := dipper.GetMapData(drivers, "daemon.drivers")
-	if !ok {
-		return
-	}
-
-	driverMap, ok := raw.(map[string]interface{})
-	if !ok {
-		return
-	}
-
-	for driverName, driverConfig := range driverMap {
-		if !isAgentDriver(driverConfig) {
-			continue
-		}
-
-		// Look up the actual driver config (e.g. drivers.openai) for engines,
-		// not the daemon metadata (drivers.daemon.drivers.openai).
-		actualDriverConfig, ok := drivers[driverName]
-		if !ok {
-			continue
-		}
-
-		collectEngineEntriesFromDriver(driverName, actualDriverConfig, seen, entries)
-	}
 }

--- a/pkg/agent/types.go
+++ b/pkg/agent/types.go
@@ -35,6 +35,13 @@ type Message struct {
 	IsChunk      bool                     `json:"is_chunk" mapstructure:"is_chunk"` // true when the message is a streaming chunk
 	InputTokens  int                      `json:"input_tokens" mapstructure:"input_tokens"`
 	OutputTokens int                      `json:"output_tokens" mapstructure:"output_tokens"`
+
+	// IsSlash marks a message that originated from a slash command (the command
+	// text itself or its reply). Slash-origin messages are persisted in the
+	// conversation history so the workflow/UI return paths can observe them, but
+	// they are NEVER sent to the model as context. This field is persisted to
+	// Redis as part of the serialized message so markers survive session restore.
+	IsSlash bool `json:"is_slash,omitempty" mapstructure:"is_slash"`
 }
 
 // Tool describes a callable tool exposed to the model.


### PR DESCRIPTION
## Summary

This is **Phase 1** of the built-in slash command feature for the honeydipper agent. It establishes the slash command framework (parse/dispatch/reply plumbing) and proves it with the non-turn built-ins `/help`, `/refresh`, `/model <name>`, `/compact`, and `/retry`.

The feature is **conversation-only** (`chat_turn` sessions), with no config surface (all built-in). The framework uses a single interception point in `AgentSession.run()`.

## Requirements covered

1. **`internal/agent/slash.go` (new)** — `parseSlashCommand` (leading `/`, first whitespace-delimited token = command, remainder = args); a built-in registry + dispatcher extensible via `registerSlashCommand(name, handler)` so config-driven commands can be added later without framework rework; and a `reply(content)` helper that appends a complete `RoleAgent` message (`IsComplete: true`) to convo history and persists it — the sole return mechanism for non-turn commands so the workflow `agent_poll`/`emitPollResponse` loop and the UI `convoHistory` read both observe the result without invoking the model.

2. **Gate in `run()`** (`agent_session.go`) — intercepts BEFORE appending the user message / `sendToDriver()`, and ONLY when session Type is `chat_turn` AND the text starts with `/`. Non-slash chat text and all inference text flow through untouched.

3. **Built-ins (always registered, no config):**
   - `/help` — static markdown list of all commands (proper `strings.Join(..., "\n")` multi-line output).
   - `/refresh` — re-runs `interpolateAgentConfig` and writes the result into `ConvoState.Agent` so the system prompt rebuilt in `sendToDriver()` reflects config changes; replies with a confirmation.
   - `/model <name>` — validates `<name>` (or `driver:engine` form) against the known engines (same source as the engine-listing API), persists the override into `ConvoState.Agent.Engine/.Driver` ALWAYS; on invalid input replies with an error listing valid engines.
   - `/compact` — force-compacts regardless of threshold; returns immediately to the async compaction flow. If compaction isn't configured/possible, replies with an explanatory message.
   - `/retry` — recognized and listed in `/help`; phase 1 replies with an explanation that regeneration is not yet built.

4. **Engine-listing logic** — extracted `collectDriverEngines`-style scan into `internal/agent/engines.go` (`CollectAgentDriverEngines`), shared by `/model` and `handleAgentListEnginesAPI` so they use one source of truth.

## IsSlash refinement (slash content persisted, never sent to model)

Slash command content (the command text and its reply) is persisted in the conversation history so the workflow/UI return paths can observe it, but is **never** sent to the model as context.

- **`pkg/agent/types.go`** — added `IsSlash bool` marker field on `Message` (`json:"is_slash,omitempty"`). It is part of the serialized message so markers persist to Redis and survive session restore.
- **`internal/agent/slash.go`** — `reply()` marks all slash reply output with `IsSlash: true` (including `/model` invalid-input error replies, via the shared `reply()`); added `recordSlashCommandText()` which appends the raw command text itself as a marked `RoleUser` message so the UI has a complete record.
- **`internal/agent/agent_session.go`** — `sendToDriver()` filters out `IsSlash` messages when building the history slice passed to the model (a clean `continue` before any driver serialization), so drivers never see slash-origin messages. `appendConvoHistory()` skips token counting for `IsSlash` messages so `ContextTokens` isn't inflated. `emitPollResponse`/`loadConvoHistory`/`persist` are **not** filtered — those keep seeing the marked messages unchanged so workflow return and UI read still work.
- **`internal/agent/agent_compaction.go`** — `shouldCompact()` uses the *last non-slash message's* role so a trailing marked slash command can't trigger compaction (via new `lastNonSlashMessage()` helper). Token recounting over `s.history` skips `IsSlash` messages.
- The `/compact` summarizer sub-agent tool-call and result remain **legitimate model context** and are intentionally **not** marked `IsSlash`.
- `MaxHistoryLen` trimming semantics are unchanged for slash messages.

## Follow-up fixes (Finding 1 & Finding 2)

**Finding 1 — `/help` formatting:** The help reply is now proper multi-line markdown built with `strings.Join(..., "\n")`: a `**Available commands**` header, blank lines, bullet lines (`- \`/help\` — Show this list of commands`, etc.), and a trailing `Type a command followed by Enter to run it.`. The reply remains `IsSlash` (persisted for UI/workflow, never sent to the model).

**Finding 2 — `/compact` no longer resumes the model conversation (design flaw):**
Root cause: `handleCompactionResult()` unconditionally called `s.sendToDriver()` after compaction — correct for automatic compaction (mid-turn, real pending user message) but wrong for `/compact`, where there is no pending user turn and the model produced a spurious continuation.
- Added a persisted, JSON-serialized `AgentSession.SlashInitiatedCompaction bool` (`agent_session.go`), surviving session restore.
- The `/compact` handler sets the flag BEFORE `compactHistory()`. If it dispatches, do NOT call `sendToDriver` and do NOT post a reply there (the confirmation is posted by `handleCompactionResult` after the summarizer completes). If it cannot run (no policy / history too short / no summarization agent), clear the flag and reply with an explanation.
- `handleCompactionResult()` now branches after `s.persist(false)`:
  - slash-initiated → clear flag, `s.reply("✅ Conversation compacted. ...")` (marked `IsSlash` + `IsComplete`), `return true` — persisted/returned to workflow+UI, never sent to the model.
  - else → `s.sendToDriver(); return true` (automatic compaction behavior unchanged).
- The compaction summary system message + preserved tail are NOT marked `IsSlash` (legitimate context for the next real turn).

## Proposed changes

- `internal/agent/slash.go` (new) — parser, registry, dispatcher, `reply()`, `recordSlashCommandText()`, and the built-ins including the markdown `/help` and origin-aware `/compact`.
- `internal/agent/engines.go` (new) — shared engine enumeration (`CollectAgentDriverEngines`) reused by `/model` and the engine-listing API.
- `internal/agent/agent_session.go` — `run()` interception gate; `sendToDriver()` IsSlash filtering; `appendConvoHistory()` token skip; `setConvoAgent` helper; `SlashInitiatedCompaction` field.
- `internal/agent/agent_compaction.go` — `shouldCompact()` uses last non-slash role; token recount skips `IsSlash`; `handleCompactionResult()` origin-aware post-compaction branch.
- `pkg/agent/types.go` — added `IsSlash` marker field on `Message`.
- `internal/service/agent_apis.go` — `handleAgentListEnginesAPI` reuses `agent.CollectAgentDriverEngines`.
- `internal/agent/slash_test.go` (new) — parser; chat-only gating; each built-in; IsSlash refinement tests; and the Finding 1 `/help` markdown test plus Finding 2 compaction tests (slash-initiated does NOT sendToDriver + confirmation reply; automatic compaction regression guard; handler dispatch/no-polcheck).
- `internal/agent/agent_test.go` — mock store now persists `cache:rpush` → `cache:lrange` history lists so the restore-path tests mirror the real Redis-backed store.

## Validation

- `go test ./...` — all packages pass, 0 failures.
- `golangci-lint run ./internal/agent/... ./pkg/agent/... ./internal/service/...` — 0 issues.