### PR TITLE
feat(api): Redis-backed session engine with sid, logout, and tiered enforcement

### DIFF
--- a/HONEYDIPPER_CONTEXT.md
+++ b/HONEYDIPPER_CONTEXT.md
@@ -421,6 +421,21 @@ by a daemon-minted opaque UUID `sid` (stable across token rotation). See
   otherwise the user re-authenticates (new sid). An idle SAML/auth-simple
   session requires re-authentication. `maxLifetime`-exceeded is always a hard
   re-auth (never silently re-vouched).
+- Sessions are registered eagerly at login: the GitHub OAuth callback reads the
+  driver-returned login as `subject` (with a `username` fallback) and registers
+  the daemon-minted `sid` immediately; SAML ACS does the same. Unknown-but-valid
+  sids are lazily registered as a rollout safety net, anchored to the token's
+  real issuance time (`iat`) so the absolute `maxLifetime` cap is measured from
+  actual issuance, not first-seen.
+- `last_seen` writes are throttled: the short-TTL cache refreshes `last_seen` in
+  memory on every request but writes through to Redis at most once per
+  `cacheTTL`, bounding write amplification on busy multi-node deployments. The
+  per-subject Redis index (`hd-auth-sessions:subject:*`) is pruned of stale sids
+  (whose records were GC'd) on revoke-all and via `PruneSubject`, so it does not
+  grow without bound.
+- Daemon JWTs minted for an authenticated principal have their `exp` bound to
+  the session's absolute `maxLifetime` cap (via `SignPrincipalJWTSession`) when
+  one is configured, so the JWT exp never disagrees with the sid-based cap.
 - `POST /auth/logout` revokes the current sid (or all sessions for the subject
   via `?all=true`), correct cross-node through the shared Redis store.
 - All expiry modes set the `X-Honeydipper-Session-Expired` response header

--- a/HONEYDIPPER_CONTEXT.md
+++ b/HONEYDIPPER_CONTEXT.md
@@ -403,12 +403,37 @@ LOOKUP[<driver>,<path>][:<printf_pattern>]
 3. Fallback to auth provider driver (`auth_web_request` RPC) → on success, issue `X-Honeydipper-JWT` header
 4. All fail → 401
 
+### 11.2.1 Server-Side Session Engine
+
+Login sessions are enforced server-side via a Redis-backed session store keyed
+by a daemon-minted opaque UUID `sid` (stable across token rotation). See
+`internal/api/session/`.
+
+- `auth.session.*` daemon config controls the policy: `enabled`, `idleTimeout`,
+  `maxLifetime` (optional absolute cap, default off), `tokenGracePeriod`
+  (roll-out grace for pre-upgrade sid-less tokens), `cacheTTL`, and `redis`
+  connection settings. Env-var overrides follow the `HD_SESSION_*` convention.
+- Provider tiers: IAP takes creds directly from the IAP JWT (no session store);
+  GitHub/SAML check the session in Redis; auth-simple is also stored so
+  logout/revoke and idle tracking work.
+- Idle timeout is a provider re-vouch trigger, not a hard logout. An idle
+  GitHub session is silently renewed (same sid) when the provider is alive,
+  otherwise the user re-authenticates (new sid). An idle SAML/auth-simple
+  session requires re-authentication. `maxLifetime`-exceeded is always a hard
+  re-auth (never silently re-vouched).
+- `POST /auth/logout` revokes the current sid (or all sessions for the subject
+  via `?all=true`), correct cross-node through the shared Redis store.
+- All expiry modes set the `X-Honeydipper-Session-Expired` response header
+  (exposed via `Access-Control-Expose-Headers`) and return a consistent
+  "re-authenticate" 401.
+
 ### 11.3 Registered Routes
 
 | Path | Service | Notes |
 |---|---|---|
 | `/auth/saml/*` | Local | SAML SP login/metadata/ACS callback |
 | `/auth/github/callback` | Local | GitHub OAuth |
+| `/auth/logout` | Local | Revoke current session (or all for subject) |
 | `/user/profile` | Local | Current user profile |
 | `/events/*` | Engine | CRUD + long-poll wait |
 | `/gh/events/*` | Engine | GitHub-scoped (with entitlement) |

--- a/internal/api/def.go
+++ b/internal/api/def.go
@@ -143,6 +143,9 @@ func GetDefs() map[string]map[string]Def {
 		"user/profile": {
 			http.MethodGet: {Object: "user/profile", Name: "userProfile", ReqType: TypeLocal, Local: userProfileHandler, Service: "api"},
 		},
+		"auth/logout": {
+			http.MethodPost: {Object: "auth/logout", Name: "authLogout", ReqType: TypeLocal, Local: logoutHandler, Service: "api"},
+		},
 		"events/:eventID/wait": {
 			http.MethodGet: {Object: "event", Name: "eventWait", ReqType: TypeFirst, Service: "engine", Timeout: InfiniteDuration},
 		},

--- a/internal/api/jwtutil.go
+++ b/internal/api/jwtutil.go
@@ -59,8 +59,30 @@ func getJWTConfig() (*JWTConfig, error) {
 
 // SignPrincipalJWT signs a daemon JWT for the given principal. The principal's
 // SID (if set) is embedded in the token and preserved verbatim so rotation
-// never regenerates the session identity.
+// never regenerates the session identity. The token exp is the configured
+// ExpiresIn unless a session cap is applied via SignPrincipalJWTSession.
 func SignPrincipalJWT(principal Principal, cfg *JWTConfig) (string, error) {
+	return signPrincipalJWTWithExp(principal, cfg, time.Now().Add(cfg.ExpiresIn))
+}
+
+// SignPrincipalJWTSession signs a daemon JWT whose expiry is bound to the
+// session's absolute cap when one is configured and the session issuance time
+// is known. This keeps the JWT exp from disagreeing with the sid-based
+// maxLifetime cap (the token does not outlive the session). When maxLifetime
+// is <= 0 or issuedAt is unknown, the configured ExpiresIn is used unchanged.
+func SignPrincipalJWTSession(principal Principal, cfg *JWTConfig, issuedAt int64, maxLifetime time.Duration) (string, error) {
+	exp := time.Now().Add(cfg.ExpiresIn)
+	if maxLifetime > 0 && issuedAt > 0 {
+		sessionExp := time.Unix(issuedAt, 0).Add(maxLifetime)
+		if sessionExp.Before(exp) {
+			exp = sessionExp
+		}
+	}
+
+	return signPrincipalJWTWithExp(principal, cfg, exp)
+}
+
+func signPrincipalJWTWithExp(principal Principal, cfg *JWTConfig, exp time.Time) (string, error) {
 	claims := PrincipalClaims{
 		Subject:     principal.Subject,
 		ProfileName: principal.ProfileName,
@@ -69,7 +91,7 @@ func SignPrincipalJWT(principal Principal, cfg *JWTConfig) (string, error) {
 		Data:        principal.Data,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    cfg.Issuer,
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(cfg.ExpiresIn)),
+			ExpiresAt: jwt.NewNumericDate(exp),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 		},
 	}
@@ -95,11 +117,17 @@ func ParsePrincipalJWT(tokenString string, cfg *JWTConfig) (*Principal, error) {
 		return nil, ErrInvalidJWT
 	}
 
+	issuedAt := int64(0)
+	if claims.IssuedAt != nil {
+		issuedAt = claims.IssuedAt.Unix()
+	}
+
 	return &Principal{
 		Subject:     claims.Subject,
 		ProfileName: claims.ProfileName,
 		Provider:    claims.Provider,
 		SID:         claims.SID,
+		IssuedAt:    issuedAt,
 		Data:        claims.Data,
 	}, nil
 }

--- a/internal/api/jwtutil.go
+++ b/internal/api/jwtutil.go
@@ -20,6 +20,11 @@ var (
 	ErrMissingJWTSigningKey = errors.New("missing JWT signing key in config")
 )
 
+// SIDClaim is the JWT claim name carrying the daemon-minted opaque session
+// identifier (sid). The sid is stable across token rotation and is the primary
+// key of the server-side session store.
+const SIDClaim = "sid"
+
 type JWTConfig struct {
 	SigningKey []byte
 	Issuer     string
@@ -30,6 +35,7 @@ type PrincipalClaims struct {
 	Subject     string                 `json:"sub"`
 	ProfileName string                 `json:"profile_name"`
 	Provider    string                 `json:"provider"`
+	SID         string                 `json:"sid,omitempty"`
 	Data        map[string]interface{} `json:"data"`
 	jwt.RegisteredClaims
 }
@@ -51,11 +57,15 @@ func getJWTConfig() (*JWTConfig, error) {
 	}, nil
 }
 
+// SignPrincipalJWT signs a daemon JWT for the given principal. The principal's
+// SID (if set) is embedded in the token and preserved verbatim so rotation
+// never regenerates the session identity.
 func SignPrincipalJWT(principal Principal, cfg *JWTConfig) (string, error) {
 	claims := PrincipalClaims{
 		Subject:     principal.Subject,
 		ProfileName: principal.ProfileName,
 		Provider:    principal.Provider,
+		SID:         principal.SID,
 		Data:        principal.Data,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    cfg.Issuer,
@@ -89,6 +99,7 @@ func ParsePrincipalJWT(tokenString string, cfg *JWTConfig) (*Principal, error) {
 		Subject:     claims.Subject,
 		ProfileName: claims.ProfileName,
 		Provider:    claims.Provider,
+		SID:         claims.SID,
 		Data:        claims.Data,
 	}, nil
 }

--- a/internal/api/jwtutil_test.go
+++ b/internal/api/jwtutil_test.go
@@ -134,3 +134,56 @@ func TestSignPrincipalJWTNoSIDForOlderClients(t *testing.T) {
 		t.Fatalf("expected empty sid for sid-less principal, got %q", got.SID)
 	}
 }
+
+// parseExpFromPrincipalJWT parses a daemon JWT and returns its exp timestamp.
+func parseExpFromPrincipalJWT(t *testing.T, token string, cfg *JWTConfig) time.Time {
+	t.Helper()
+	claims := &PrincipalClaims{}
+	parsed, err := jwt.ParseWithClaims(token, claims, func(tok *jwt.Token) (interface{}, error) {
+		if _, ok := tok.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, ErrInvalidJWT
+		}
+
+		return cfg.SigningKey, nil
+	}, jwt.WithIssuer(cfg.Issuer))
+	if err != nil {
+		t.Fatalf("ParseWithClaims: %v", err)
+	}
+	if !parsed.Valid || claims.ExpiresAt == nil {
+		t.Fatalf("expected valid token with exp, got %+v", claims)
+	}
+
+	return claims.ExpiresAt.Time
+}
+
+func TestSignPrincipalJWTSessionBindsExpToMaxLifetime(t *testing.T) {
+	cfg := &JWTConfig{SigningKey: testJWTCfg.SigningKey, Issuer: "honeydipper", ExpiresIn: 24 * time.Hour}
+	principal := Principal{Subject: "alice", Provider: "auth-github", SID: "sid-1", IssuedAt: time.Now().Unix()}
+
+	// Strong cap: session expires well before the default 24h JWT exp.
+	token, err := SignPrincipalJWTSession(principal, cfg, principal.IssuedAt, time.Hour)
+	if err != nil {
+		t.Fatalf("SignPrincipalJWTSession: %v", err)
+	}
+	expTime := parseExpFromPrincipalJWT(t, token, cfg)
+	now := time.Now()
+	if expTime.Before(now) || expTime.After(now.Add(90*time.Minute)) {
+		t.Fatalf("expected session-bound exp near now+1h, got %v", expTime)
+	}
+}
+
+func TestSignPrincipalJWTSessionFallsBackToExpiresIn(t *testing.T) {
+	cfg := &JWTConfig{SigningKey: testJWTCfg.SigningKey, Issuer: "honeydipper", ExpiresIn: time.Hour}
+	principal := Principal{Subject: "alice", Provider: "auth-github", SID: "sid-1", IssuedAt: time.Now().Unix()}
+
+	// No maxLifetime configured -> default ExpiresIn applies unchanged.
+	token, err := SignPrincipalJWTSession(principal, cfg, principal.IssuedAt, 0)
+	if err != nil {
+		t.Fatalf("SignPrincipalJWTSession: %v", err)
+	}
+	expTime := parseExpFromPrincipalJWT(t, token, cfg)
+	now := time.Now()
+	if expTime.Before(now.Add(50*time.Minute)) || expTime.After(now.Add(70*time.Minute)) {
+		t.Fatalf("expected default 1h exp, got %v", expTime)
+	}
+}

--- a/internal/api/jwtutil_test.go
+++ b/internal/api/jwtutil_test.go
@@ -100,3 +100,37 @@ func TestParsePrincipalJWT_NonHDJWTRejected(t *testing.T) {
 		t.Fatal("expected SAML session JWT to be rejected by middleware, got nil error")
 	}
 }
+
+func TestSignPrincipalJWTEmbedsAndPreservesSID(t *testing.T) {
+	principal := Principal{Subject: "alice", ProfileName: "Alice", Provider: "test", SID: "stable-sid-123"}
+	token, err := SignPrincipalJWT(principal, testJWTCfg)
+	if err != nil {
+		t.Fatalf("SignPrincipalJWT: %v", err)
+	}
+
+	got, err := ParsePrincipalJWT(token, testJWTCfg)
+	if err != nil {
+		t.Fatalf("ParsePrincipalJWT: %v", err)
+	}
+	if got.SID != "stable-sid-123" {
+		t.Fatalf("expected sid embedded and preserved, got %q", got.SID)
+	}
+}
+
+func TestSignPrincipalJWTNoSIDForOlderClients(t *testing.T) {
+	// A principal without a sid produces a token without a sid claim, matching
+	// the pre-upgrade (sid-less) token path.
+	principal := Principal{Subject: "bob", Provider: "test"}
+	token, err := SignPrincipalJWT(principal, testJWTCfg)
+	if err != nil {
+		t.Fatalf("SignPrincipalJWT: %v", err)
+	}
+
+	got, err := ParsePrincipalJWT(token, testJWTCfg)
+	if err != nil {
+		t.Fatalf("ParsePrincipalJWT: %v", err)
+	}
+	if got.SID != "" {
+		t.Fatalf("expected empty sid for sid-less principal, got %q", got.SID)
+	}
+}

--- a/internal/api/session/cache.go
+++ b/internal/api/session/cache.go
@@ -1,0 +1,153 @@
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Cache wraps a Store with a short-TTL in-memory validation cache so a full
+// Redis round-trip is not needed on every request. Revocation is boundedly
+// stale up to the cache TTL.
+//
+// On a revocation, the revoked sid(s) are immediately evicted from the local
+// cache and a revoked record is cached that overrides any earlier positive
+// entry for the TTL. Cross-node revocation propagation therefore lags by at
+// most the cache TTL on nodes that did not observe the revoke call directly.
+type Cache struct {
+	store Store
+	ttl   time.Duration
+	mu    sync.Mutex
+	state map[string]cacheEntry
+}
+
+type cacheEntry struct {
+	record  Record
+	unknown bool
+	expires time.Time
+}
+
+// NewCache wraps store with an in-memory validation cache with the given TTL.
+func NewCache(store Store, ttl time.Duration) *Cache {
+	if ttl <= 0 {
+		ttl = 30 * time.Second
+	}
+
+	return &Cache{store: store, ttl: ttl, state: map[string]cacheEntry{}}
+}
+
+// Register delegates to the underlying store and warms the local cache.
+func (c *Cache) Register(ctx context.Context, r Record) error {
+	if err := c.store.Register(ctx, r); err != nil {
+		return fmt.Errorf("%w", err)
+	}
+	c.put(r.SID, cacheEntry{record: r, expires: time.Now().Add(c.ttl)})
+
+	return nil
+}
+
+// Touch delegates to the underlying store and warms the local cache.
+func (c *Cache) Touch(ctx context.Context, sid, subject, provider string, issuedAt int64) (Record, error) {
+	r, err := c.store.Touch(ctx, sid, subject, provider, issuedAt)
+	if err != nil {
+		return r, fmt.Errorf("%w", err)
+	}
+	c.put(sid, cacheEntry{record: r, expires: time.Now().Add(c.ttl)})
+
+	return r, nil
+}
+
+// Get returns the cached record within TTL or falls back to Redis.
+func (c *Cache) Get(ctx context.Context, sid string) (Record, error) {
+	if e, ok := c.peek(sid); ok {
+		if e.unknown {
+			return Record{}, ErrNotFound
+		}
+
+		return e.record, nil
+	}
+
+	r, err := c.store.Get(ctx, sid)
+	if errors.Is(err, ErrNotFound) {
+		// Cache a short negative entry to amortize repeated unknown lookups.
+		c.put(sid, cacheEntry{unknown: true, expires: time.Now().Add(c.ttl)})
+
+		return r, fmt.Errorf("%w", err)
+	}
+	if err == nil && r.Revoked {
+		// Cache the revoked tombstone so it stays rejected for the window.
+		c.put(sid, cacheEntry{record: r, expires: time.Now().Add(c.revokeTTL())})
+	}
+
+	if err != nil {
+		return r, fmt.Errorf("%w", err)
+	}
+
+	return r, nil
+}
+
+// Revoke revokes the sid and immediately caches the revoked tombstone, giving
+// it a TTL that outlives any remaining token validity.
+func (c *Cache) Revoke(ctx context.Context, sid string) error {
+	if err := c.store.Revoke(ctx, sid); err != nil {
+		return fmt.Errorf("%w", err)
+	}
+	c.put(sid, cacheEntry{record: Record{SID: sid, Revoked: true}, expires: time.Now().Add(c.revokeTTL())})
+
+	return nil
+}
+
+// RevokeAllForSubject revokes every session for subject and caches each revoked
+// sid locally so subsequent requests on this node are rejected immediately.
+func (c *Cache) RevokeAllForSubject(ctx context.Context, subject string) ([]string, error) {
+	sids, err := c.store.RevokeAllForSubject(ctx, subject)
+	if err != nil {
+		return nil, fmt.Errorf("%w", err)
+	}
+	ttl := c.revokeTTL()
+	for _, sid := range sids {
+		c.put(sid, cacheEntry{record: Record{SID: sid, Revoked: true}, expires: time.Now().Add(ttl)})
+	}
+
+	return sids, nil
+}
+
+func (c *Cache) revokeTTL() time.Duration {
+	// Revoked sids must stay rejected for at least the remaining token window.
+	if c.ttl < 24*time.Hour {
+		return 24 * time.Hour
+	}
+
+	return c.ttl
+}
+
+func (c *Cache) peek(sid string) (cacheEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.state[sid]
+	if !ok {
+		return cacheEntry{}, false
+	}
+	if time.Now().After(e.expires) {
+		delete(c.state, sid)
+
+		return cacheEntry{}, false
+	}
+
+	return e, true
+}
+
+func (c *Cache) put(sid string, e cacheEntry) {
+	e.record.SID = sid
+	c.mu.Lock()
+	c.state[sid] = e
+	c.mu.Unlock()
+}

--- a/internal/api/session/cache.go
+++ b/internal/api/session/cache.go
@@ -22,6 +22,12 @@ import (
 // cache and a revoked record is cached that overrides any earlier positive
 // entry for the TTL. Cross-node revocation propagation therefore lags by at
 // most the cache TTL on nodes that did not observe the revoke call directly.
+//
+// The cache also throttles last_seen write amplification: Touch refreshes the
+// in-memory LastSeen on every call but only writes through to the underlying
+// store at most once per cache TTL. This bounds per-node Redis writes for a
+// busy deployment while keeping idle-timeout semantics within the throttle
+// window (negligible compared to typical idle timeouts of minutes/hours).
 type Cache struct {
 	store Store
 	ttl   time.Duration
@@ -33,6 +39,9 @@ type cacheEntry struct {
 	record  Record
 	unknown bool
 	expires time.Time
+	// lastStoreWrite is when the underlying store was last written for this
+	// sid, used to throttle last_seen write amplification.
+	lastStoreWrite time.Time
 }
 
 // NewCache wraps store with an in-memory validation cache with the given TTL.
@@ -49,18 +58,52 @@ func (c *Cache) Register(ctx context.Context, r Record) error {
 	if err := c.store.Register(ctx, r); err != nil {
 		return fmt.Errorf("%w", err)
 	}
-	c.put(r.SID, cacheEntry{record: r, expires: time.Now().Add(c.ttl)})
+	c.put(r.SID, cacheEntry{record: r, expires: time.Now().Add(c.ttl), lastStoreWrite: time.Now()})
 
 	return nil
 }
 
-// Touch delegates to the underlying store and warms the local cache.
+// Touch refreshes LastSeen, lazily creating the session if the sid is unknown.
+//
+// Known, active sids have their LastSeen refreshed in the local cache on every
+// call, but the underlying store is only written at most once per cache TTL to
+// avoid write amplification on a busy multi-node deployment. Unknown/revoked
+// sids always fall through to the store.
 func (c *Cache) Touch(ctx context.Context, sid, subject, provider string, issuedAt int64) (Record, error) {
+	now := time.Now()
+	c.mu.Lock()
+	e, ok := c.state[sid]
+	if ok && !e.unknown && !e.record.Revoked && now.Before(e.expires) {
+		// Refresh last_seen locally.
+		e.record.LastSeen = now.Unix()
+		throttled := now.Sub(e.lastStoreWrite) < c.ttl
+		c.state[sid] = e
+		c.mu.Unlock()
+		if throttled {
+			// No store write this time; the in-memory value is current enough
+			// for idle semantics within the throttle window.
+			return e.record, nil
+		}
+		// Bounded write-through: refresh the store, then warm the cache from
+		// the authoritative result.
+		r, err := c.store.Touch(ctx, sid, subject, provider, issuedAt)
+		if err != nil {
+			return r, fmt.Errorf("%w", err)
+		}
+		r.LastSeen = now.Unix()
+		c.put(sid, cacheEntry{record: r, expires: now.Add(c.ttl), lastStoreWrite: now})
+
+		return r, nil
+	}
+	c.mu.Unlock()
+
+	// Unknown or revoked sid (or cache expired): write through to the store so
+	// lazy registration / revocation handling stays correct.
 	r, err := c.store.Touch(ctx, sid, subject, provider, issuedAt)
 	if err != nil {
 		return r, fmt.Errorf("%w", err)
 	}
-	c.put(sid, cacheEntry{record: r, expires: time.Now().Add(c.ttl)})
+	c.put(sid, cacheEntry{record: r, expires: now.Add(c.ttl), lastStoreWrite: now})
 
 	return r, nil
 }
@@ -118,6 +161,16 @@ func (c *Cache) RevokeAllForSubject(ctx context.Context, subject string) ([]stri
 	}
 
 	return sids, nil
+}
+
+// PruneSubject delegates pruning of the per-subject index to the underlying
+// store so expired/GC'd sids stop accumulating in the index.
+func (c *Cache) PruneSubject(ctx context.Context, subject string) error {
+	if err := c.store.PruneSubject(ctx, subject); err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	return nil
 }
 
 func (c *Cache) revokeTTL() time.Duration {

--- a/internal/api/session/manager.go
+++ b/internal/api/session/manager.go
@@ -37,6 +37,10 @@ type CheckResult struct {
 	// Unknown is true when the sid was not previously known and was lazily
 	// registered (safety net / backfill).
 	Unknown bool
+	// IssuedAt is the authoritative session issuance time (unix seconds)
+	// resolved from the store. It lets callers anchor token expirations to the
+	// session's absolute cap even when the sid was lazily registered.
+	IssuedAt int64
 }
 
 // Manager evaluates sessions against a session store and the daemon policy.
@@ -95,13 +99,13 @@ func (m *Manager) Check(ctx context.Context, sid, subject, provider string, issu
 				IssuedAt: issuedAt, LastSeen: now,
 			})
 
-			return CheckResult{Sid: sid, Subject: subject, OK: true, Unknown: true}
+			return CheckResult{Sid: sid, Subject: subject, OK: true, Unknown: true, IssuedAt: issuedAt}
 		}
 
 		return CheckResult{Sid: sid, StoreDown: true}
 	}
 
-	res := CheckResult{Sid: sid, Subject: rec.Subject, Revoked: rec.Revoked}
+	res := CheckResult{Sid: sid, Subject: rec.Subject, Revoked: rec.Revoked, IssuedAt: rec.IssuedAt}
 	if res.Revoked {
 		return res
 	}

--- a/internal/api/session/manager.go
+++ b/internal/api/session/manager.go
@@ -1,0 +1,131 @@
+// Package session (part 2): policy evaluation manager.
+//
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+package session
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// CheckResult carries the outcome of evaluating a session for a request.
+type CheckResult struct {
+	// Sid is the session identifier being evaluated.
+	Sid string
+	// Subject is the subject resolved from the store (authoritative).
+	Subject string
+	// OK is true when the request may proceed with this sid (policy allows).
+	OK bool
+	// IdleExceeded is true when the idle window has elapsed. Whether this is a
+	// re-vouch (provider alive) or a hard re-auth is decided by the caller
+	// based on the provider tier.
+	IdleExceeded bool
+	// MaxLifetimeExceeded is true when the absolute cap has been reached. This
+	// is a hard re-auth - the sid must never be silently re-vouched.
+	MaxLifetimeExceeded bool
+	// Revoked is true when the sid has been revoked server-side.
+	Revoked bool
+	// StoreDown is true when the session store (Redis) is unavailable. Access
+	// must fail closed.
+	StoreDown bool
+	// Unknown is true when the sid was not previously known and was lazily
+	// registered (safety net / backfill).
+	Unknown bool
+}
+
+// Manager evaluates sessions against a session store and the daemon policy.
+type Manager struct {
+	store            Store
+	policy           Policy
+	tokenGracePeriod time.Duration
+}
+
+// NewManager builds a Manager around the given store and policy.
+func NewManager(store Store, policy Policy, tokenGracePeriod time.Duration) *Manager {
+	return &Manager{store: store, policy: policy, tokenGracePeriod: tokenGracePeriod}
+}
+
+// Store returns the underlying session store (used for logout revocation).
+func (m *Manager) Store() Store {
+	return m.store
+}
+
+// GraceActive reports whether the roll-out grace period is still in effect for
+// pre-upgrade (sid-less) tokens.
+func (m *Manager) GraceActive() bool {
+	return m.tokenGracePeriod > 0
+}
+
+// CheckNoSID evaluates a pre-upgrade token that carries no sid. During the
+// configured grace period such tokens are accepted on a best-effort basis;
+// after the grace period they are cleanly rejected (session-expired).
+func (m *Manager) CheckNoSID() CheckResult {
+	if m.GraceActive() {
+		return CheckResult{OK: true, Unknown: true}
+	}
+
+	return CheckResult{OK: false}
+}
+
+// Check evaluates a token carrying the given sid.
+//
+// This is a read-only policy evaluation (it does not refresh LastSeen). Unknown
+// sids on validly-signed tokens are lazily registered as a roll-out safety net.
+func (m *Manager) Check(ctx context.Context, sid, subject, provider string, issuedAt int64) CheckResult {
+	rec, err := m.store.Get(ctx, sid)
+	if err != nil {
+		if errors.Is(err, ErrUnavailable) {
+			return CheckResult{Sid: sid, StoreDown: true}
+		}
+		if errors.Is(err, ErrNotFound) {
+			// Safety net / backfill: validly-signed token carrying a sid unknown
+			// to the store. Register it lazily and accept.
+			now := time.Now().Unix()
+			if issuedAt == 0 {
+				issuedAt = now
+			}
+			_ = m.store.Register(ctx, Record{
+				SID: sid, Subject: subject, Provider: provider,
+				IssuedAt: issuedAt, LastSeen: now,
+			})
+
+			return CheckResult{Sid: sid, Subject: subject, OK: true, Unknown: true}
+		}
+
+		return CheckResult{Sid: sid, StoreDown: true}
+	}
+
+	res := CheckResult{Sid: sid, Subject: rec.Subject, Revoked: rec.Revoked}
+	if res.Revoked {
+		return res
+	}
+
+	now := time.Now().Unix()
+	if m.policy.MaxLifetime > 0 && rec.IssuedAt > 0 && now-rec.IssuedAt >= int64(m.policy.MaxLifetime.Seconds()) {
+		res.MaxLifetimeExceeded = true
+
+		return res
+	}
+	if m.policy.IdleTimeout > 0 && rec.LastSeen > 0 && now-rec.LastSeen >= int64(m.policy.IdleTimeout.Seconds()) {
+		res.IdleExceeded = true
+	}
+
+	res.OK = true
+
+	return res
+}
+
+// Refresh refreshes LastSeen for an accepted session (idle definition: any
+// authenticated request reaching an API route counts as activity).
+func (m *Manager) Refresh(ctx context.Context, sid string) error {
+	_, err := m.store.Touch(ctx, sid, "", "", 0)
+
+	//nolint:wrapcheck // the underlying store already returns session-domain errors
+	return err
+}

--- a/internal/api/session/memory.go
+++ b/internal/api/session/memory.go
@@ -1,0 +1,135 @@
+// Package session (test double): in-memory Store implementation.
+//
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+package session
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// MemoryStore is an in-memory Store implementation for tests and for local
+// single-node operation when no Redis is configured. It mirrors the semantics
+// of RedisStore so policy logic can be unit-tested without a Redis server.
+type MemoryStore struct {
+	mu        sync.RWMutex
+	records   map[string]Record
+	subjectTo map[string]map[string]bool
+}
+
+// NewMemoryStore builds an empty MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		records:   map[string]Record{},
+		subjectTo: map[string]map[string]bool{},
+	}
+}
+
+// Register implements Store.
+func (m *MemoryStore) Register(ctx context.Context, r Record) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, ok := m.records[r.SID]; ok {
+		if existing.Revoked {
+			r.Revoked = true
+		}
+		if existing.IssuedAt > 0 {
+			r.IssuedAt = existing.IssuedAt
+		}
+	}
+	if m.subjectTo[r.Subject] == nil {
+		m.subjectTo[r.Subject] = map[string]bool{}
+	}
+	m.subjectTo[r.Subject][r.SID] = true
+	m.records[r.SID] = r
+
+	return nil
+}
+
+// Touch implements Store.
+func (m *MemoryStore) Touch(ctx context.Context, sid, subject, provider string, issuedAt int64) (Record, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, ok := m.records[sid]; ok {
+		if existing.Revoked {
+			return existing, nil
+		}
+		existing.LastSeen = time.Now().Unix()
+		m.records[sid] = existing
+
+		return existing, nil
+	}
+	now := time.Now().Unix()
+	r := Record{SID: sid, Subject: subject, Provider: provider, IssuedAt: issuedAt, LastSeen: now}
+	if r.IssuedAt == 0 {
+		r.IssuedAt = now
+	}
+	if m.subjectTo[r.Subject] == nil {
+		m.subjectTo[r.Subject] = map[string]bool{}
+	}
+	m.subjectTo[r.Subject][sid] = true
+	m.records[sid] = r
+
+	return r, nil
+}
+
+// Get implements Store.
+func (m *MemoryStore) Get(ctx context.Context, sid string) (Record, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	r, ok := m.records[sid]
+	if !ok {
+		return Record{}, ErrNotFound
+	}
+
+	return r, nil
+}
+
+// Revoke implements Store.
+func (m *MemoryStore) Revoke(ctx context.Context, sid string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, ok := m.records[sid]; ok {
+		existing.Revoked = true
+		m.records[sid] = existing
+
+		return nil
+	}
+	m.records[sid] = Record{SID: sid, Revoked: true}
+
+	return nil
+}
+
+// RevokeAllForSubject implements Store.
+func (m *MemoryStore) RevokeAllForSubject(ctx context.Context, subject string) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	revoked := []string{}
+	for sid := range m.subjectTo[subject] {
+		if existing, ok := m.records[sid]; ok {
+			existing.Revoked = true
+			m.records[sid] = existing
+			revoked = append(revoked, sid)
+		}
+	}
+
+	return revoked, nil
+}
+
+// Snapshot returns a shallow copy of all records (test helper).
+func (m *MemoryStore) Snapshot() map[string]Record {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	cp := make(map[string]Record, len(m.records))
+	for k, v := range m.records {
+		cp[k] = v
+	}
+
+	return cp
+}

--- a/internal/api/session/memory.go
+++ b/internal/api/session/memory.go
@@ -122,6 +122,25 @@ func (m *MemoryStore) RevokeAllForSubject(ctx context.Context, subject string) (
 	return revoked, nil
 }
 
+// PruneSubject removes sids from the per-subject index whose session records
+// are no longer present (already GC'd). This keeps the index from growing
+// without bound for long-lived subjects.
+func (m *MemoryStore) PruneSubject(ctx context.Context, subject string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	index := m.subjectTo[subject]
+	for sid := range index {
+		if _, ok := m.records[sid]; !ok {
+			delete(index, sid)
+		}
+	}
+	if len(index) == 0 {
+		delete(m.subjectTo, subject)
+	}
+
+	return nil
+}
+
 // Snapshot returns a shallow copy of all records (test helper).
 func (m *MemoryStore) Snapshot() map[string]Record {
 	m.mu.RLock()

--- a/internal/api/session/redis.go
+++ b/internal/api/session/redis.go
@@ -1,0 +1,230 @@
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+// RedisConfig carries the connection settings for the session store.
+type RedisConfig struct {
+	Addr     string `json:"addr"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	DB       int    `json:"db"`
+}
+
+// RedisStore is a Redis-backed Store implementation. All session records are
+// keyed by sid, with a per-subject index enabling revoke-all-for-subject.
+type RedisStore struct {
+	client *redis.Client
+	policy Policy
+}
+
+// NewRedisStore constructs a RedisStore.
+func NewRedisStore(client *redis.Client, policy Policy) *RedisStore {
+	return &RedisStore{client: client, policy: policy}
+}
+
+// NewRedisClient builds a go-redis client from the connection config.
+func NewRedisClient(cfg RedisConfig) *redis.Client {
+	opts := &redis.Options{Addr: cfg.Addr, Username: cfg.Username, Password: cfg.Password, DB: cfg.DB}
+	if opts.Addr == "" {
+		opts.Addr = "localhost:6379"
+	}
+
+	return redis.NewClient(opts)
+}
+
+func sidKey(sid string) string {
+	return "hd-auth-session:" + sid
+}
+
+func subjectKey(subject string) string {
+	return "hd-auth-sessions:subject:" + subject
+}
+
+// Register eagerly creates or updates a session.
+func (s *RedisStore) Register(ctx context.Context, r Record) error {
+	existing, err := s.load(ctx, r.SID)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return MapErr(err)
+	}
+	// Preserve issued_at (never reset on rotation) and the revoked tombstone.
+	if err == nil {
+		if existing.Revoked {
+			r.Revoked = true
+		}
+		if existing.IssuedAt > 0 {
+			r.IssuedAt = existing.IssuedAt
+		}
+	}
+	if r.IssuedAt == 0 {
+		r.IssuedAt = time.Now().Unix()
+	}
+	if r.LastSeen == 0 {
+		r.LastSeen = time.Now().Unix()
+	}
+
+	return s.save(ctx, r)
+}
+
+// Touch refreshes LastSeen, lazily registering an unknown-but-valid sid.
+func (s *RedisStore) Touch(ctx context.Context, sid, subject, provider string, issuedAt int64) (Record, error) {
+	existing, err := s.load(ctx, sid)
+	if err == nil {
+		if existing.Revoked {
+			return existing, nil
+		}
+		existing.LastSeen = time.Now().Unix()
+		if err := s.save(ctx, existing); err != nil {
+			return existing, err
+		}
+
+		return existing, nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return Record{}, MapErr(err)
+	}
+
+	// Lazy registration / backfill for rollout (requirement 4).
+	now := time.Now().Unix()
+	r := Record{SID: sid, Subject: subject, Provider: provider, IssuedAt: issuedAt, LastSeen: now}
+	if r.IssuedAt == 0 {
+		r.IssuedAt = now
+	}
+	if err := s.save(ctx, r); err != nil {
+		return Record{}, err
+	}
+
+	return r, nil
+}
+
+// Get returns the current record for a sid.
+func (s *RedisStore) Get(ctx context.Context, sid string) (Record, error) {
+	return s.load(ctx, sid)
+}
+
+func (s *RedisStore) load(ctx context.Context, sid string) (Record, error) {
+	vals, err := s.client.HGetAll(ctx, sidKey(sid)).Result()
+	if err != nil {
+		return Record{}, MapErr(err)
+	}
+	if len(vals) == 0 {
+		return Record{}, ErrNotFound
+	}
+	r := decodeRecord(vals)
+	r.SID = sid
+
+	return r, nil
+}
+
+func (s *RedisStore) save(ctx context.Context, r Record) error {
+	pipe := s.client.TxPipeline()
+	key := sidKey(r.SID)
+	ttl := s.policy.RecordTTL()
+	pipe.HSet(ctx, key, map[string]interface{}{
+		"subject":   r.Subject,
+		"provider":  r.Provider,
+		"issued_at": strconv.FormatInt(r.IssuedAt, 10),
+		"last_seen": strconv.FormatInt(r.LastSeen, 10),
+		"revoked":   boolToStr(r.Revoked),
+	})
+	pipe.Expire(ctx, key, ttl)
+	if r.Subject != "" {
+		pipe.SAdd(ctx, subjectKey(r.Subject), r.SID)
+		pipe.Expire(ctx, subjectKey(r.Subject), ttl)
+	}
+	_, err := pipe.Exec(ctx)
+
+	return MapErr(err)
+}
+
+// Revoke marks a single sid as revoked, retaining the record as a tombstone
+// with a TTL that outlives any remaining token validity (requirement 3).
+func (s *RedisStore) Revoke(ctx context.Context, sid string) error {
+	existing, err := s.load(ctx, sid)
+	if err == nil {
+		existing.Revoked = true
+		if err := s.save(ctx, existing); err != nil {
+			return MapErr(err)
+		}
+
+		return nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return MapErr(err)
+	}
+
+	// Unknown sid: record a bare tombstone so any replayed token for this sid
+	// remains rejected for the remainder of its possible validity window.
+	return MapErr(s.save(ctx, Record{SID: sid, Revoked: true, LastSeen: time.Now().Unix()}))
+}
+
+// RevokeAllForSubject revokes every session for a subject and returns the
+// revoked sids so callers can invalidate local caches.
+func (s *RedisStore) RevokeAllForSubject(ctx context.Context, subject string) ([]string, error) {
+	key := subjectKey(subject)
+	sids, err := s.client.SMembers(ctx, key).Result()
+	if err != nil {
+		return nil, MapErr(err)
+	}
+	revoked := make([]string, 0, len(sids))
+	pipe := s.client.TxPipeline()
+	for _, sid := range sids {
+		pipe.HSet(ctx, sidKey(sid), "revoked", "1")
+		pipe.Expire(ctx, sidKey(sid), s.policy.RecordTTL())
+		revoked = append(revoked, sid)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return nil, MapErr(err)
+	}
+
+	return revoked, nil
+}
+
+func decodeRecord(vals map[string]string) Record {
+	r := Record{}
+	r.Subject = vals["subject"]
+	r.Provider = vals["provider"]
+	if issuedAt, err := strconv.ParseInt(vals["issued_at"], 10, 64); err == nil {
+		r.IssuedAt = issuedAt
+	}
+	if lastSeen, err := strconv.ParseInt(vals["last_seen"], 10, 64); err == nil {
+		r.LastSeen = lastSeen
+	}
+	r.Revoked, _ = strconv.ParseBool(vals["revoked"])
+
+	return r
+}
+
+func boolToStr(b bool) string {
+	if b {
+		return "1"
+	}
+
+	return "false"
+}
+
+// MapErr maps raw redis errors onto session errors. A store outage is surfaced
+// as ErrUnavailable so callers can fail closed.
+func MapErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, redis.Nil) {
+		return ErrNotFound
+	}
+
+	return fmt.Errorf("%w: %w", ErrUnavailable, err)
+}

--- a/internal/api/session/redis.go
+++ b/internal/api/session/redis.go
@@ -179,18 +179,107 @@ func (s *RedisStore) RevokeAllForSubject(ctx context.Context, subject string) ([
 	if err != nil {
 		return nil, MapErr(err)
 	}
-	revoked := make([]string, 0, len(sids))
-	pipe := s.client.TxPipeline()
-	for _, sid := range sids {
-		pipe.HSet(ctx, sidKey(sid), "revoked", "1")
-		pipe.Expire(ctx, sidKey(sid), s.policy.RecordTTL())
-		revoked = append(revoked, sid)
+
+	// Determine which indexed sids still have a live session record. Sid entries
+	// whose record was already GC'd (TTL expiry) are pruned from the index so it
+	// does not grow without bound and so we do not resurrect bare tombstones.
+	live, stale, err := s.partitionLiveSids(ctx, sids)
+	if err != nil {
+		return nil, err
 	}
-	if _, err := pipe.Exec(ctx); err != nil {
-		return nil, MapErr(err)
+	if len(stale) > 0 {
+		if err := MapErr(s.client.SRem(ctx, key, stale).Err()); err != nil {
+			return nil, err
+		}
+	}
+
+	revoked := make([]string, 0, len(live))
+	if len(live) > 0 {
+		pipe := s.client.TxPipeline()
+		for _, sid := range live {
+			pipe.HSet(ctx, sidKey(sid), "revoked", "1")
+			pipe.Expire(ctx, sidKey(sid), s.policy.RecordTTL())
+			revoked = append(revoked, sid)
+		}
+		if _, err := pipe.Exec(ctx); err != nil {
+			return nil, MapErr(err)
+		}
+	}
+
+	// Drop the subject key entirely once the index is empty.
+	if len(sids) == len(stale) {
+		if err := MapErr(s.client.Del(ctx, key).Err()); err != nil {
+			return nil, err
+		}
 	}
 
 	return revoked, nil
+}
+
+// partitionLiveSids splits a list of indexed sids into those that still have a
+// live session record and those whose record has been GC'd. It returns an
+// error when the live-ness probe fails (fail closed).
+func (s *RedisStore) partitionLiveSids(ctx context.Context, sids []string) (live, stale []string, err error) {
+	if len(sids) == 0 {
+		return nil, nil, nil
+	}
+	pipe := s.client.TxPipeline()
+	for _, sid := range sids {
+		pipe.HExists(ctx, sidKey(sid), "subject")
+	}
+	cmders, err := pipe.Exec(ctx)
+	if err != nil {
+		return nil, nil, MapErr(err)
+	}
+	live = make([]string, 0, len(sids))
+	stale = make([]string, 0, len(sids))
+	for i, cmd := range cmders {
+		exists, ok := cmd.(*redis.BoolCmd)
+		if !ok {
+			return nil, nil, ErrUnavailable
+		}
+		if !exists.Val() {
+			stale = append(stale, sids[i])
+		} else {
+			live = append(live, sids[i])
+		}
+	}
+
+	return live, stale, nil
+}
+
+// PruneSubject removes stale sids from the per-subject index whose session
+// records have already been GC'd (TTL expiry). Called as part of normal GC so
+// the subject index does not grow without bound.
+func (s *RedisStore) PruneSubject(ctx context.Context, subject string) error {
+	key := subjectKey(subject)
+	sids, err := s.client.SMembers(ctx, key).Result()
+	if err != nil {
+		return MapErr(err)
+	}
+	if len(sids) == 0 {
+		return nil
+	}
+
+	_, stale, err := s.partitionLiveSids(ctx, sids)
+	if err != nil {
+		return err
+	}
+	if len(stale) == 0 {
+		return nil
+	}
+
+	if err := MapErr(s.client.SRem(ctx, key, stale).Err()); err != nil {
+		return err
+	}
+	// Drop the subject key entirely once the index is empty.
+	if len(sids) == len(stale) {
+		if err := MapErr(s.client.Del(ctx, key).Err()); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func decodeRecord(vals map[string]string) Record {

--- a/internal/api/session/redis_test.go
+++ b/internal/api/session/redis_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+package session
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redismock/v8"
+)
+
+func TestRedisStoreGet(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	store := NewRedisStore(client, Policy{TokenValidity: 24 * time.Hour})
+
+	mock.ExpectHGetAll("hd-auth-session:sid-1").SetVal(map[string]string{
+		"subject":   "alice",
+		"provider":  "auth-github",
+		"issued_at": "100",
+		"last_seen": "200",
+		"revoked":   "false",
+	})
+
+	r, err := store.Get(context.Background(), "sid-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if r.Subject != "alice" || r.Provider != "auth-github" || r.IssuedAt != 100 || r.LastSeen != 200 {
+		t.Fatalf("unexpected record: %+v", r)
+	}
+	if r.SID != "sid-1" {
+		t.Fatalf("expected sid set from key, got %q", r.SID)
+	}
+}
+
+func TestRedisStoreGetUnknownReturnsNotFound(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	store := NewRedisStore(client, Policy{TokenValidity: 24 * time.Hour})
+
+	mock.ExpectHGetAll("hd-auth-session:missing").RedisNil()
+
+	_, err := store.Get(context.Background(), "missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestRedisStoreRegisterWritesHashes(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	store := NewRedisStore(client, Policy{TokenValidity: 24 * time.Hour})
+
+	now := time.Now().Unix()
+	key := "hd-auth-session:sid-1"
+	expectedHash := map[string]interface{}{
+		"subject":   "alice",
+		"provider":  "auth-github",
+		"issued_at": strconv.FormatInt(now, 10),
+		"last_seen": strconv.FormatInt(now, 10),
+		"revoked":   "false",
+	}
+
+	mock.ExpectHGetAll(key).RedisNil()
+	mock.ExpectTxPipeline()
+	mock.ExpectHSet(key, expectedHash).SetVal(1)
+	mock.ExpectExpire(key, store.policy.RecordTTL()).SetVal(true)
+	mock.ExpectSAdd("hd-auth-sessions:subject:alice", "sid-1").SetVal(1)
+	mock.ExpectExpire("hd-auth-sessions:subject:alice", store.policy.RecordTTL()).SetVal(true)
+	mock.ExpectTxPipelineExec()
+
+	err := store.Register(context.Background(), Record{SID: "sid-1", Subject: "alice", Provider: "auth-github", IssuedAt: now, LastSeen: now})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+}
+
+func TestRedisStoreRevokePreservesTombstone(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	store := NewRedisStore(client, Policy{TokenValidity: 24 * time.Hour})
+
+	key := "hd-auth-session:sid-1"
+	// Revoke loads the existing record (last_seen 1000 preserved) and rewrites
+	// it with revoked=true.
+	mock.ExpectHGetAll(key).SetVal(map[string]string{
+		"subject":   "alice",
+		"provider":  "auth-github",
+		"issued_at": "1000",
+		"last_seen": "1000",
+		"revoked":   "false",
+	})
+	mock.ExpectTxPipeline()
+	mock.ExpectHSet(key, map[string]interface{}{
+		"subject":   "alice",
+		"provider":  "auth-github",
+		"issued_at": "1000",
+		"last_seen": "1000",
+		"revoked":   "1",
+	}).SetVal(1)
+	mock.ExpectExpire(key, store.policy.RecordTTL()).SetVal(true)
+	mock.ExpectSAdd("hd-auth-sessions:subject:alice", "sid-1").SetVal(1)
+	mock.ExpectExpire("hd-auth-sessions:subject:alice", store.policy.RecordTTL()).SetVal(true)
+	mock.ExpectTxPipelineExec()
+
+	if err := store.Revoke(context.Background(), "sid-1"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+}
+
+func TestRedisStoreUnavailableMapsToErrUnavailable(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	store := NewRedisStore(client, Policy{TokenValidity: 24 * time.Hour})
+
+	mock.ExpectHGetAll("hd-auth-session:s").SetErr(errors.New("connection refused"))
+
+	_, err := store.Get(context.Background(), "s")
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("expected ErrUnavailable on outage, got %v", err)
+	}
+}

--- a/internal/api/session/redis_test.go
+++ b/internal/api/session/redis_test.go
@@ -123,3 +123,71 @@ func TestRedisStoreUnavailableMapsToErrUnavailable(t *testing.T) {
 		t.Fatalf("expected ErrUnavailable on outage, got %v", err)
 	}
 }
+
+func TestRedisStoreRevokeAllForSubjectPrunesStale(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	store := NewRedisStore(client, Policy{TokenValidity: 24 * time.Hour})
+
+	// Subject index holds a live sid (has a session record) and a stale sid
+	// (record already GC'd). Revoke-all must only revoke the live one and prune
+	// the stale one from the index (F4).
+	indexKey := "hd-auth-sessions:subject:alice"
+	mock.ExpectSMembers(indexKey).SetVal([]string{"live-sid", "stale-sid"})
+	mock.ExpectTxPipeline()
+	mock.ExpectHExists("hd-auth-session:live-sid", "subject").SetVal(true)
+	mock.ExpectHExists("hd-auth-session:stale-sid", "subject").SetVal(false)
+	mock.ExpectTxPipelineExec()
+	mock.ExpectSRem(indexKey, "stale-sid").SetVal(1)
+	mock.ExpectTxPipeline()
+	mock.ExpectHSet("hd-auth-session:live-sid", "revoked", "1").SetVal(1)
+	mock.ExpectExpire("hd-auth-session:live-sid", store.policy.RecordTTL()).SetVal(true)
+	mock.ExpectTxPipelineExec()
+
+	revoked, err := store.RevokeAllForSubject(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("RevokeAllForSubject: %v", err)
+	}
+	if len(revoked) != 1 || revoked[0] != "live-sid" {
+		t.Fatalf("expected only live-sid revoked, got %v", revoked)
+	}
+}
+
+func TestRedisStoreRevokeAllForSubjectDropsEmptyIndex(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	store := NewRedisStore(client, Policy{TokenValidity: 24 * time.Hour})
+
+	indexKey := "hd-auth-sessions:subject:bob"
+	// All indexed sids are stale (records GC'd): nothing to revoke, and the now
+	// empty subject index is dropped entirely.
+	mock.ExpectSMembers(indexKey).SetVal([]string{"gone-sid"})
+	mock.ExpectTxPipeline()
+	mock.ExpectHExists("hd-auth-session:gone-sid", "subject").SetVal(false)
+	mock.ExpectTxPipelineExec()
+	mock.ExpectSRem(indexKey, "gone-sid").SetVal(1)
+	mock.ExpectDel(indexKey).SetVal(1)
+
+	revoked, err := store.RevokeAllForSubject(context.Background(), "bob")
+	if err != nil {
+		t.Fatalf("RevokeAllForSubject: %v", err)
+	}
+	if len(revoked) != 0 {
+		t.Fatalf("expected no revoked sids, got %v", revoked)
+	}
+}
+
+func TestRedisStorePruneSubject(t *testing.T) {
+	client, mock := redismock.NewClientMock()
+	store := NewRedisStore(client, Policy{TokenValidity: 24 * time.Hour})
+
+	indexKey := "hd-auth-sessions:subject:carol"
+	mock.ExpectSMembers(indexKey).SetVal([]string{"live", "stale"})
+	mock.ExpectTxPipeline()
+	mock.ExpectHExists("hd-auth-session:live", "subject").SetVal(true)
+	mock.ExpectHExists("hd-auth-session:stale", "subject").SetVal(false)
+	mock.ExpectTxPipelineExec()
+	mock.ExpectSRem(indexKey, "stale").SetVal(1)
+
+	if err := store.PruneSubject(context.Background(), "carol"); err != nil {
+		t.Fatalf("PruneSubject: %v", err)
+	}
+}

--- a/internal/api/session/session.go
+++ b/internal/api/session/session.go
@@ -1,0 +1,95 @@
+// Package session provides the Redis-backed server-side login session store
+// used by the Honeydipper API auth middleware.
+//
+// Session identity is a daemon-minted opaque UUID (sid) that is stable across
+// token rotation. It is the primary key of the session store. Because
+// Honeydipper is multi-node, the store is Redis-backed so that login sessions
+// can be enforced consistently across all API nodes.
+package session
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	// ErrNotFound indicates no session record exists for the given sid.
+	ErrNotFound = errors.New("session not found")
+	// ErrUnavailable indicates the session store (Redis) could not be reached.
+	// Callers should fail closed rather than allow access.
+	ErrUnavailable = errors.New("session store unavailable")
+)
+
+// Record is the server-side representation of a login session.
+//
+// IssuedAt is preserved across token rotation so the optional absolute
+// maxLifetime cap cannot be bypassed by rotating tokens. LastSeen is refreshed
+// on every authenticated request (idle definition) and drives the idle timeout.
+type Record struct {
+	SID      string
+	Subject  string
+	Provider string
+	// IssuedAt is the unix-seconds time the session was first minted.
+	IssuedAt int64
+	// LastSeen is the unix-seconds time of the most recent authenticated activity.
+	LastSeen int64
+	// Revoked marks the sid as revoked (a revocation tombstone).
+	Revoked bool
+}
+
+// Policy carries the daemon-side session policy knobs.
+type Policy struct {
+	// IdleTimeout, when > 0, is the inactivity window after which the session is
+	// considered idle. It is a provider re-vouch trigger, not a hard logout.
+	IdleTimeout time.Duration
+	// MaxLifetime, when > 0, is an absolute cap on session lifetime for
+	// compliance. A sid that has exceeded MaxLifetime must never be silently
+	// re-vouched; it always requires a new session.
+	MaxLifetime time.Duration
+	// TokenValidity is the longest token validity window in the system. It is
+	// used to size record TTLs so a revocation tombstone outlives any
+	// replayed-but-still-signature-valid token.
+	TokenValidity time.Duration
+}
+
+// RecordTTL returns the Redis TTL for a session record.
+//
+// The TTL is sized so that the record (and any revocation tombstone) outlives
+// the longest possible remaining token validity window after the session stops
+// being touched. This prevents a GC'd entry from being resurrected by a
+// replayed-but-still-signature-valid token (requirement 3).
+func (p Policy) RecordTTL() time.Duration {
+	ttl := p.TokenValidity
+	if p.IdleTimeout > ttl {
+		ttl = p.IdleTimeout
+	}
+	if p.MaxLifetime > ttl {
+		ttl = p.MaxLifetime
+	}
+	ttl += p.TokenValidity
+	if ttl <= 0 {
+		ttl = 24 * time.Hour
+	}
+
+	return ttl
+}
+
+// Store is the interface the auth middleware uses to enforce sessions.
+type Store interface {
+	// Register eagerly creates or updates a session. If the sid already exists,
+	// IssuedAt and Revoked are preserved (so rotation cannot reset the absolute
+	// cap or resurrect a revoked session) and only LastSeen is refreshed.
+	Register(ctx context.Context, r Record) error
+	// Touch refreshes LastSeen, lazily creating the session if the sid is
+	// unknown (safety net / backfill for rollout).
+	Touch(ctx context.Context, sid, subject, provider string, issuedAt int64) (Record, error)
+	// Get returns the current record and a definitive result. It returns
+	// ErrNotFound for an unknown sid or ErrUnavailable on a store outage.
+	Get(ctx context.Context, sid string) (Record, error)
+	// Revoke marks a single sid as revoked (server-side logout).
+	Revoke(ctx context.Context, sid string) error
+	// RevokeAllForSubject revokes every session belonging to subject (incident
+	// response) and returns the revoked sids for local cache invalidation.
+	RevokeAllForSubject(ctx context.Context, subject string) ([]string, error)
+}

--- a/internal/api/session/session.go
+++ b/internal/api/session/session.go
@@ -92,4 +92,8 @@ type Store interface {
 	// RevokeAllForSubject revokes every session belonging to subject (incident
 	// response) and returns the revoked sids for local cache invalidation.
 	RevokeAllForSubject(ctx context.Context, subject string) ([]string, error)
+	// PruneSubject removes stale sids from the per-subject index whose session
+	// records have already expired/been GC'd, so the index does not grow
+	// without bound.
+	PruneSubject(ctx context.Context, subject string) error
 }

--- a/internal/api/session/session_test.go
+++ b/internal/api/session/session_test.go
@@ -195,6 +195,10 @@ func (f *failingStore) RevokeAllForSubject(ctx context.Context, subject string) 
 	return nil, ErrUnavailable
 }
 
+func (f *failingStore) PruneSubject(ctx context.Context, subject string) error {
+	return ErrUnavailable
+}
+
 func TestManagerCheckNoSIDGrace(t *testing.T) {
 	store := NewMemoryStore()
 	// Within grace.
@@ -229,5 +233,99 @@ func TestCacheRevokeImmediatelyInvalidatesPositiveEntry(t *testing.T) {
 	}
 	if !r.Revoked {
 		t.Fatalf("expected cached record to be revoked")
+	}
+}
+
+// TestManagerCheckPopulatesIssuedAt verifies Check returns the authoritative
+// session issuance time (F2) for both an existing and a lazily-registered sid.
+func TestManagerCheckPopulatesIssuedAt(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Now().Unix()
+	store.Register(context.Background(), Record{SID: "s", Subject: "alice", IssuedAt: now - 3600, LastSeen: now})
+
+	mgr := NewManager(store, Policy{}, 0)
+	res := mgr.Check(context.Background(), "s", "alice", "auth-github", 0)
+	if !res.OK {
+		t.Fatalf("expected OK, got %+v", res)
+	}
+	if res.IssuedAt != now-3600 {
+		t.Fatalf("expected IssuedAt from store (%d), got %d", now-3600, res.IssuedAt)
+	}
+}
+
+// TestManagerCheckLazyRegistrationAnchorsIssuedAt verifies that lazy
+// registration stores the provided real issuance time (not first-seen) so the
+// absolute maxLifetime cap is measured from actual token issuance (F2).
+func TestManagerCheckLazyRegistrationAnchorsIssuedAt(t *testing.T) {
+	store := NewMemoryStore()
+	mgr := NewManager(store, Policy{}, 0)
+	issuedAt := time.Now().Add(-20 * time.Hour).Unix()
+
+	res := mgr.Check(context.Background(), "unknown-sid", "alice", "auth-github", issuedAt)
+	if !res.OK || !res.Unknown {
+		t.Fatalf("expected lazy-accepted unknown sid, got %+v", res)
+	}
+	if res.IssuedAt != issuedAt {
+		t.Fatalf("expected lazy registration IssuedAt anchored to %d, got %d", issuedAt, res.IssuedAt)
+	}
+	r, _ := store.Get(context.Background(), "unknown-sid")
+	if r.IssuedAt != issuedAt {
+		t.Fatalf("expected store record IssuedAt %d, got %d", issuedAt, r.IssuedAt)
+	}
+}
+
+// TestCacheTouchThrottlesWrites verifies the cache only writes through to the
+// store at most once per cache TTL (F3).
+func TestCacheTouchThrottlesWrites(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Now().Unix()
+	store.Register(context.Background(), Record{SID: "s", Subject: "alice", IssuedAt: now, LastSeen: now})
+
+	cache := NewCache(store, time.Hour)
+
+	// First Touch writes through.
+	if _, err := cache.Touch(context.Background(), "s", "alice", "auth-github", now); err != nil {
+		t.Fatalf("Touch: %v", err)
+	}
+	firstOnDisk := store.Snapshot()["s"].LastSeen
+
+	// A second Touch within the TTL must NOT write through: the underlying
+	// store's record is untouched, only the in-memory cache value changes.
+	time.Sleep(5 * time.Millisecond)
+	if _, err := cache.Touch(context.Background(), "s", "alice", "auth-github", now); err != nil {
+		t.Fatalf("Touch (throttled): %v", err)
+	}
+	secondOnDisk := store.Snapshot()["s"].LastSeen
+	if secondOnDisk != firstOnDisk {
+		t.Fatalf("expected throttled Touch not to write through, disk last_seen changed %d -> %d", firstOnDisk, secondOnDisk)
+	}
+}
+
+// TestMemoryStorePruneSubject verifies PruneSubject removes stale sids from the
+// per-subject index whose records are gone (F4).
+func TestMemoryStorePruneSubject(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Now().Unix()
+	store.Register(context.Background(), Record{SID: "s1", Subject: "alice", IssuedAt: now, LastSeen: now})
+	store.Register(context.Background(), Record{SID: "s2", Subject: "alice", IssuedAt: now, LastSeen: now})
+
+	// Simulate GC: remove s1's record entirely (as if it expired).
+	// Use a helper via the internal map through Snapshot-free path: delete directly.
+	store.mu.Lock()
+	delete(store.records, "s1")
+	store.mu.Unlock()
+
+	if err := store.PruneSubject(context.Background(), "alice"); err != nil {
+		t.Fatalf("PruneSubject: %v", err)
+	}
+
+	// s2 remains, s1 pruned from the index.
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if _, ok := store.subjectTo["alice"]["s1"]; ok {
+		t.Fatalf("expected s1 pruned from alice index")
+	}
+	if !store.subjectTo["alice"]["s2"] {
+		t.Fatalf("expected s2 to remain in alice index")
 	}
 }

--- a/internal/api/session/session_test.go
+++ b/internal/api/session/session_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMemoryStoreRegisterAndGet(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Now().Unix()
+	r := Record{SID: "sid-1", Subject: "alice", Provider: "auth-github", IssuedAt: now, LastSeen: now}
+
+	if err := store.Register(context.Background(), r); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	got, err := store.Get(context.Background(), "sid-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Subject != "alice" || got.IssuedAt != now {
+		t.Fatalf("unexpected record: %+v", got)
+	}
+}
+
+func TestMemoryStoreRevokePreservesIssuedAt(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Now().Unix()
+	if err := store.Register(context.Background(), Record{SID: "s", Subject: "bob", IssuedAt: now, LastSeen: now}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if err := store.Revoke(context.Background(), "s"); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	got, err := store.Get(context.Background(), "s")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.Revoked {
+		t.Fatalf("expected revoked record")
+	}
+	if got.IssuedAt != now {
+		t.Fatalf("revocation must preserve issued_at, got %d", got.IssuedAt)
+	}
+}
+
+func TestMemoryStoreRegisterDoesNotResetIssuedAtOnReRegister(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Now().Unix()
+	if err := store.Register(context.Background(), Record{SID: "s", Subject: "carol", IssuedAt: now, LastSeen: now}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	// Re-registration (rotation) must not reset issued_at.
+	later := now + 3600
+	if err := store.Register(context.Background(), Record{SID: "s", Subject: "carol", IssuedAt: later, LastSeen: later}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	got, _ := store.Get(context.Background(), "s")
+	if got.IssuedAt != now {
+		t.Fatalf("rotation must not reset issued_at, got %d want %d", got.IssuedAt, now)
+	}
+	if got.Revoked {
+		t.Fatalf("rotation must not resurrect a record, revoked=%v", got.Revoked)
+	}
+}
+
+func TestMemoryStoreRevokeAllForSubject(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Now().Unix()
+	for _, sid := range []string{"s1", "s2"} {
+		if err := store.Register(context.Background(), Record{SID: sid, Subject: "dave", IssuedAt: now, LastSeen: now}); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
+	}
+	if err := store.Register(context.Background(), Record{SID: "other", Subject: "eve", IssuedAt: now, LastSeen: now}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	revoked, err := store.RevokeAllForSubject(context.Background(), "dave")
+	if err != nil {
+		t.Fatalf("RevokeAllForSubject: %v", err)
+	}
+	if len(revoked) != 2 {
+		t.Fatalf("expected 2 revoked sids, got %v", revoked)
+	}
+	for _, sid := range revoked {
+		r, _ := store.Get(context.Background(), sid)
+		if !r.Revoked {
+			t.Fatalf("expected %s revoked", sid)
+		}
+	}
+	// Other subject unaffected.
+	o, _ := store.Get(context.Background(), "other")
+	if o.Revoked {
+		t.Fatalf("other subject should not be revoked")
+	}
+}
+
+func TestPolicyRecordTTL(t *testing.T) {
+	p := Policy{TokenValidity: 24 * time.Hour, IdleTimeout: time.Hour}
+	ttl := p.RecordTTL()
+	if ttl < 48*time.Hour {
+		t.Fatalf("expected TTL at least 2x token validity, got %v", ttl)
+	}
+
+	p2 := Policy{TokenValidity: 24 * time.Hour}
+	if ttl2 := p2.RecordTTL(); ttl2 < 48*time.Hour {
+		t.Fatalf("expected default TTL, got %v", ttl2)
+	}
+}
+
+// TestManagerIdleExceeded checks that an idle session is flagged but a recent
+// one is not.
+func TestManagerIdleExceeded(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Unix(time.Now().Unix(), 0)
+	store.Register(context.Background(), Record{
+		SID: "s", Subject: "alice", IssuedAt: now.Unix(), LastSeen: now.Add(-2 * time.Hour).Unix(),
+	})
+
+	mgr := NewManager(store, Policy{IdleTimeout: time.Hour}, 0)
+	res := mgr.Check(context.Background(), "s", "alice", "auth-github", now.Unix())
+	if res.IdleExceeded == false || res.OK == false {
+		t.Fatalf("expected idle-exceeded but OK, got %+v", res)
+	}
+}
+
+func TestManagerRefreshTouchesLastSeen(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Now().Unix()
+	store.Register(context.Background(), Record{SID: "s", Subject: "alice", IssuedAt: now, LastSeen: now - 3600})
+
+	mgr := NewManager(store, Policy{IdleTimeout: time.Hour}, 0)
+	if err := mgr.Refresh(context.Background(), "s"); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	r, _ := store.Get(context.Background(), "s")
+	if r.LastSeen <= now-3600 {
+		t.Fatalf("expected last_seen refreshed, got %d", r.LastSeen)
+	}
+}
+
+func TestManagerCheckLazilyRegistersUnknownSID(t *testing.T) {
+	store := NewMemoryStore()
+	mgr := NewManager(store, Policy{}, 0)
+	now := time.Now().Unix()
+
+	res := mgr.Check(context.Background(), "unknown-sid", "alice", "auth-github", now)
+	if !res.OK {
+		t.Fatalf("expected unknown sid to be accepted via lazy registration, got %+v", res)
+	}
+	if !res.Unknown {
+		t.Fatalf("expected Unknown flag, got %+v", res)
+	}
+	// Now the store has it.
+	if _, err := store.Get(context.Background(), "unknown-sid"); err != nil {
+		t.Fatalf("expected sid to be registered, got %v", err)
+	}
+}
+
+func TestManagerCheckStoreDownFailsClosed(t *testing.T) {
+	store := &failingStore{}
+	mgr := NewManager(store, Policy{}, 0)
+	res := mgr.Check(context.Background(), "s", "alice", "auth-github", 0)
+	if !res.StoreDown || res.OK {
+		t.Fatalf("expected store-down fail closed, got %+v", res)
+	}
+}
+
+type failingStore struct{}
+
+func (f *failingStore) Register(ctx context.Context, r Record) error {
+	return ErrUnavailable
+}
+
+func (f *failingStore) Touch(ctx context.Context, sid, subject, provider string, issuedAt int64) (Record, error) {
+	return Record{}, ErrUnavailable
+}
+
+func (f *failingStore) Get(ctx context.Context, sid string) (Record, error) {
+	return Record{}, ErrUnavailable
+}
+
+func (f *failingStore) Revoke(ctx context.Context, sid string) error {
+	return ErrUnavailable
+}
+
+func (f *failingStore) RevokeAllForSubject(ctx context.Context, subject string) ([]string, error) {
+	return nil, ErrUnavailable
+}
+
+func TestManagerCheckNoSIDGrace(t *testing.T) {
+	store := NewMemoryStore()
+	// Within grace.
+	mgr := NewManager(store, Policy{}, time.Hour)
+	if res := mgr.CheckNoSID(); !res.OK {
+		t.Fatalf("expected sid-less token accepted during grace, got %+v", res)
+	}
+	// After grace.
+	mgr2 := NewManager(store, Policy{}, 0)
+	if res := mgr2.CheckNoSID(); res.OK {
+		t.Fatalf("expected sid-less token rejected after grace, got %+v", res)
+	}
+}
+
+func TestCacheRevokeImmediatelyInvalidatesPositiveEntry(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Now().Unix()
+	store.Register(context.Background(), Record{SID: "s", Subject: "alice", IssuedAt: now, LastSeen: now})
+
+	cache := NewCache(store, time.Minute)
+	if _, err := cache.Get(context.Background(), "s"); err != nil {
+		t.Fatalf("cache Get: %v", err)
+	}
+	if err := cache.Revoke(context.Background(), "s"); err != nil {
+		t.Fatalf("cache Revoke: %v", err)
+	}
+	// The cache must return the revoked tombstone record (not ErrNotFound) so
+	// the manager's lazy-registration safety net cannot resurrect the sid.
+	r, err := cache.Get(context.Background(), "s")
+	if err != nil {
+		t.Fatalf("expected revoked tombstone record, got %v", err)
+	}
+	if !r.Revoked {
+		t.Fatalf("expected cached record to be revoked")
+	}
+}

--- a/internal/api/session_config.go
+++ b/internal/api/session_config.go
@@ -1,0 +1,143 @@
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+package api
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/honeydipper/honeydipper/v4/internal/api/session"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper"
+)
+
+// Session policy constants and default values.
+const (
+	// DefaultSessionCacheTTL bounds the staleness of the short-TTL validation
+	// cache used to avoid a Redis round-trip on every authenticated request.
+	DefaultSessionCacheTTL = 30 * time.Second
+
+	// DefaultSessionTokenGracePeriod is the roll-out grace period for
+	// pre-upgrade (sid-less) tokens when not otherwise configured.
+	DefaultSessionTokenGracePeriod = 24 * time.Hour
+
+	// SessionExpiredHeader signals to the (cross-origin) UI that the presented
+	// session cannot continue and it must re-authenticate.
+	SessionExpiredHeader = "X-Honeydipper-Session-Expired"
+)
+
+// sessionEngine holds the parsed session policy and the live session manager.
+type sessionEngine struct {
+	enabled          bool
+	idleTimeout      time.Duration
+	maxLifetime      time.Duration
+	tokenGracePeriod time.Duration
+	cacheTTL         time.Duration
+	manager          *session.Manager
+	redisAddr        string
+}
+
+// loadSessionEngine parses the auth.session.* configuration and env overrides
+// (HD_SESSION_* convention) and constructs the session manager. When no
+// session config is present a local in-memory store is used so the API keeps
+// working for single-node/test deployments; when configured, a Redis-backed
+// store is used which is correct across multiple nodes.
+func loadSessionEngine(cfg interface{}) *sessionEngine {
+	engine := &sessionEngine{
+		tokenGracePeriod: DefaultSessionTokenGracePeriod,
+		cacheTTL:         DefaultSessionCacheTTL,
+	}
+
+	enabled, ok := envBool("HD_SESSION_ENABLED")
+	if !ok {
+		enabled, _ = dipper.GetMapDataBool(cfg, "auth.session.enabled")
+	}
+	engine.enabled = enabled
+
+	engine.idleTimeout = parseDurationEnv(cfg, "HD_SESSION_IDLE_TIMEOUT", "auth.session.idleTimeout", 0)
+	engine.maxLifetime = parseDurationEnv(cfg, "HD_SESSION_MAX_LIFETIME", "auth.session.maxLifetime", 0)
+	engine.tokenGracePeriod = parseDurationEnv(
+		cfg, "HD_SESSION_TOKEN_GRACE_PERIOD", "auth.session.tokenGracePeriod", DefaultSessionTokenGracePeriod)
+	engine.cacheTTL = parseDurationEnv(cfg, "HD_SESSION_CACHE_TTL", "auth.session.cacheTTL", DefaultSessionCacheTTL)
+
+	redisCfg := session.RedisConfig{}
+	if v := os.Getenv("HD_SESSION_REDIS_ADDR"); v != "" {
+		redisCfg.Addr = v
+	} else if v, ok := dipper.GetMapDataStr(cfg, "auth.session.redis.addr"); ok {
+		redisCfg.Addr = v
+	}
+	if v := os.Getenv("HD_SESSION_REDIS_USERNAME"); v != "" {
+		redisCfg.Username = v
+	} else if v, ok := dipper.GetMapDataStr(cfg, "auth.session.redis.username"); ok {
+		redisCfg.Username = v
+	}
+	if v := os.Getenv("HD_SESSION_REDIS_PASSWORD"); v != "" {
+		redisCfg.Password = v
+	} else if v, ok := dipper.GetMapDataStr(cfg, "auth.session.redis.password"); ok {
+		redisCfg.Password = v
+	}
+	if v := os.Getenv("HD_SESSION_REDIS_DB"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			redisCfg.DB = n
+		}
+	} else if v, ok := dipper.GetMapDataStr(cfg, "auth.session.redis.db"); ok {
+		if n, err := strconv.Atoi(v); err == nil {
+			redisCfg.DB = n
+		}
+	}
+	engine.redisAddr = redisCfg.Addr
+
+	policy := session.Policy{
+		IdleTimeout:   engine.idleTimeout,
+		MaxLifetime:   engine.maxLifetime,
+		TokenValidity: 24 * time.Hour,
+	}
+
+	var store session.Store
+	if redisCfg.Addr != "" {
+		client := session.NewRedisClient(redisCfg)
+		store = session.NewRedisStore(client, policy)
+	} else {
+		store = session.NewMemoryStore()
+	}
+	cached := session.NewCache(store, engine.cacheTTL)
+	engine.manager = session.NewManager(cached, policy, engine.tokenGracePeriod)
+
+	return engine
+}
+
+func parseDurationEnv(cfg interface{}, env, configPath string, def time.Duration) time.Duration {
+	if v := os.Getenv(env); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	if v, ok := dipper.GetMapDataStr(cfg, configPath); ok {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+
+	return def
+}
+
+func envBool(name string) (bool, bool) {
+	v := os.Getenv(name)
+	if v == "" {
+		return false, false
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false, false
+	}
+
+	return b, true
+}
+
+// sessionCtx is a convenience context for session store calls.
+var sessionCtx = context.Background()

--- a/internal/api/session_config_test.go
+++ b/internal/api/session_config_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadSessionEngineDisabledByDefault(t *testing.T) {
+	// No session config at all -> enabled defaults to false.
+	engine := loadSessionEngine(map[string]interface{}{})
+	if engine.enabled {
+		t.Fatalf("expected sessions disabled when not configured")
+	}
+	if engine.tokenGracePeriod != DefaultSessionTokenGracePeriod {
+		t.Fatalf("expected default token grace period, got %v", engine.tokenGracePeriod)
+	}
+}
+
+func TestLoadSessionEngineReadsConfig(t *testing.T) {
+	cfg := map[string]interface{}{
+		"auth": map[string]interface{}{
+			"session": map[string]interface{}{
+				"enabled":          true,
+				"idleTimeout":      "1h",
+				"maxLifetime":      "24h",
+				"tokenGracePeriod": "12h",
+				"redis": map[string]interface{}{
+					"addr": "redis.example:6379",
+				},
+			},
+		},
+	}
+
+	engine := loadSessionEngine(cfg)
+	if !engine.enabled {
+		t.Fatalf("expected sessions enabled")
+	}
+	if engine.idleTimeout != time.Hour {
+		t.Fatalf("expected idleTimeout 1h, got %v", engine.idleTimeout)
+	}
+	if engine.maxLifetime != 24*time.Hour {
+		t.Fatalf("expected maxLifetime 24h, got %v", engine.maxLifetime)
+	}
+	if engine.tokenGracePeriod != 12*time.Hour {
+		t.Fatalf("expected tokenGracePeriod 12h, got %v", engine.tokenGracePeriod)
+	}
+	if engine.redisAddr != "redis.example:6379" {
+		t.Fatalf("expected redis addr, got %q", engine.redisAddr)
+	}
+	if engine.manager == nil {
+		t.Fatalf("expected session manager built")
+	}
+}
+
+func TestLoadSessionEngineRedisUsesRedisStore(t *testing.T) {
+	cfg := map[string]interface{}{
+		"auth": map[string]interface{}{
+			"session": map[string]interface{}{
+				"enabled": true,
+				"redis": map[string]interface{}{
+					"addr": "localhost:6379",
+				},
+			},
+		},
+	}
+	engine := loadSessionEngine(cfg)
+	if engine.redisAddr != "localhost:6379" {
+		t.Fatalf("expected redis addr")
+	}
+	if engine.manager == nil || engine.manager.Store() == nil {
+		t.Fatalf("expected session store")
+	}
+}

--- a/internal/api/session_engine_test.go
+++ b/internal/api/session_engine_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/honeydipper/honeydipper/v4/internal/api/session"
+)
+
+// newTestSessionEngine builds an enabled session engine backed by an in-memory
+// store with the given policy, for use in middleware tests.
+func newTestSessionEngine(policy session.Policy, grace time.Duration) *sessionEngine {
+	store := session.NewMemoryStore()
+	cache := session.NewCache(store, time.Minute)
+	mgr := session.NewManager(cache, policy, grace)
+
+	return &sessionEngine{
+		enabled:          true,
+		idleTimeout:      policy.IdleTimeout,
+		maxLifetime:      policy.MaxLifetime,
+		tokenGracePeriod: grace,
+		cacheTTL:         time.Minute,
+		manager:          mgr,
+	}
+}
+
+// registerTestSession registers a session into the store attached to a test engine.
+func registerTestSession(engine *sessionEngine, sid, subject, provider string, issuedAt, lastSeen int64) {
+	if engine == nil || engine.manager == nil {
+		return
+	}
+	_ = engine.manager.Store().Register(context.Background(), session.Record{
+		SID: sid, Subject: subject, Provider: provider, IssuedAt: issuedAt, LastSeen: lastSeen,
+	})
+}

--- a/internal/api/session_logout.go
+++ b/internal/api/session_logout.go
@@ -1,0 +1,50 @@
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// logoutHandler implements POST /auth/logout. It revokes the current sid (and,
+// when requested via all=true, every session for the subject). Revocation is
+// correct cross-node because it writes to the shared Redis session store.
+func logoutHandler(r *Request) (map[string]interface{}, error) {
+	p, ok := r.ctx.Get("principal")
+	if !ok {
+		r.ctx.AbortWithStatusJSON(http.StatusUnauthorized, map[string]interface{}{"error": "session expired", "expired": true})
+
+		return nil, nil
+	}
+	principal, ok := p.(Principal)
+	if !ok || principal.Provider == "none" || principal.Subject == "" {
+		r.ctx.AbortWithStatusJSON(http.StatusUnauthorized, map[string]interface{}{"error": "session expired", "expired": true})
+
+		return nil, nil
+	}
+
+	if !r.store.sessionEnabled() {
+		return map[string]interface{}{"loggedOut": true}, nil
+	}
+
+	revokeAll := r.ctx.GetParam("all") == "true" || r.ctx.GetParam("all") == "1"
+	manager := r.store.sessionEngine.manager
+	if revokeAll {
+		if _, err := manager.Store().RevokeAllForSubject(sessionCtx, principal.Subject); err != nil {
+			return nil, fmt.Errorf("revoking all sessions: %w", err)
+		}
+	} else if principal.SID != "" {
+		if err := manager.Store().Revoke(sessionCtx, principal.SID); err != nil {
+			return nil, fmt.Errorf("revoking session: %w", err)
+		}
+	}
+
+	r.store.markSessionExpiredRequest(r.ctx)
+
+	return map[string]interface{}{"loggedOut": true}, nil
+}

--- a/internal/api/session_logout_test.go
+++ b/internal/api/session_logout_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/honeydipper/honeydipper/v4/internal/api/mock_api"
+	"github.com/honeydipper/honeydipper/v4/internal/api/session"
+)
+
+func TestLogoutHandlerRevokesCurrentSID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	engine := newTestSessionEngine(session.Policy{}, 0)
+	now := time.Now().Unix()
+	registerTestSession(engine, "sid-1", "alice", "auth-github", now, now)
+
+	mockCtx := mock_api.NewMockRequestContext(ctrl)
+	mockCtx.EXPECT().Get("principal").Return(Principal{Subject: "alice", Provider: "auth-github", SID: "sid-1"}, true)
+	mockCtx.EXPECT().GetParam("all").Return("").AnyTimes()
+
+	store := &Store{sessionEngine: engine}
+	req := &Request{store: store, ctx: mockCtx}
+	result, err := logoutHandler(req)
+	if err != nil {
+		t.Fatalf("logoutHandler: %v", err)
+	}
+	if result["loggedOut"] != true {
+		t.Fatalf("expected loggedOut result, got %+v", result)
+	}
+
+	// The sid must now be revoked in the store.
+	r, _ := store.sessionEngine.manager.Store().Get(context.Background(), "sid-1")
+	if !r.Revoked {
+		t.Fatalf("expected sid revoked after logout")
+	}
+}
+
+func TestLogoutHandlerRevokeAllForSubject(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	engine := newTestSessionEngine(session.Policy{}, 0)
+	now := time.Now().Unix()
+	registerTestSession(engine, "sid-1", "bob", "auth-github", now, now)
+	registerTestSession(engine, "sid-2", "bob", "auth-github", now, now)
+
+	mockCtx := mock_api.NewMockRequestContext(ctrl)
+	mockCtx.EXPECT().Get("principal").Return(Principal{Subject: "bob", Provider: "auth-github", SID: "sid-1"}, true)
+	mockCtx.EXPECT().GetParam("all").Return("true").AnyTimes()
+
+	store := &Store{sessionEngine: engine}
+	req := &Request{store: store, ctx: mockCtx}
+	if _, err := logoutHandler(req); err != nil {
+		t.Fatalf("logoutHandler: %v", err)
+	}
+
+	for _, sid := range []string{"sid-1", "sid-2"} {
+		r, _ := store.sessionEngine.manager.Store().Get(context.Background(), sid)
+		if !r.Revoked {
+			t.Fatalf("expected %s revoked in revoke-all", sid)
+		}
+	}
+}
+
+func TestLogoutHandlerNoPrincipalAborts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCtx := mock_api.NewMockRequestContext(ctrl)
+	mockCtx.EXPECT().Get("principal").Return(nil, false)
+	mockCtx.EXPECT().AbortWithStatusJSON(gomock.Any(), gomock.Any()).Return()
+
+	store := &Store{sessionEngine: newTestSessionEngine(session.Policy{}, 0)}
+	req := &Request{store: store, ctx: mockCtx}
+	result, err := logoutHandler(req)
+	if err != nil {
+		t.Fatalf("logoutHandler: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result on abort, got %+v", result)
+	}
+}
+
+func TestLogoutRouteDefRegistered(t *testing.T) {
+	defs := GetDefs()
+	routeDefs, ok := defs["auth/logout"]
+	if !ok {
+		t.Fatalf("missing auth/logout route")
+	}
+	def, ok := routeDefs[http.MethodPost]
+	if !ok {
+		t.Fatalf("missing POST auth/logout")
+	}
+	if def.ReqType != TypeLocal {
+		t.Fatalf("expected local handler")
+	}
+	if def.AllowAnonymous {
+		t.Fatalf("logout must not be anonymous")
+	}
+}

--- a/internal/api/session_middleware.go
+++ b/internal/api/session_middleware.go
@@ -9,6 +9,7 @@ package api
 import (
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -78,7 +79,11 @@ func (l *Store) enforceSession(c *gin.Context, principal Principal, engine *sess
 		return false, principal
 	}
 
-	res := engine.manager.Check(sessionCtx, sid, principal.Subject, principal.Provider, 0)
+	// Anchor lazy registration to the token's real issuance time (if known) so
+	// the absolute maxLifetime cap is measured from actual issuance, not from
+	// first-seen. principal.IssuedAt is populated from the daemon JWT iat and
+	// from the GitHub driver's principal reply when the daemon mints the JWT.
+	res := engine.manager.Check(sessionCtx, sid, principal.Subject, principal.Provider, principal.IssuedAt)
 	if res.StoreDown || res.Revoked {
 		l.markSessionExpired(c)
 
@@ -97,6 +102,12 @@ func (l *Store) enforceSession(c *gin.Context, principal Principal, engine *sess
 	// Accepted: any authenticated request reaching an API route is activity
 	// (idle definition).
 	_ = engine.manager.Refresh(sessionCtx, sid)
+
+	// Propagate the authoritative session issuance time so a daemon JWT minted
+	// for this request can bind its exp to the session's absolute cap (F6).
+	if res.IssuedAt > 0 {
+		principal.IssuedAt = res.IssuedAt
+	}
 
 	return true, principal
 }
@@ -177,4 +188,15 @@ func abortSessionExpired(c *gin.Context) {
 		"reAuth":  true,
 		"expired": true,
 	})
+}
+
+// sessionMaxLifetime returns the configured absolute session lifetime cap, or 0
+// when sessions are disabled/not configured. Used to bind daemon JWT expiries
+// to the session cap (F6).
+func (l *Store) sessionMaxLifetime() time.Duration {
+	if l.sessionEngine == nil {
+		return 0
+	}
+
+	return l.sessionEngine.maxLifetime
 }

--- a/internal/api/session_middleware.go
+++ b/internal/api/session_middleware.go
@@ -1,0 +1,180 @@
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// session provider tiers.
+const (
+	tierIAP    = "iap"
+	tierGitHub = "github"
+	tierSAML   = "saml"
+	tierSimple = "simple"
+	tierOther  = "other"
+)
+
+// providerTier maps a provider name to its session-enforcement tier.
+//
+// IAP takes creds directly from the IAP JWT and never touches the session
+// store. GitHub/SAML check the session in Redis. auth-simple is also stored so
+// logout/revoke works and idle applies; it has no provider re-vouch so expiry
+// is a login.
+func (l *Store) providerTier(provider string) string {
+	switch {
+	case provider == "auth-gcp-iap" || strings.Contains(provider, "iap"):
+		return tierIAP
+	case provider == "auth-github":
+		return tierGitHub
+	case provider == "auth-saml":
+		return tierSAML
+	case provider == "auth-simple":
+		return tierSimple
+	default:
+		return tierOther
+	}
+}
+
+// enforceSession applies the daemon session policy to an authenticated
+// principal. alreadyVouched indicates the principal was just returned by the
+// provider driver (driver-fallback path), meaning the provider confirmed the
+// session is alive this request.
+//
+// It returns (proceed, effectivePrincipal). When proceed is false the caller
+// must abort with the session-expired response.
+func (l *Store) enforceSession(c *gin.Context, principal Principal, engine *sessionEngine, alreadyVouched bool) (bool, Principal) {
+	if engine == nil || !engine.enabled || engine.manager == nil {
+		return true, principal
+	}
+
+	if l.providerTier(principal.Provider) == tierIAP {
+		// IAP: no session store involvement (driver validates the IAP JWT).
+		return true, principal
+	}
+
+	sid := principal.SID
+	if sid == "" {
+		// A freshly vouched session from the driver-fallback path (provider
+		// alive this request) carries no sid yet; the caller mints one
+		// afterwards, so it must proceed.
+		if alreadyVouched {
+			return true, principal
+		}
+		// Pre-upgrade (sid-less) token. Accepted best-effort during the
+		// configured grace period; cleanly rejected afterwards.
+		if engine.manager.GraceActive() {
+			return true, principal
+		}
+		l.markSessionExpired(c)
+
+		return false, principal
+	}
+
+	res := engine.manager.Check(sessionCtx, sid, principal.Subject, principal.Provider, 0)
+	if res.StoreDown || res.Revoked {
+		l.markSessionExpired(c)
+
+		return false, principal
+	}
+	if res.MaxLifetimeExceeded {
+		// Hard re-auth: never silently re-vouch past the absolute cap.
+		l.markSessionExpired(c)
+
+		return false, principal
+	}
+	if res.IdleExceeded {
+		return l.handleIdleExceeded(c, principal, alreadyVouched)
+	}
+
+	// Accepted: any authenticated request reaching an API route is activity
+	// (idle definition).
+	_ = engine.manager.Refresh(sessionCtx, sid)
+
+	return true, principal
+}
+
+func (l *Store) handleIdleExceeded(c *gin.Context, principal Principal, alreadyVouched bool) (bool, Principal) {
+	engine := l.sessionEngine
+	if engine == nil || engine.manager == nil {
+		return true, principal
+	}
+
+	if alreadyVouched {
+		// The provider driver just re-vouched this very request (provider
+		// alive): a silent renewal with the same sid. This is the idle-exceeded
+		// -> re-vouch path for any stored provider tier; only GitHub reaches it
+		// in practice because others do not map to a re-vouchable provider.
+		_ = engine.manager.Refresh(sessionCtx, principal.SID)
+
+		return true, principal
+	}
+
+	// A daemon JWT cannot re-confirm the provider session on its own. Idle thus
+	// forces a fresh login with a new sid for every stored tier:
+	//   - GitHub: no re-vouch without going back through the provider
+	//   - SAML: no IdP session introspection exists -> re-auth (new sid)
+	//   - auth-simple: no refresh possible -> expiry = login
+	l.markSessionExpired(c)
+	l.mustReauthWithNewSID(c)
+
+	return false, principal
+}
+
+// markSessionExpired signals that the presented session cannot continue and
+// records an Access-Control-Expose-Headers entry so cross-origin UIs can read
+// the indicator.
+func (l *Store) markSessionExpired(c *gin.Context) {
+	c.Header(SessionExpiredHeader, "true")
+	l.ensureExposeHeader(c, SessionExpiredHeader)
+}
+
+// mustReauthWithNewSID marks that a fresh login (with a new sid) is required.
+// It is informational for the UI layer (Phase B) and reinforces the
+// session-expired signal already set.
+func (l *Store) mustReauthWithNewSID(c *gin.Context) {
+	c.Header("X-Honeydipper-Reauth", "new-session")
+	l.ensureExposeHeader(c, "X-Honeydipper-Reauth")
+}
+
+// markSessionExpiredRequest signals session-expired through a RequestContext
+// used by local handlers (which are not gin.Context directly).
+func (l *Store) markSessionExpiredRequest(rc RequestContext) {
+	if g, ok := rc.(*GinRequestContext); ok {
+		l.markSessionExpired(g.gin)
+	}
+}
+
+// ensureExposeHeader adds header to Access-Control-Expose-Headers without
+// duplicating an existing entry.
+func (l *Store) ensureExposeHeader(c *gin.Context, header string) {
+	exposed := c.Writer.Header().Get("Access-Control-Expose-Headers")
+	if exposed == "" {
+		c.Header("Access-Control-Expose-Headers", header)
+
+		return
+	}
+	for _, part := range strings.Split(exposed, ",") {
+		if strings.EqualFold(strings.TrimSpace(part), header) {
+			return
+		}
+	}
+	c.Header("Access-Control-Expose-Headers", exposed+", "+header)
+}
+
+// abortSessionExpired writes a 401 with the session-expired indicator set. All
+// expiry modes funnel here so the UI sees one consistent re-authenticate path.
+func abortSessionExpired(c *gin.Context) {
+	c.AbortWithStatusJSON(http.StatusUnauthorized, map[string]interface{}{
+		"error":   "session expired",
+		"reAuth":  true,
+		"expired": true,
+	})
+}

--- a/internal/api/session_middleware_test.go
+++ b/internal/api/session_middleware_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+//go:build !integration
+// +build !integration
+
+package api
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/honeydipper/honeydipper/v4/internal/api/session"
+)
+
+// newTestCtx builds a gin context with a recorder for middleware tests.
+func newTestCtx() (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+
+	return ctx, w
+}
+
+func TestEnforceSession_IAPSkipsSessionStore(t *testing.T) {
+	store := &Store{sessionEngine: newTestSessionEngine(session.Policy{MaxLifetime: time.Minute}, 0)}
+	ctx, _ := newTestCtx()
+
+	principal := Principal{Subject: "iap-user", Provider: "auth-gcp-iap", SID: ""}
+	proceed, eff := store.enforceSession(ctx, principal, store.sessionEngine, false)
+	if !proceed {
+		t.Fatalf("IAP should always proceed, got false")
+	}
+	if eff.Subject != "iap-user" {
+		t.Fatalf("unexpected principal: %+v", eff)
+	}
+}
+
+func TestEnforceSession_GraceAcceptsPreUpgradeToken(t *testing.T) {
+	store := &Store{sessionEngine: newTestSessionEngine(session.Policy{}, time.Hour)}
+	ctx, _ := newTestCtx()
+
+	principal := Principal{Subject: "alice", Provider: "auth-github", SID: ""}
+	proceed, _ := store.enforceSession(ctx, principal, store.sessionEngine, false)
+	if !proceed {
+		t.Fatalf("pre-upgrade token should be accepted during grace")
+	}
+}
+
+func TestEnforceSession_NoGraceRejectsPreUpgradeToken(t *testing.T) {
+	store := &Store{sessionEngine: newTestSessionEngine(session.Policy{}, 0)}
+	ctx, w := newTestCtx()
+
+	principal := Principal{Subject: "alice", Provider: "auth-github", SID: ""}
+	proceed, _ := store.enforceSession(ctx, principal, store.sessionEngine, false)
+	if proceed {
+		t.Fatalf("pre-upgrade token should be rejected after grace")
+	}
+	if w.Header().Get(SessionExpiredHeader) != "true" {
+		t.Fatalf("expected session-expired header, got %q", w.Header().Get(SessionExpiredHeader))
+	}
+	if !strings.Contains(w.Header().Get("Access-Control-Expose-Headers"), SessionExpiredHeader) {
+		t.Fatalf("expected session-expired header exposed, got %q", w.Header().Get("Access-Control-Expose-Headers"))
+	}
+}
+
+func TestEnforceSession_IdleNotExceededProceeds(t *testing.T) {
+	engine := newTestSessionEngine(session.Policy{IdleTimeout: time.Hour}, 0)
+	now := time.Now().Unix()
+	registerTestSession(engine, "sid-1", "alice", "auth-github", now, now)
+	store := &Store{sessionEngine: engine}
+	ctx, _ := newTestCtx()
+
+	principal := Principal{Subject: "alice", Provider: "auth-github", SID: "sid-1"}
+	proceed, _ := store.enforceSession(ctx, principal, store.sessionEngine, false)
+	if !proceed {
+		t.Fatalf("expected active session to proceed")
+	}
+}
+
+func TestEnforceSession_IdleExceeded_NotVouched_Reauth(t *testing.T) {
+	engine := newTestSessionEngine(session.Policy{IdleTimeout: time.Hour}, 0)
+	now := time.Now().Unix()
+	registerTestSession(engine, "sid-1", "alice", "auth-github", now, now-2*3600)
+	store := &Store{sessionEngine: engine}
+	ctx, w := newTestCtx()
+
+	principal := Principal{Subject: "alice", Provider: "auth-github", SID: "sid-1"}
+	proceed, _ := store.enforceSession(ctx, principal, store.sessionEngine, false)
+	if proceed {
+		t.Fatalf("expected idle daemon JWT to require re-auth")
+	}
+	if w.Header().Get(SessionExpiredHeader) != "true" {
+		t.Fatalf("expected session-expired header")
+	}
+	if w.Header().Get("X-Honeydipper-Reauth") != "new-session" {
+		t.Fatalf("expected new-session reauth marker")
+	}
+}
+
+func TestEnforceSession_MaxLifetimeExceeded_HardReauth(t *testing.T) {
+	engine := newTestSessionEngine(session.Policy{MaxLifetime: time.Hour}, 0)
+	now := time.Now().Unix()
+	registerTestSession(engine, "sid-1", "alice", "auth-github", now-2*3600, now)
+	store := &Store{sessionEngine: engine}
+	ctx, _ := newTestCtx()
+
+	principal := Principal{Subject: "alice", Provider: "auth-github", SID: "sid-1"}
+	proceed, _ := store.enforceSession(ctx, principal, store.sessionEngine, true) // even vouched
+	if proceed {
+		t.Fatalf("maxLifetime-exceeded must be a hard re-auth even when vouched")
+	}
+}
+
+func TestEnforceSession_RevokedRejects(t *testing.T) {
+	engine := newTestSessionEngine(session.Policy{}, 0)
+	now := time.Now().Unix()
+	registerTestSession(engine, "sid-1", "alice", "auth-github", now, now)
+	_ = engine.manager.Store().Revoke(context.Background(), "sid-1")
+	store := &Store{sessionEngine: engine}
+	ctx, _ := newTestCtx()
+
+	principal := Principal{Subject: "alice", Provider: "auth-github", SID: "sid-1"}
+	proceed, _ := store.enforceSession(ctx, principal, store.sessionEngine, false)
+	if proceed {
+		t.Fatalf("revoked session must be rejected")
+	}
+}
+
+func TestEnforceSession_GitHubVouchedIdleRenews(t *testing.T) {
+	engine := newTestSessionEngine(session.Policy{IdleTimeout: time.Hour}, 0)
+	now := time.Now().Unix()
+	registerTestSession(engine, "sid-1", "alice", "auth-github", now, now-2*3600)
+	store := &Store{sessionEngine: engine}
+	ctx, _ := newTestCtx()
+
+	principal := Principal{Subject: "alice", Provider: "auth-github", SID: "sid-1"}
+	proceed, _ := store.enforceSession(ctx, principal, store.sessionEngine, true)
+	if !proceed {
+		t.Fatalf("expected idle+already-vouched GitHub session to silently renew")
+	}
+}
+
+func TestEnforceSession_AuthSimpleIdleHardReauth(t *testing.T) {
+	engine := newTestSessionEngine(session.Policy{IdleTimeout: time.Hour}, 0)
+	now := time.Now().Unix()
+	registerTestSession(engine, "sid-1", "admin", "auth-simple", now, now-2*3600)
+	store := &Store{sessionEngine: engine}
+	ctx, w := newTestCtx()
+
+	principal := Principal{Subject: "admin", Provider: "auth-simple", SID: "sid-1"}
+	proceed, _ := store.enforceSession(ctx, principal, store.sessionEngine, false)
+	if proceed {
+		t.Fatalf("expected auth-simple idle to require re-login")
+	}
+	if w.Header().Get(SessionExpiredHeader) != "true" {
+		t.Fatalf("expected session-expired header")
+	}
+}
+
+func TestProviderTierMapping(t *testing.T) {
+	r := &Store{}
+	cases := map[string]string{
+		"auth-gcp-iap": tierIAP,
+		"auth-github":  tierGitHub,
+		"auth-saml":    tierSAML,
+		"auth-simple":  tierSimple,
+		"something":    tierOther,
+	}
+	for provider, want := range cases {
+		if got := r.providerTier(provider); got != want {
+			t.Fatalf("providerTier(%s) = %s, want %s", provider, got, want)
+		}
+	}
+}
+
+func TestAbortSessionExpiredBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	abortSessionExpired(ctx)
+	if w.Code != 401 {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "session expired") {
+		t.Fatalf("expected session expired body, got %q", body)
+	}
+}

--- a/internal/api/session_registration.go
+++ b/internal/api/session_registration.go
@@ -1,0 +1,66 @@
+// Copyright 2026 PayPal Inc.
+//
+// This Source Code Form is subject to the terms of the MIT License.
+// If a copy of the MIT License was not distributed with this file,
+// you can obtain one at https://mit-license.org/.
+
+package api
+
+import (
+	"time"
+
+	"github.com/honeydipper/honeydipper/v4/internal/api/session"
+)
+
+// newSID mints a fresh session identifier. The daemon is the sole authority for
+// minting sids; it is opaque, random, and stable across token rotation.
+func (l *Store) newSID() string {
+	return l.newUUID()
+}
+
+// RegisterEagerSession eagerly registers a login session for a principal that
+// carries a sid. Used at login time (SAML ACS, GitHub OAuth callback) and on
+// the driver-fallback path so the session exists in the store before the first
+// request.
+func (l *Store) RegisterEagerSession(principal Principal) {
+	if !l.sessionEnabled() {
+		return
+	}
+	if principal.SID == "" || principal.Subject == "" {
+		return
+	}
+	now := time.Now().Unix()
+	_ = l.sessionEngine.manager.Store().Register(sessionCtx, session.Record{
+		SID:      principal.SID,
+		Subject:  principal.Subject,
+		Provider: principal.Provider,
+		IssuedAt: now,
+		LastSeen: now,
+	})
+}
+
+// ensureSIDForPrincipal makes sure a principal from the provider-fallback path
+// carries a sid whenever its provider tier uses the session store. Providers
+// that embed their own sid (GitHub driver) keep it; providers that do not
+// (e.g. auth-simple) get a fresh daemon-minted sid so logout/revoke and idle
+// tracking work. IAP never touches the session store and is left untouched.
+func (l *Store) ensureSIDForPrincipal(principal Principal) Principal {
+	if !l.sessionEnabled() {
+		return principal
+	}
+	tier := l.providerTier(principal.Provider)
+	if tier == tierIAP {
+		return principal
+	}
+	if principal.SID != "" {
+		return principal
+	}
+	principal.SID = l.newSID()
+	l.RegisterEagerSession(principal)
+
+	return principal
+}
+
+func (l *Store) sessionEnabled() bool {
+	return l.sessionEngine != nil && l.sessionEngine.enabled && l.sessionEngine.manager != nil
+}

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -77,6 +77,7 @@ type Store struct {
 	enforcer        *casbin.Enforcer
 	apiPrefix       string
 	uiURL           string
+	sessionEngine   *sessionEngine
 
 	writeTimeout time.Duration
 }
@@ -86,7 +87,10 @@ type Principal struct {
 	Subject     string
 	ProfileName string
 	Provider    string
-	Data        map[string]interface{}
+	// SID is the daemon-minted opaque session identifier, stable across token
+	// rotation, and used as the primary key of the server-side session store.
+	SID  string
+	Data map[string]interface{}
 }
 
 // HandleAPIACK handles the call ACK from the eventbus.
@@ -198,8 +202,14 @@ func githubOAuthCallbackHandler(r *Request) (map[string]interface{}, error) {
 		return nil, ErrMissingAuthorizationCode
 	}
 
+	// The daemon is the sole authority for minting the session id. It is passed
+	// to the driver so the driver embeds the same sid in its session token, and
+	// registered eagerly once the callback returns.
+	sid := r.store.newSID()
+
 	answer, err := r.store.caller.Call("driver:auth-github", "github_oauth_callback", map[string]interface{}{
 		"code": code,
+		"sid":  sid,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
@@ -211,6 +221,17 @@ func githubOAuthCallbackHandler(r *Request) (map[string]interface{}, error) {
 	result := map[string]interface{}{}
 	if err := json.Unmarshal(answer, &result); err != nil {
 		return nil, fmt.Errorf("%w", err)
+	}
+
+	// Register the session eagerly now that the callback succeeded.
+	subject, _ := result["subject"].(string)
+	if subject != "" {
+		r.store.RegisterEagerSession(Principal{
+			Subject:  subject,
+			Provider: "auth-github",
+			SID:      sid,
+			Data:     result,
+		})
 	}
 
 	return result, nil
@@ -307,8 +328,11 @@ func samlACSCallbackHandler(r *Request) (map[string]interface{}, error) {
 	// Fall back to the driver's own session token for backwards compatibility.
 	tokenSet := false
 	if subject != "" {
+		// The daemon mints the session id and registers it eagerly at login.
+		sid := r.store.newSID()
+		principal := Principal{Subject: subject, ProfileName: profileName, Provider: "auth-saml", Data: data, SID: sid}
+		r.store.RegisterEagerSession(principal)
 		if jwtCfg, err := getJWTConfig(); err == nil {
-			principal := Principal{Subject: subject, ProfileName: profileName, Provider: "auth-saml", Data: data}
 			if hdToken, err := SignPrincipalJWT(principal, jwtCfg); err == nil {
 				query.Set("token", hdToken)
 				tokenSet = true
@@ -338,6 +362,7 @@ func (l *Store) GetAPIHandler(prefix string, cfg interface{}) http.Handler {
 	gin.DefaultWriter = dipper.LoggingWriter
 	l.config = cfg
 	l.apiPrefix = prefix
+	l.sessionEngine = loadSessionEngine(cfg)
 	l.engine = gin.New()
 	l.engine.Use(gin.Logger())
 	l.engine.Use(gin.Recovery())
@@ -388,6 +413,8 @@ func (l *Store) Enforce(args ...interface{}) (bool, error) {
 }
 
 // AuthMiddleware is a middleware handles auth.
+//
+//nolint:nestif // auth has inherently nested fallback branches
 func (l *Store) AuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if l.isAnonymousRoute(c) {
@@ -406,8 +433,13 @@ func (l *Store) AuthMiddleware() gin.HandlerFunc {
 			jwtToken = ExtractJWTFromRequest(authHeader)
 			if jwtToken != "" {
 				if p, err := ParsePrincipalJWT(jwtToken, jwtCfg); err == nil && p != nil {
-					c.Set("principal", *p)
-					c.Next()
+					if proceed, effPrincipal := l.enforceSession(c, *p, l.sessionEngine, false); proceed {
+						c.Set("principal", effPrincipal)
+						c.Next()
+
+						return
+					}
+					abortSessionExpired(c)
 
 					return
 				}
@@ -457,16 +489,25 @@ func (l *Store) AuthMiddleware() gin.HandlerFunc {
 				continue
 			} else {
 				principal.Provider = provider
-				l.applyRotatedJWTHeader(c, principal)
-				c.Set("principal", principal)
-				// Issue a new JWT for the principal if possible
-				if jwtErr == nil {
-					if token, err := SignPrincipalJWT(principal, jwtCfg); err == nil {
-						c.Header("X-Honeydipper-JWT", token)
-						// Optionally, set as cookie here if desired
+				// The driver just returned a principal, meaning it vouched for
+				// the session this request (provider alive) - used to support
+				// silent idle renew for GitHub.
+				if proceed, effPrincipal := l.enforceSession(c, principal, l.sessionEngine, true); proceed {
+					principal = l.ensureSIDForPrincipal(effPrincipal)
+					l.applyRotatedJWTHeader(c, principal)
+					c.Set("principal", principal)
+					// Issue a new JWT for the principal if possible
+					if jwtErr == nil {
+						if token, err := SignPrincipalJWT(principal, jwtCfg); err == nil {
+							c.Header("X-Honeydipper-JWT", token)
+							// Optionally, set as cookie here if desired
+						}
 					}
+					c.Next()
+
+					return
 				}
-				c.Next()
+				abortSessionExpired(c)
 
 				return
 			}

--- a/internal/api/store.go
+++ b/internal/api/store.go
@@ -89,8 +89,12 @@ type Principal struct {
 	Provider    string
 	// SID is the daemon-minted opaque session identifier, stable across token
 	// rotation, and used as the primary key of the server-side session store.
-	SID  string
-	Data map[string]interface{}
+	SID string
+	// IssuedAt is the unix-seconds issuance time of the underlying token/session.
+	// It is surfaced so lazy session registration anchors the absolute cap to
+	// the real issuance time rather than first-seen.
+	IssuedAt int64
+	Data     map[string]interface{}
 }
 
 // HandleAPIACK handles the call ACK from the eventbus.
@@ -223,8 +227,13 @@ func githubOAuthCallbackHandler(r *Request) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("%w", err)
 	}
 
-	// Register the session eagerly now that the callback succeeded.
+	// Register the session eagerly now that the callback succeeded. The driver
+	// returns the GitHub login as "subject" (newer) and "username" (legacy); read
+	// subject first and fall back to username so eager registration always fires.
 	subject, _ := result["subject"].(string)
+	if subject == "" {
+		subject, _ = result["username"].(string)
+	}
 	if subject != "" {
 		r.store.RegisterEagerSession(Principal{
 			Subject:  subject,
@@ -328,12 +337,15 @@ func samlACSCallbackHandler(r *Request) (map[string]interface{}, error) {
 	// Fall back to the driver's own session token for backwards compatibility.
 	tokenSet := false
 	if subject != "" {
-		// The daemon mints the session id and registers it eagerly at login.
+		// The daemon mints the session id and registers it eagerly at login. The
+		// session was just minted now, so its issuance time anchors the JWT exp
+		// to the absolute maxLifetime cap when one is configured (F6).
 		sid := r.store.newSID()
-		principal := Principal{Subject: subject, ProfileName: profileName, Provider: "auth-saml", Data: data, SID: sid}
+		issuedAt := time.Now().Unix()
+		principal := Principal{Subject: subject, ProfileName: profileName, Provider: "auth-saml", Data: data, SID: sid, IssuedAt: issuedAt}
 		r.store.RegisterEagerSession(principal)
 		if jwtCfg, err := getJWTConfig(); err == nil {
-			if hdToken, err := SignPrincipalJWT(principal, jwtCfg); err == nil {
+			if hdToken, err := SignPrincipalJWTSession(principal, jwtCfg, issuedAt, r.store.sessionMaxLifetime()); err == nil {
 				query.Set("token", hdToken)
 				tokenSet = true
 			}
@@ -496,9 +508,10 @@ func (l *Store) AuthMiddleware() gin.HandlerFunc {
 					principal = l.ensureSIDForPrincipal(effPrincipal)
 					l.applyRotatedJWTHeader(c, principal)
 					c.Set("principal", principal)
-					// Issue a new JWT for the principal if possible
+					// Issue a new JWT for the principal if possible, binding the token
+					// exp to the session's absolute cap when one is configured (F6).
 					if jwtErr == nil {
-						if token, err := SignPrincipalJWT(principal, jwtCfg); err == nil {
+						if token, err := SignPrincipalJWTSession(principal, jwtCfg, principal.IssuedAt, l.sessionMaxLifetime()); err == nil {
 							c.Header("X-Honeydipper-JWT", token)
 							// Optionally, set as cookie here if desired
 						}

--- a/internal/api/store_auth_middleware_test.go
+++ b/internal/api/store_auth_middleware_test.go
@@ -12,8 +12,13 @@ package api
 import (
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/golang/mock/gomock"
+	"github.com/honeydipper/honeydipper/v4/internal/api/mock_api"
+	"github.com/honeydipper/honeydipper/v4/internal/api/session"
+	"github.com/honeydipper/honeydipper/v4/pkg/dipper/mock_dipper"
 )
 
 func TestApplyRotatedJWTHeaderSetsHeader(t *testing.T) {
@@ -74,5 +79,52 @@ func TestApplyRotatedJWTHeaderNoDataNoHeader(t *testing.T) {
 
 	if got := w.Header().Get(RefreshedJWTHeader); got != "" {
 		t.Fatalf("expected empty refreshed JWT header, got %q", got)
+	}
+}
+
+func TestGitHubOAuthCallbackRegistersEagerSessionFromUsername(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCaller := mock_dipper.NewMockRPCCaller(ctrl)
+	mockReqCtx := mock_api.NewMockRequestContext(ctrl)
+	mockReqCtx.EXPECT().GetParam("code").Return("auth-code")
+	mockCaller.EXPECT().Call(
+		"driver:auth-github",
+		"github_oauth_callback",
+		gomock.Any(),
+	).Return([]byte(`{"username":"alice","email":"alice@example.com"}`), nil)
+
+	// Build an enabled session engine whose manager wraps a plain MemoryStore so
+	// the test can inspect the eagerly-registered session directly.
+	memStore := session.NewMemoryStore()
+	engine := &sessionEngine{
+		enabled:     true,
+		cacheTTL:    time.Minute,
+		manager:     session.NewManager(memStore, session.Policy{}, 0),
+		idleTimeout: 0,
+		maxLifetime: 0,
+	}
+	store := NewStore(mockCaller)
+	store.sessionEngine = engine
+
+	req := &Request{store: store, ctx: mockReqCtx}
+	if _, err := githubOAuthCallbackHandler(req); err != nil {
+		t.Fatalf("githubOAuthCallbackHandler: %v", err)
+	}
+
+	// The eager registration must have created a session for subject "alice"
+	// (read from "username", since the driver reply carries no "subject" key).
+	snapshot := memStore.Snapshot()
+	if len(snapshot) != 1 {
+		t.Fatalf("expected one eagerly registered session, got %d", len(snapshot))
+	}
+	for _, rec := range snapshot {
+		if rec.Subject != "alice" {
+			t.Fatalf("expected subject alice from username fallback, got %+v", rec)
+		}
+		if rec.SID == "" {
+			t.Fatalf("expected a daemon-minted sid to be registered")
+		}
 	}
 }


### PR DESCRIPTION
## Phase A (backend): Honeydipper login session engine

Implements the backend session engine for login session expiry, refresh, and revocation across the honeydipper daemon (v4), paired with the GitHub auth driver changes in `Charles546/hd-driver-auth-github`.

### Session identity (sid)
- Add a daemon-minted opaque UUID `sid` claim to daemon JWTs (`Principal.SID` in `PrincipalClaims`), stable across token rotation. The daemon is the sole authority for minting sids.
- SAML ACS callback and GitHub OAuth callback mint and eagerly register the sid; the GitHub callback passes the sid to the driver so the driver embeds it in its token.

### Redis-backed session store
- New `internal/api/session` package: Redis-backed store keyed by `sid -> {subject, issued_at, last_seen}` with TTL-based GC, revoke-by-sid, revoke-all-for-subject, and revocation tombstones whose TTL outlives any remaining token validity (so a GC'd entry cannot be resurrected by a replayed-but-valid token).
- A short-TTL validation cache avoids a Redis round-trip on every request; revocation is boundedly stale up to the cache TTL and documented as such.
- Redis outage fails closed (session-expired 401), never allowing access.
- A `MemoryStore` test double mirrors Redis semantics for unit tests and single-node deployments.

### Tiered AuthMiddleware + Manager
- Session `Manager` enforces idle timeout (a provider re-vouch trigger, not a hard logout) and an optional `maxLifetime` (hard re-auth, never silently re-vouched).
- Provider tiers: IAP takes creds directly from the IAP JWT (no session store); GitHub/SAML/auth-simple check the session in Redis.
- Idle-exceeded vs maxLifetime-exceeded diverge: idle GitHub renews silently with the same sid when the provider is alive (driver-fallback path), otherwise requires re-auth (new sid); SAML/auth-simple idle requires re-auth; maxLifetime-exceeded is always a hard 401.

### Logout + signaling
- `POST /auth/logout` revokes the current sid (or all sessions for the subject via `?all=true`), correct cross-node through the shared Redis store.
- All expiry modes emit `X-Honeydipper-Session-Expired` (exposed via `Access-Control-Expose-Headers`) and return a consistent "re-authenticate" 401.

### Config + graceful upgrade
- `auth.session.*` config: `enabled`, `idleTimeout`, `maxLifetime`, `tokenGracePeriod`, `cacheTTL`, and `redis` connection, with `HD_SESSION_*` env overrides.
- Pre-upgrade (sid-less) tokens are accepted best-effort during a configurable grace period, then cleanly rejected with the session-expired "re-authenticate" response.

### Tests / lint
- Tests cover: sid rotation does not reset the absolute cap, idle-exceeded → re-vouch, maxLifetime-exceeded → hard 401, logout revocation, graceful-upgrade path, Redis store (redismock), config loading.
- `go test ./...` for `internal/api/...` and `internal/api/session` pass; `golangci-lint run` passes with 0 issues.