### PR TITLE
feat(agent): implement /retry slash command (phase 2)

### DIFF
--- a/internal/agent/agent_session.go
+++ b/internal/agent/agent_session.go
@@ -961,10 +961,14 @@ func (s *AgentSession) resolveUnresolvedToolCalls() {
 		return
 	}
 
-	// Check if the last message has unresolved tool calls
-	// Unresolved tool calls means: the last message has ToolCalls populated,
-	// but there is no subsequent RoleToolResult message with the results.
-	lastMsg := s.history[len(s.history)-1]
+	// Look at the last non-slash message. A trailing marked slash command (e.g.
+	// the /retry command text recorded by recordSlashCommandText) is not part of
+	// the real conversation and must not hide an unresolved tool call from the
+	// interrupted turn sitting just below it.
+	lastMsg := s.lastNonSlashMsg()
+	if lastMsg == nil {
+		return
+	}
 
 	// If the last message doesn't have tool calls, nothing to resolve
 	if len(lastMsg.ToolCalls) == 0 {

--- a/internal/agent/slash.go
+++ b/internal/agent/slash.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/honeydipper/honeydipper/v4/internal/config"
 	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
@@ -285,11 +286,114 @@ func listKnownEngines(s *AgentSession) string {
 	return strings.Join(lines, "\n")
 }
 
-// slashRetry implements /retry. In phase 1 the command is recognized (so it
-// shows in /help) but the regeneration logic is not yet built; it replies with
-// an explanation rather than being unknown.
+// rewindToPreviousUserTurn locates the last real (non-slash) user message that
+// has content, walking backwards past any trailing assistant, tool, or tool
+// result turns as well as any slash-origin messages (e.g. the /retry command
+// text itself, which is recorded as a marked IsSlash RoleUser message by
+// recordSlashCommandText and must never be mistaken for the previous user
+// turn). It returns the index of that user message, or -1 when no such message
+// exists.
+func (s *AgentSession) rewindToPreviousUserTurn() int {
+	for i := len(s.history) - 1; i >= 0; i-- {
+		m := s.history[i]
+		if m.IsSlash {
+			continue
+		}
+		if m.Role == RoleUser && m.Content != "" {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// persistConvoHistory rewrites the persisted conversation history in the cache
+// to exactly match the session's in-memory history. It is used by /retry after
+// rewinding the conversation so the stored history (and therefore the UI read
+// path and any subsequent model round-trip) reflects the truncation.
+func (s *AgentSession) persistConvoHistory() {
+	if s.ConvoID == "" {
+		return
+	}
+	_, _ = s.store.Call("cache", "del", map[string]interface{}{"key": ConvoHistoryKeyPrefix + s.ConvoID})
+	convoTTL, _ := time.ParseDuration(ConvoStreamTTL)
+	fullKey := ConvoHistoryKeyPrefix + s.ConvoID
+	for _, m := range s.history {
+		_, _ = s.store.Call("cache", "rpush", map[string]interface{}{
+			"key":   fullKey,
+			"value": string(dipper.SerializeContent(m)),
+			"ttl":   float64(convoTTL),
+		})
+	}
+}
+
+// slashRetry implements /retry: re-send the previous real user message to
+// regenerate the last response. It locates the last non-slash user message
+// that has content, truncates the history back to just before it (dropping the
+// assistant/tool messages it already answered), re-appends that user message
+// as a normal, non-slash RoleUser message, and sends it to the driver so the
+// response is regenerated through the normal model round-trip. When there is
+// no prior user message with content it replies with a helpful error and does
+// NOT send to the model.
 func slashRetry(s *AgentSession, _ string) bool {
-	s.reply("Retry is not available yet in this build. Please re-ask your question or use /compact to reset context.")
+	idx := s.rewindToPreviousUserTurn()
+	if idx < 0 {
+		s.reply("No previous user message to retry. Please send a new message to continue the conversation or use /help for other commands.")
+
+		return true
+	}
+
+	user, _ := dipper.GetMapDataStr(s.CurrentMsg.Payload, "user")
+	msg := s.history[idx]
+	msg.Role = RoleUser
+	msg.User = user
+	msg.IsSlash = false
+
+	// Preserve any trailing slash-origin messages (in practice the /retry
+	// command text recorded by recordSlashCommandText) so the UI keeps a
+	// complete record of what the user typed. They are excluded from the model
+	// context via their IsSlash marker and must not be mistaken for the
+	// previous real user turn.
+	var trailing []AgentMessage
+	for _, m := range s.history[idx+1:] {
+		if m.IsSlash {
+			trailing = append(trailing, m)
+		}
+	}
+
+	// Truncate back to just before the previous user turn (dropping the
+	// assistant/tool messages it already answered) and re-append that user
+	// message (with the session user) as a normal, non-slash RoleUser message,
+	// followed by the preserved slash-origin markers.
+	s.history = append(make([]AgentMessage, 0, idx+1+len(trailing)), s.history[:idx]...)
+	s.history = append(s.history, msg)
+	s.history = append(s.history, trailing...)
+
+	// Persist the rewound history so both the UI read path and any subsequent
+	// poll/history return observe the regenerated conversation.
+	s.persistConvoHistory()
+
+	// Recalculate ContextTokens from the rewound history since messages were
+	// dropped; the re-appended user message must not be double counted.
+	if s.TokenCounter != nil {
+		lockedConvoStateUpdate(s.ConvoID, s.store, func(cs *ConvoState) {
+			cs.ContextTokens = s.countSystemPromptTokens()
+			for _, m := range s.history {
+				if m.IsSlash {
+					continue
+				}
+				cs.ContextTokens += s.countMessageTokens(m)
+			}
+		})
+	}
+
+	// Point the poll at the tail of the rewound history so the regenerated
+	// response (appended when the model returns) is collected as a new turn.
+	s.LastPoll = len(s.history)
+
+	// Regenerate the response through the normal model round-trip
+	// (ReceiveInference -> processAgentMessage -> history/poll return).
+	s.sendToDriver()
 
 	return true
 }

--- a/internal/agent/slash.go
+++ b/internal/agent/slash.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/honeydipper/honeydipper/v4/internal/config"
 	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
@@ -49,7 +48,7 @@ func ensureSlashBuiltins() {
 		registerSlashCommand("refresh", "Rebuild the system prompt from current agent config", slashRefresh)
 		registerSlashCommand("model", "Switch the model for this conversation", slashModel)
 		registerSlashCommand("compact", "Compact the conversation history to save context", slashCompact)
-		registerSlashCommand("retry", "Regenerate the last response", slashRetry)
+		registerSlashCommand("retry", "Resume an interrupted turn", slashRetry)
 	})
 }
 
@@ -286,114 +285,65 @@ func listKnownEngines(s *AgentSession) string {
 	return strings.Join(lines, "\n")
 }
 
-// rewindToPreviousUserTurn locates the last real (non-slash) user message that
-// has content, walking backwards past any trailing assistant, tool, or tool
-// result turns as well as any slash-origin messages (e.g. the /retry command
-// text itself, which is recorded as a marked IsSlash RoleUser message by
-// recordSlashCommandText and must never be mistaken for the previous user
-// turn). It returns the index of that user message, or -1 when no such message
-// exists.
-func (s *AgentSession) rewindToPreviousUserTurn() int {
+// lastNonSlashMsg returns the most recent history message that is not marked
+// IsSlash, or nil when history is empty or every message is slash-origin.
+// Marked slash messages (command text and replies) are not part of the real
+// conversation, so they are skipped when deciding whether a turn is interrupted.
+func (s *AgentSession) lastNonSlashMsg() *AgentMessage {
 	for i := len(s.history) - 1; i >= 0; i-- {
-		m := s.history[i]
-		if m.IsSlash {
-			continue
-		}
-		if m.Role == RoleUser && m.Content != "" {
-			return i
+		if !s.history[i].IsSlash {
+			return &s.history[i]
 		}
 	}
 
-	return -1
+	return nil
 }
 
-// persistConvoHistory rewrites the persisted conversation history in the cache
-// to exactly match the session's in-memory history. It is used by /retry after
-// rewinding the conversation so the stored history (and therefore the UI read
-// path and any subsequent model round-trip) reflects the truncation.
-func (s *AgentSession) persistConvoHistory() {
-	if s.ConvoID == "" {
-		return
+// hasInterruptedTurn reports whether the last real (non-slash) message marks an
+// interrupted turn — anything that is NOT a complete agent message. A nil last
+// message (empty history) or a complete agent message (Role == RoleAgent &&
+// IsComplete && len(ToolCalls) == 0) is a clean state, so there is nothing to
+// retry. Everything else — a trailing RoleUser, a RoleToolResult, a RoleAgent
+// with pending ToolCalls, or an incomplete RoleAgent — is considered interrupted
+// and can be resumed by /retry.
+func (s *AgentSession) hasInterruptedTurn() bool {
+	m := s.lastNonSlashMsg()
+	if m == nil {
+		return false
 	}
-	_, _ = s.store.Call("cache", "del", map[string]interface{}{"key": ConvoHistoryKeyPrefix + s.ConvoID})
-	convoTTL, _ := time.ParseDuration(ConvoStreamTTL)
-	fullKey := ConvoHistoryKeyPrefix + s.ConvoID
-	for _, m := range s.history {
-		_, _ = s.store.Call("cache", "rpush", map[string]interface{}{
-			"key":   fullKey,
-			"value": string(dipper.SerializeContent(m)),
-			"ttl":   float64(convoTTL),
-		})
+	if m.Role == RoleAgent && m.IsComplete && len(m.ToolCalls) == 0 {
+		return false
 	}
+
+	return true
 }
 
-// slashRetry implements /retry: re-send the previous real user message to
-// regenerate the last response. It locates the last non-slash user message
-// that has content, truncates the history back to just before it (dropping the
-// assistant/tool messages it already answered), re-appends that user message
-// as a normal, non-slash RoleUser message, and sends it to the driver so the
-// response is regenerated through the normal model round-trip. When there is
-// no prior user message with content it replies with a helpful error and does
-// NOT send to the model.
+// slashRetry implements /retry: resume an interrupted turn. When the last real
+// (non-slash) message is a complete agent message (or history is empty) there is
+// nothing to retry and it replies with an explanation. Otherwise the turn was
+// interrupted (cancelled or errored mid-way) and history already ends at the
+// interruption point: resolveUnresolvedToolCalls clears any hanging tool calls,
+// then sendToDriver() rebuilds the model history from s.history (filtering the
+// marked slash command text) and appends a synthetic "Please continue." only
+// when the trailing role isn't a user — it is never written into s.history, so
+// no "continue" text or duplicate user message pollutes the conversation.
 func slashRetry(s *AgentSession, _ string) bool {
-	idx := s.rewindToPreviousUserTurn()
-	if idx < 0 {
-		s.reply("No previous user message to retry. Please send a new message to continue the conversation or use /help for other commands.")
+	if !s.hasInterruptedTurn() {
+		s.reply("Nothing to retry: the last turn already completed.")
 
 		return true
 	}
 
-	user, _ := dipper.GetMapDataStr(s.CurrentMsg.Payload, "user")
-	msg := s.history[idx]
-	msg.Role = RoleUser
-	msg.User = user
-	msg.IsSlash = false
+	// Resolve any hanging tool calls from the interrupted turn so the model gets
+	// a clean continuation point (appends failure RoleToolResult messages).
+	s.resolveUnresolvedToolCalls()
 
-	// Preserve any trailing slash-origin messages (in practice the /retry
-	// command text recorded by recordSlashCommandText) so the UI keeps a
-	// complete record of what the user typed. They are excluded from the model
-	// context via their IsSlash marker and must not be mistaken for the
-	// previous real user turn.
-	var trailing []AgentMessage
-	for _, m := range s.history[idx+1:] {
-		if m.IsSlash {
-			trailing = append(trailing, m)
-		}
-	}
-
-	// Truncate back to just before the previous user turn (dropping the
-	// assistant/tool messages it already answered) and re-append that user
-	// message (with the session user) as a normal, non-slash RoleUser message,
-	// followed by the preserved slash-origin markers.
-	s.history = append(make([]AgentMessage, 0, idx+1+len(trailing)), s.history[:idx]...)
-	s.history = append(s.history, msg)
-	s.history = append(s.history, trailing...)
-
-	// Persist the rewound history so both the UI read path and any subsequent
-	// poll/history return observe the regenerated conversation.
-	s.persistConvoHistory()
-
-	// Recalculate ContextTokens from the rewound history since messages were
-	// dropped; the re-appended user message must not be double counted.
-	if s.TokenCounter != nil {
-		lockedConvoStateUpdate(s.ConvoID, s.store, func(cs *ConvoState) {
-			cs.ContextTokens = s.countSystemPromptTokens()
-			for _, m := range s.history {
-				if m.IsSlash {
-					continue
-				}
-				cs.ContextTokens += s.countMessageTokens(m)
-			}
-		})
-	}
-
-	// Point the poll at the tail of the rewound history so the regenerated
-	// response (appended when the model returns) is collected as a new turn.
+	// History now ends at the interruption point. Point the poll at the tail so
+	// the resumed response (appended when the model returns) is collected as a
+	// new turn, then send to the driver.
 	s.LastPoll = len(s.history)
-
-	// Regenerate the response through the normal model round-trip
-	// (ReceiveInference -> processAgentMessage -> history/poll return).
 	s.sendToDriver()
+	s.persist(false)
 
 	return true
 }

--- a/internal/agent/slash_test.go
+++ b/internal/agent/slash_test.go
@@ -214,7 +214,7 @@ func TestSlashHelp_IsMarkdown(t *testing.T) {
 	assert.Contains(t, content, "\n- `/help`")
 	assert.Contains(t, content, "- `/help` — Show this list of commands")
 	assert.Contains(t, content, "- `/compact` — Compact the conversation history to save context")
-	assert.Contains(t, content, "- `/retry` — Regenerate the last response")
+	assert.Contains(t, content, "- `/retry` — Resume an interrupted turn")
 	assert.Contains(t, content, "- `/refresh` — Rebuild the system prompt from current agent config")
 	assert.Contains(t, content, "- `/model` — Switch the model for this conversation")
 	assert.Contains(t, content, "Type a command followed by Enter to run it.")
@@ -835,26 +835,31 @@ func TestSlashCompact_HandlerNoPolicy_RepliesNoModel(t *testing.T) {
 // /retry
 // ---------------------------------------------------------------------------
 
-func TestSlashRetry_RegeneratesPreviousResponse(t *testing.T) {
+// TestSlashRetry_InterruptedTurn_ResumesWithoutNewUserMessage verifies that
+// /retry on an interrupted turn (the last real message is a user message with
+// no reply yet) invokes sendToDriver WITHOUT truncating history and WITHOUT
+// appending a new (non-slash) user message. The /retry command text itself is
+// recorded as a marked IsSlash message, which sendToDriver filters from the
+// model payload so nothing but the original turn is sent.
+func TestSlashRetry_InterruptedTurn_ResumesWithoutNewUserMessage(t *testing.T) {
 	store, s := newChatSlashStore(t, nil)
-	// Seed a conversation with a real user turn and its assistant response.
+	// Interrupted turn: the last non-slash message is a user message (no reply).
 	s.history = []AgentMessage{
 		{Role: RoleUser, User: "u", Content: "hello"},
-		{Role: RoleAgent, Content: "hi there", IsComplete: true},
 	}
 	setChatText(s, AgentSessionTypeChatTurn, "/retry")
 
 	s.run()
 
-	// The model is invoked to regenerate the response.
+	// sendToDriver is invoked to resume the turn.
 	params := store.getNoWaitParams("driver:openai:send_to_model")
-	require.NotNil(t, params, "sendToDriver must be invoked for /retry")
+	require.NotNil(t, params, "sendToDriver must be invoked for /retry on an interrupted turn")
 	driverHistory, ok := params["history"].([]AgentMessage)
 	require.True(t, ok)
 
-	// The history is rewound: the previous assistant response is dropped and the
-	// previous real user message is re-sent. The /retry command text must NOT be
-	// what is sent to the model.
+	// The model payload holds the system prompt plus the original user turn only.
+	// The /retry command text is IsSlash and must be filtered out, and no new
+	// "continue" user message is introduced (trailing role is already a user).
 	expected := []string{"You are helpful.", "hello"}
 	require.Len(t, driverHistory, len(expected))
 	for i, want := range expected {
@@ -862,57 +867,89 @@ func TestSlashRetry_RegeneratesPreviousResponse(t *testing.T) {
 		assert.False(t, driverHistory[i].IsSlash)
 	}
 
-	// The in-memory history after the rewind holds the previous user message
-	// (now the re-appended normal RoleUser) plus the preserved /retry marker.
-	require.NotEmpty(t, s.history)
+	// In-memory history is NOT rewound or re-appended: it holds the original user
+	// turn plus the recorded /retry command text (IsSlash). No duplicate user
+	// message is added.
+	require.Len(t, s.history, 2)
 	assert.Equal(t, RoleUser, s.history[0].Role)
 	assert.Equal(t, "hello", s.history[0].Content)
-	assert.False(t, s.history[0].IsSlash, "re-appended user message must not be marked slash")
+	assert.False(t, s.history[0].IsSlash)
+	assert.Equal(t, RoleUser, s.history[1].Role)
+	assert.Equal(t, "/retry", s.history[1].Content)
+	assert.True(t, s.history[1].IsSlash, "/retry command text must be marked IsSlash")
 }
 
-func TestSlashRetry_SkipsTrailingSlashMessagesToFindRealUserTurn(t *testing.T) {
+// TestSlashRetry_CompleteTurn_NothingToRetry verifies that /retry on a turn that
+// already completed (last non-slash message is a complete agent message) replies
+// "nothing to retry" and does NOT invoke the model.
+func TestSlashRetry_CompleteTurn_NothingToRetry(t *testing.T) {
 	store, s := newChatSlashStore(t, nil)
-	// A real conversation followed by a separate slash turn (e.g. /help). The
-	// slash-origin messages must not be mistaken for the previous user turn.
 	s.history = []AgentMessage{
 		{Role: RoleUser, User: "u", Content: "hello"},
 		{Role: RoleAgent, Content: "hi there", IsComplete: true},
-		{Role: RoleUser, Content: "/help", IsSlash: true},
-		{Role: RoleAgent, Content: "Available commands...", IsComplete: true, IsSlash: true},
 	}
 	setChatText(s, AgentSessionTypeChatTurn, "/retry")
 
 	s.run()
+
+	assert.False(t, store.hasCall("driver:openai:send_to_model"), "no model call when the last turn already completed")
+	last := requireLastAgentReply(t, s)
+	assert.Contains(t, last.Content, "Nothing to retry")
+}
+
+// TestSlashRetry_MidToolCallInterruption_ResolvesThenResumes verifies that /retry
+// after a mid-tool-call interruption calls resolveUnresolvedToolCalls to append
+// failure results, advances LastPoll to the new tail, and then invokes
+// sendToDriver so the model sees a clean continuation point.
+func TestSlashRetry_MidToolCallInterruption_ResolvesThenResumes(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	s.history = []AgentMessage{
+		{Role: RoleUser, User: "u", Content: "hello"},
+		{
+			Role: RoleAgent,
+			ToolCalls: []AgentToolCall{
+				{FuncName: "test_tool", Params: map[string]interface{}{"arg": "val"}},
+			},
+		},
+	}
+	setChatText(s, AgentSessionTypeChatTurn, "/retry")
+
+	s.run()
+
+	// The hanging tool call from the interrupted turn is resolved with a failure
+	// result appended to history, before the model is resumed. recordSlashCommandText
+	// records the /retry marker first, so the appended tool result is the final
+	// entry in history (the /retry slash text sits just before it).
+	require.GreaterOrEqual(t, len(s.history), 4)
+	lastIdx := len(s.history) - 1
+	assert.Equal(t, RoleToolResult, s.history[lastIdx].Role)
+	require.Len(t, s.history[lastIdx].ToolResult, 1)
+	assert.Equal(t, "failure", s.history[lastIdx].ToolResult[0]["status"])
+	assert.Equal(t, "test_tool", s.history[lastIdx].ToolResult[0]["func_name"])
+	// LastPoll advanced to the tail of the (now grown) history.
+	assert.Equal(t, len(s.history), s.LastPoll)
 
 	params := store.getNoWaitParams("driver:openai:send_to_model")
-	require.NotNil(t, params)
+	require.NotNil(t, params, "sendToDriver must be invoked to resume the paused tool turn")
 	driverHistory, ok := params["history"].([]AgentMessage)
 	require.True(t, ok)
-	expected := []string{"You are helpful.", "hello"}
-	require.Len(t, driverHistory, len(expected))
-	for i, want := range expected {
-		assert.Equal(t, want, driverHistory[i].Content, "driver history[%d]", i)
-		assert.False(t, driverHistory[i].IsSlash)
-	}
+	// system + user + agent tool call + tool_result failure + synthetic continue.
+	require.Len(t, driverHistory, 5)
+	assert.Equal(t, RoleUser, driverHistory[1].Role)
+	assert.Equal(t, "hello", driverHistory[1].Content)
+	assert.Equal(t, RoleAgent, driverHistory[2].Role)
+	assert.Len(t, driverHistory[2].ToolCalls, 1)
+	assert.Equal(t, RoleToolResult, driverHistory[3].Role)
+	assert.Equal(t, "failure", driverHistory[3].ToolResult[0]["status"])
+	// Because the trailing real role is a tool result, sendToDriver appends the
+	// ephemeral "Please continue." user message (never persisted to s.history).
+	assert.Equal(t, RoleUser, driverHistory[4].Role)
+	assert.Equal(t, "Please continue.", driverHistory[4].Content)
 }
 
-func TestSlashRetry_NoPriorUserMessage_RepliesErrorNoModel(t *testing.T) {
-	store, s := newChatSlashStore(t, nil)
-	// No real user message in history (only slash-origin entries).
-	s.history = []AgentMessage{
-		{Role: RoleUser, Content: "/help", IsSlash: true},
-	}
-	setChatText(s, AgentSessionTypeChatTurn, "/retry")
-
-	s.run()
-
-	// No model invocation; a helpful marked error reply is produced instead.
-	assert.False(t, store.hasCall("driver:openai:send_to_model"), "no model call when there is nothing to retry")
-	last := requireLastAgentReply(t, s)
-	assert.Contains(t, last.Content, "No previous user message")
-}
-
-func TestSlashRetry_EmptyHistory_RepliesErrorNoModel(t *testing.T) {
+// TestSlashRetry_EmptyHistory_NothingToRetry verifies that /retry on empty
+// history replies "nothing to retry" and does not invoke the model.
+func TestSlashRetry_EmptyHistory_NothingToRetry(t *testing.T) {
 	store, s := newChatSlashStore(t, nil)
 	s.history = nil
 	setChatText(s, AgentSessionTypeChatTurn, "/retry")
@@ -921,14 +958,17 @@ func TestSlashRetry_EmptyHistory_RepliesErrorNoModel(t *testing.T) {
 
 	assert.False(t, store.hasCall("driver:openai:send_to_model"), "no model call on empty history")
 	last := requireLastAgentReply(t, s)
-	assert.Contains(t, last.Content, "No previous user message")
+	assert.Contains(t, last.Content, "Nothing to retry")
 }
 
-func TestSlashRetry_WorkflowChatTurn_RegeneratedResponseObservableViaPoll(t *testing.T) {
+// TestSlashRetry_WorkflowChatTurn_ResumedResponseObservableViaPoll verifies that
+// a /retry resume flows through the normal workflow return path: the model
+// response is appended to history and emitPollResponse surfaces it as the new
+// agent_response.
+func TestSlashRetry_WorkflowChatTurn_ResumedResponseObservableViaPoll(t *testing.T) {
 	store, s := newChatSlashStore(t, nil)
 	s.history = []AgentMessage{
 		{Role: RoleUser, User: "u", Content: "hello"},
-		{Role: RoleAgent, Content: "old response", IsComplete: true},
 	}
 	setChatText(s, AgentSessionTypeChatTurn, "/retry")
 
@@ -936,41 +976,41 @@ func TestSlashRetry_WorkflowChatTurn_RegeneratedResponseObservableViaPoll(t *tes
 	// sendToDriver(). No entry-specific code is required.
 	s.run()
 	params := store.getNoWaitParams("driver:openai:send_to_model")
-	require.NotNil(t, params, "regeneration dispatched for /retry")
+	require.NotNil(t, params, "resume dispatched for /retry")
 	driverHistory, _ := params["history"].([]AgentMessage)
 	require.Len(t, driverHistory, 2)
 	assert.Equal(t, "hello", driverHistory[1].Content)
 
-	// Simulate the model returning the regenerated response (ReceiveInference ->
+	// Simulate the model returning the resumed response (ReceiveInference ->
 	// processAgentResponse -> processAgentMessage appends to history).
 	respMsg := &dipper.Message{
 		Labels: map[string]string{"agent_session_id": s.ID, "status": "success"},
 		Payload: map[string]interface{}{
 			"message": map[string]interface{}{
 				"Role":       RoleAgent,
-				"Content":    "regenerated response",
+				"Content":    "resumed response",
 				"IsComplete": true,
 			},
 		},
 	}
 	s.processAgentResponse(respMsg)
 
-	// The regenerated response is appended to the history.
+	// The resumed response is appended to the history.
 	require.NotEmpty(t, s.history)
 	last := s.history[len(s.history)-1]
 	assert.Equal(t, RoleAgent, last.Role)
-	assert.Equal(t, "regenerated response", last.Content)
+	assert.Equal(t, "resumed response", last.Content)
 
-	// The workflow poll path (PollInference -> emitPollResponse) surfaces the
-	// regenerated response as the new agent_response. After the rewind,
-	// LastPoll pointed just before the regenerated response.
+	// The workflow poll path surfaces the resumed response as the new
+	// agent_response. LastPoll pointed at the tail when /retry ran, so the
+	// appended response is collected as a new turn.
 	pollMsg := &dipper.Message{Labels: map[string]string{
 		"resume_key":       "wf.0",
 		"agent_session_id": s.ID,
 	}}
 	emittedBefore := len(store.getEmitted())
 	handled := s.emitPollResponse(pollMsg)
-	assert.True(t, handled, "emitPollResponse should emit the regenerated response")
+	assert.True(t, handled, "emitPollResponse should emit the resumed response")
 	emitted := store.getEmitted()
 	require.Greater(t, len(emitted), emittedBefore)
 	lastEmitted := emitted[len(emitted)-1]
@@ -978,5 +1018,22 @@ func TestSlashRetry_WorkflowChatTurn_RegeneratedResponseObservableViaPoll(t *tes
 	fullMessages, ok := lastEmitted.Payload.(map[string]interface{})["full_messages"].([]map[string]string)
 	require.True(t, ok, "expected full_messages in poll response")
 	require.NotEmpty(t, fullMessages)
-	assert.Contains(t, fullMessages[0]["content"], "regenerated response")
+	assert.Contains(t, fullMessages[0]["content"], "resumed response")
+}
+
+// TestSlashRetry_InferenceNoOp verifies /retry is chat-turn-only: in an
+// inference session the leading "/retry" is treated as ordinary text and flows
+// through untouched (no slash dispatch, no special handling).
+func TestSlashRetry_InferenceNoOp(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	setChatText(s, AgentSessionTypeInference, "/retry")
+
+	s.run()
+
+	// Inference always flows through untouched, even with a leading slash.
+	assert.True(t, store.hasCall("driver:openai:send_to_model"))
+	require.Len(t, s.history, 1)
+	assert.Equal(t, RoleUser, s.history[0].Role)
+	assert.Equal(t, "/retry", s.history[0].Content)
+	assert.False(t, s.history[0].IsSlash)
 }

--- a/internal/agent/slash_test.go
+++ b/internal/agent/slash_test.go
@@ -830,3 +830,153 @@ func TestSlashCompact_HandlerNoPolicy_RepliesNoModel(t *testing.T) {
 	assert.Contains(t, last.Content, "not configured")
 	assert.Empty(t, store.getEmitted())
 }
+
+// ---------------------------------------------------------------------------
+// /retry
+// ---------------------------------------------------------------------------
+
+func TestSlashRetry_RegeneratesPreviousResponse(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	// Seed a conversation with a real user turn and its assistant response.
+	s.history = []AgentMessage{
+		{Role: RoleUser, User: "u", Content: "hello"},
+		{Role: RoleAgent, Content: "hi there", IsComplete: true},
+	}
+	setChatText(s, AgentSessionTypeChatTurn, "/retry")
+
+	s.run()
+
+	// The model is invoked to regenerate the response.
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params, "sendToDriver must be invoked for /retry")
+	driverHistory, ok := params["history"].([]AgentMessage)
+	require.True(t, ok)
+
+	// The history is rewound: the previous assistant response is dropped and the
+	// previous real user message is re-sent. The /retry command text must NOT be
+	// what is sent to the model.
+	expected := []string{"You are helpful.", "hello"}
+	require.Len(t, driverHistory, len(expected))
+	for i, want := range expected {
+		assert.Equal(t, want, driverHistory[i].Content, "driver history[%d]", i)
+		assert.False(t, driverHistory[i].IsSlash)
+	}
+
+	// The in-memory history after the rewind holds the previous user message
+	// (now the re-appended normal RoleUser) plus the preserved /retry marker.
+	require.NotEmpty(t, s.history)
+	assert.Equal(t, RoleUser, s.history[0].Role)
+	assert.Equal(t, "hello", s.history[0].Content)
+	assert.False(t, s.history[0].IsSlash, "re-appended user message must not be marked slash")
+}
+
+func TestSlashRetry_SkipsTrailingSlashMessagesToFindRealUserTurn(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	// A real conversation followed by a separate slash turn (e.g. /help). The
+	// slash-origin messages must not be mistaken for the previous user turn.
+	s.history = []AgentMessage{
+		{Role: RoleUser, User: "u", Content: "hello"},
+		{Role: RoleAgent, Content: "hi there", IsComplete: true},
+		{Role: RoleUser, Content: "/help", IsSlash: true},
+		{Role: RoleAgent, Content: "Available commands...", IsComplete: true, IsSlash: true},
+	}
+	setChatText(s, AgentSessionTypeChatTurn, "/retry")
+
+	s.run()
+
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params)
+	driverHistory, ok := params["history"].([]AgentMessage)
+	require.True(t, ok)
+	expected := []string{"You are helpful.", "hello"}
+	require.Len(t, driverHistory, len(expected))
+	for i, want := range expected {
+		assert.Equal(t, want, driverHistory[i].Content, "driver history[%d]", i)
+		assert.False(t, driverHistory[i].IsSlash)
+	}
+}
+
+func TestSlashRetry_NoPriorUserMessage_RepliesErrorNoModel(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	// No real user message in history (only slash-origin entries).
+	s.history = []AgentMessage{
+		{Role: RoleUser, Content: "/help", IsSlash: true},
+	}
+	setChatText(s, AgentSessionTypeChatTurn, "/retry")
+
+	s.run()
+
+	// No model invocation; a helpful marked error reply is produced instead.
+	assert.False(t, store.hasCall("driver:openai:send_to_model"), "no model call when there is nothing to retry")
+	last := requireLastAgentReply(t, s)
+	assert.Contains(t, last.Content, "No previous user message")
+}
+
+func TestSlashRetry_EmptyHistory_RepliesErrorNoModel(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	s.history = nil
+	setChatText(s, AgentSessionTypeChatTurn, "/retry")
+
+	s.run()
+
+	assert.False(t, store.hasCall("driver:openai:send_to_model"), "no model call on empty history")
+	last := requireLastAgentReply(t, s)
+	assert.Contains(t, last.Content, "No previous user message")
+}
+
+func TestSlashRetry_WorkflowChatTurn_RegeneratedResponseObservableViaPoll(t *testing.T) {
+	store, s := newChatSlashStore(t, nil)
+	s.history = []AgentMessage{
+		{Role: RoleUser, User: "u", Content: "hello"},
+		{Role: RoleAgent, Content: "old response", IsComplete: true},
+	}
+	setChatText(s, AgentSessionTypeChatTurn, "/retry")
+
+	// Workflow-originated path: runTurn -> run() dispatches /retry which calls
+	// sendToDriver(). No entry-specific code is required.
+	s.run()
+	params := store.getNoWaitParams("driver:openai:send_to_model")
+	require.NotNil(t, params, "regeneration dispatched for /retry")
+	driverHistory, _ := params["history"].([]AgentMessage)
+	require.Len(t, driverHistory, 2)
+	assert.Equal(t, "hello", driverHistory[1].Content)
+
+	// Simulate the model returning the regenerated response (ReceiveInference ->
+	// processAgentResponse -> processAgentMessage appends to history).
+	respMsg := &dipper.Message{
+		Labels: map[string]string{"agent_session_id": s.ID, "status": "success"},
+		Payload: map[string]interface{}{
+			"message": map[string]interface{}{
+				"Role":       RoleAgent,
+				"Content":    "regenerated response",
+				"IsComplete": true,
+			},
+		},
+	}
+	s.processAgentResponse(respMsg)
+
+	// The regenerated response is appended to the history.
+	require.NotEmpty(t, s.history)
+	last := s.history[len(s.history)-1]
+	assert.Equal(t, RoleAgent, last.Role)
+	assert.Equal(t, "regenerated response", last.Content)
+
+	// The workflow poll path (PollInference -> emitPollResponse) surfaces the
+	// regenerated response as the new agent_response. After the rewind,
+	// LastPoll pointed just before the regenerated response.
+	pollMsg := &dipper.Message{Labels: map[string]string{
+		"resume_key":       "wf.0",
+		"agent_session_id": s.ID,
+	}}
+	emittedBefore := len(store.getEmitted())
+	handled := s.emitPollResponse(pollMsg)
+	assert.True(t, handled, "emitPollResponse should emit the regenerated response")
+	emitted := store.getEmitted()
+	require.Greater(t, len(emitted), emittedBefore)
+	lastEmitted := emitted[len(emitted)-1]
+	assert.Equal(t, "agent_response", lastEmitted.Subject)
+	fullMessages, ok := lastEmitted.Payload.(map[string]interface{})["full_messages"].([]map[string]string)
+	require.True(t, ok, "expected full_messages in poll response")
+	require.NotEmpty(t, fullMessages)
+	assert.Contains(t, fullMessages[0]["content"], "regenerated response")
+}


### PR DESCRIPTION
## Summary

Implements the turn-producing built-in `/retry` slash command (Phase 2 of the agent slash-command feature). It replaces the Phase 1 placeholder `slashRetry` handler with the real resume logic.

> **Note (reworked):** `/retry` is for retrying after an **interrupted turn** (e.g. cancelled or errored out mid-way). It resumes/continues the conversation rather than rewinding and regenerating.

## What changed

**`internal/agent/slash.go`**
- Added `lastNonSlashMsg()` — returns the most recent history message that is not marked `IsSlash`, or `nil` when history is empty (or every message is slash-origin).
- Added `hasInterruptedTurn()` — returns `false` when the last non-slash message is `nil` (empty history) or is a complete agent message (`Role == RoleAgent && IsComplete && len(ToolCalls) == 0`); returns `true` otherwise (interrupted). Interrupted cases: trailing `RoleUser`, `RoleToolResult`, `RoleAgent` with `ToolCalls > 0`, or `RoleAgent` with `IsComplete == false`.
- Replaced the placeholder with a real `slashRetry`:
  1. If the turn is **not** interrupted, replies `"Nothing to retry: the last turn already completed."` via `reply()` and does **not** send to the model.
  2. Otherwise the turn was interrupted and history already ends at the interruption point: `resolveUnresolvedToolCalls()` clears any hanging tool calls.
  3. Points `LastPoll` at the tail, calls `sendToDriver()`, and persists.

  `sendToDriver()` **already implements resume**: it rebuilds model history from `s.history` (filtering `IsSlash` — which removes the `/retry` command text just recorded), and appends a synthetic `"Please continue."` only to the local history slice when the trailing role isn't a user — it is **never written to `s.history`**. So nothing is recorded as a new user message.

**`internal/agent/agent_session.go`**
- `resolveUnresolvedToolCalls()` now looks at the **last non-slash message** so a trailing marked slash command text (the `/retry` marker) does not hide an unresolved tool call from the interrupted turn just below it. It remains idempotent and correct for the existing cancel-path call sites.

**`internal/agent/slash_test.go`**
- `/retry` on an interrupted turn (last non-slash msg is `RoleUser`) invokes `sendToDriver` (recording store spy) and does **not** append a new `RoleUser` message to history; the `/retry` command text is recorded `IsSlash` and filtered from the model payload.
- `/retry` on a complete turn (last non-slash msg is complete agent message) returns `"Nothing to retry"` via `reply()` and does **not** call `sendToDriver`.
- `/retry` after a mid-tool-call interruption → `resolveUnresolvedToolCalls` adds failure results, `LastPoll` advanced, then `sendToDriver`.
- `/retry` with empty history → `"Nothing to retry"`, no model call.
- `/retry` returns across the workflow path: model response appended → `emitPollResponse` yields it as `agent_response`.
- Guard: `/retry` is chat-turn-only and a no-op for inference.
- Updated `/help` description to "Resume an interrupted turn".

## Behavior notes
- `/retry` works on both workflow-originated and UI-originated chat turns — it is just another path through `sendToDriver()` + the shared history/poll return; no entry-specific code.
- No lifecycle changes needed: typing `/retry` as a new chat message creates a fresh session, so `checkCancelled()` returns false and the turn lock was already released when the prior turn ended.
- The `/retry` command text is recorded as a marked `IsSlash` `RoleUser` message and never sent to the model as context.

## Validation
- `go test ./...` passes.
- `golangci-lint run ./internal/agent/` reports 0 issues.